### PR TITLE
Added the ability to import and export the ciphered private key

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -502,19 +502,20 @@ input::-moz-focus-inner {
     margin: 0;
     text-align: center;
 }
-
+#PrivateCipheredQR img,
 #PrivateQR img,
 #PublicQR img {
     width: 95px !important;
     height: 95px !important;
 }
-
+#PrivateCipheredTxt,
 #PrivateTxt {
     color: black;
     font-size: 12px !important;
     text-align: center;
     line-height: 20px;
 }
+
 
 /* -- Pubkey QR -- */
 
@@ -1083,7 +1084,7 @@ a {
     #genKeyWarning .pivx-button-big {
         margin-top: 20px;
     }
-
+    #PrivateCipheredQR img,
     #PrivateQR img,
     #PublicQR img {
         width: 90px !important;
@@ -1109,7 +1110,9 @@ a {
     #PrivateTxt {
         font-size: 25px;
     }
-
+    #PrivateCipheredTxt{
+        font-size: 25px;
+    }
     #PublicTxt {
         font-size: 25px;
     }
@@ -1121,7 +1124,9 @@ a {
     #PrivateTxt {
         font-size: 18px;
     }
-
+    #PrivateCipheredTxt{
+        font-size: 18px;
+    }
     #PublicTxt {
         font-size: 25px;
     }
@@ -1232,7 +1237,7 @@ a {
     #pubkey-box .pivx-button-big {
         width: 230px !important;
     }
-
+    #PrivateCipheredQR img,
     #PrivateQR img,
     #PublicQR img {
         width: 75px !important;
@@ -1271,6 +1276,9 @@ a {
 
     /* Main Wallet page */
     #PrivateTxt {
+        font-size: 17px;
+    }
+    #PrivateCipheredTxt{
         font-size: 17px;
     }
 
@@ -1360,6 +1368,9 @@ a {
 
     /* Main Wallet page */
     #PrivateTxt {
+        font-size: 13px;
+    }
+    #PrivateCipheredTxt{
         font-size: 13px;
     }
 
@@ -1472,6 +1483,9 @@ a {
 
     /* Main Wallet page */
     #PrivateTxt {
+        font-size: 8px;
+    }
+    #PrivateCipheredTxt{
         font-size: 8px;
     }
 

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
                   <div class="col-md-11 pivx-feature-interior">
 
                     <div class="col-md-12 feature-icon">
-                      <img src="https://pivx.org/build/images/content/img_privacy.png" alt="P1IVX Privacy" class="smaller-feature">
+                      <img src="https://pivx.org/build/images/content/img_privacy.png" alt="PIVX Privacy" class="smaller-feature">
                     </div>
 
                     <h4>Don't trust, verify!</h4>
@@ -777,9 +777,7 @@
 
     let viewPrivKey = 0;
     function toggleKeyView(){
-      
-      viewPrivKey= (viewPrivKey+1)%3
-      
+      viewPrivKey = (viewPrivKey+1)%3
       switch(viewPrivKey){
         case 0:
         domGuiViewKey.innerHTML= "PubKey QR";
@@ -788,8 +786,8 @@
         domPublicQr.style.display ='block'
         domPrivateQr.style.display='none'
         domPrivateCipheredQr.style.display='none'
-        
           break;
+
         case 1:
         domGuiViewKey.innerHTML= "Ciphered QR"
         domPrivateTxt.style.display='none'
@@ -807,10 +805,9 @@
         domPrivateQr.style.display='block'
         domPrivateCipheredQr.style.display='none'
         break;
-        
       }
     }
-      
+
     function hideAllWalletOptions() {
       // Hide and Reset the Vanity address input
       domPrefix.value = PUBKEY_PREFIX;
@@ -841,18 +838,18 @@
     }
     function onPrivateKeyChanged(){
       if(hasEncryptedWallet()) return;
-      //Check whether the first character is + (hence it is not base58)
-      domPrivKeyPassword.hidden= domPrivKey.value.charAt(0)!=="+";
+      //Check whether the length of the string is 128 bytes (that's the length of ciphered plain texts)
+      domPrivKeyPassword.hidden= domPrivKey.value.length!==128;
     }
 
     async function guiImportWallet() {
-      const isEncrypted=domPrivKey.value.charAt(0)==="+"
+      const isEncrypted=domPrivKey.value.length===128;
   
       // If we don't have a DB wallet and the input is plain: prompt an import
       if (!hasEncryptedWallet() && !isEncrypted) return importWallet();
 
       // If we don't have a DB wallet and the input is ciphered: 
-      const privateKey = domPrivKey.value.slice(1);
+      const privateKey = domPrivKey.value
       const strPassword= domPrivKeyPassword.value;
       if(!hasEncryptedWallet() && isEncrypted){
         const strDecWIF = await decrypt(privateKey, strPassword);

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
                   <div class="col-md-11 pivx-feature-interior">
 
                     <div class="col-md-12 feature-icon">
-                      <img src="https://pivx.org/build/images/content/img_privacy.png" alt="PIVX Privacy" class="smaller-feature">
+                      <img src="https://pivx.org/build/images/content/img_privacy.png" alt="P1IVX Privacy" class="smaller-feature">
                     </div>
 
                     <h4>Don't trust, verify!</h4>
@@ -338,8 +338,10 @@
                             <div id="pubkey-padd">
                                 <div id="pubkey-box" class="col-md-4 desktop-pubkey">
                                   <div id="PrivateQR" class="margin-padded-qr" style="display: none;"><img src="" width="82" height="82"></div>
+                                  <div id="PrivateCipheredQR" class="margin-padded-qr" style="display: none;"><img src="" width="82" height="82"></div>
                                   <div id="PublicQR" class="margin-padded-qr" style="display: block;"><img src="" width="82" height="82"></div>
                                   <textarea id="PrivateTxt" style="display: none;" disabled="" class="form-control private-key-area"></textarea>
+                                  <textarea id="PrivateCipheredTxt" style="display: none;" disabled="" class="form-control private-key-area"></textarea>
                                   <button class="pivx-button-big" onclick="toggleKeyView()">
                                       <span class="buttoni-icon"><i class="far fa-eye fa-tiny-margin"></i></span>
                                       <span class="buttoni-text" id="guiViewKey">Pubkey QR</span>
@@ -403,7 +405,8 @@
                   <!-- IMPORT WALLET -->
                   <input class="hide-element" type="text" id="clipboard">
                   <div id='importWallet' style='display: none;'>
-                    <input type="password" id='privateKey' placeholder="Private Key">
+                    <input type="password" id='privateKey' placeholder="Private Key" oninput="onPrivateKeyChanged()">
+                    <input hidden type="password" id='privateKeyPassword' placeholder="Password"> <!-- I added this --> 
                     <button class="pivx-button-big" onclick="guiImportWallet()">
                                   <span class="buttoni-icon"><i class="fas fa-file-upload fa-tiny-margin"></i></span>
                                   <span class="buttoni-text" id="importWalletText">Import Wallet</span>
@@ -637,7 +640,9 @@
     const domValue1s = document.getElementById("value1s");
     const domGuiViewKey = document.getElementById('guiViewKey');
     const domPrivateTxt = document.getElementById('PrivateTxt');
+    const domPrivateCipheredTxt= document.getElementById('PrivateCipheredTxt')
     const domPrivateQr = document.getElementById('PrivateQR');
+    const domPrivateCipheredQr= document.getElementById('PrivateCipheredQR')
     const domPublicQr = document.getElementById('PublicQR');
     const domModalQR = document.getElementById('ModalQR');
     const domModalQrLabel = document.getElementById('ModalQRLabel');
@@ -664,6 +669,7 @@
     const domReqDisplay = document.getElementById('reqDescDisplay');
     const domIdenticon = document.getElementById("identicon");
     const domPrivKey = document.getElementById("privateKey");
+    const domPrivKeyPassword = document.getElementById("privateKeyPassword");
     const domAvailToDelegate = document.getElementById('availToDelegate');
     const domAvailToUndelegate = document.getElementById('availToUndelegate');
     const domAnalyticsDescriptor = document.getElementById('analyticsDescriptor');
@@ -769,14 +775,42 @@
       domValue1s.focus();
     }
 
-    let viewPrivKey = false;
-    function toggleKeyView() {
-      viewPrivKey = !viewPrivKey;
-      domGuiViewKey.innerHTML     = viewPrivKey  ? 'Privkey QR' : 'Pubkey QR';
-      domPrivateTxt.style.display = domPrivateQr.style.display = viewPrivKey  ? 'block' : 'none';
-      domPublicQr.style.display   = !viewPrivKey ? 'block' : 'none';
+    let viewPrivKey = 0;
+    function toggleKeyView(){
+      
+      viewPrivKey= (viewPrivKey+1)%3
+      
+      switch(viewPrivKey){
+        case 0:
+        domGuiViewKey.innerHTML= "PubKey QR";
+        domPrivateTxt.style.display= 'none';
+        domPrivateCipheredTxt.style.display='none';
+        domPublicQr.style.display ='block'
+        domPrivateQr.style.display='none'
+        domPrivateCipheredQr.style.display='none'
+        
+          break;
+        case 1:
+        domGuiViewKey.innerHTML= "Ciphered QR"
+        domPrivateTxt.style.display='none'
+        domPrivateCipheredTxt.style.display='block';
+        domPublicQr.style.display ='none'
+        domPrivateQr.style.display='none'
+        domPrivateCipheredQr.style.display='block'
+          break;
+        
+        case 2:
+        domGuiViewKey.innerHTML= "Privkey QR";
+        domPrivateTxt.style.display='block'; 
+        domPrivateCipheredTxt.style.display='none';
+        domPublicQr.style.display ='none'
+        domPrivateQr.style.display='block'
+        domPrivateCipheredQr.style.display='none'
+        break;
+        
+      }
     }
-
+      
     function hideAllWalletOptions() {
       // Hide and Reset the Vanity address input
       domPrefix.value = PUBKEY_PREFIX;
@@ -805,11 +839,30 @@
         domPrivKey.focus();
       }
     }
+    function onPrivateKeyChanged(){
+      if(hasEncryptedWallet()) return;
+      //Check whether the first character is + (hence it is not base58)
+      domPrivKeyPassword.hidden= domPrivKey.value.charAt(0)!=="+";
+    }
 
     async function guiImportWallet() {
-      // If we don't have a DB wallet: prompt an import
-      if (!hasEncryptedWallet()) return importWallet();
+      const isEncrypted=domPrivKey.value.charAt(0)==="+"
+  
+      // If we don't have a DB wallet and the input is plain: prompt an import
+      if (!hasEncryptedWallet() && !isEncrypted) return importWallet();
 
+      // If we don't have a DB wallet and the input is ciphered: 
+      const privateKey = domPrivKey.value.slice(1);
+      const strPassword= domPrivKeyPassword.value;
+      if(!hasEncryptedWallet() && isEncrypted){
+        const strDecWIF = await decrypt(privateKey, strPassword);
+        if (!strDecWIF || strDecWIF === "decryption failed!") {
+          return createAlert('warning', '<b>Failed to import!</b> Invalid password',6000);
+        } else {
+          localStorage.setItem("encwif", privateKey);
+          return importWallet(strDecWIF);
+        }
+      }
       // Prompt for decryption of the existing wallet
       const fHasWallet = await decryptWallet(domPrivKey.value);
 

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -36,6 +36,7 @@ const to_b58 = function (B) {
     var d = [],    //the array for storing the stream of base58 digits
         s = "",    //the result string variable that will be returned
         i,         //the iterator variable for the byte input
+
         j,         //the iterator variable for the base58 digit array (d)
         c,         //the carry amount variable that is used to overflow from the current base58 digit to the next base58 digit
         n;         //a temporary placeholder variable for the current base58 digit
@@ -110,9 +111,9 @@ function createAlert(type, message, timeout = 0) {
 }
 
 // Generates and sets a QRCode image from a string and dom element
-function createQR(strData = '', domImg) {
+function createQR(strData = '', domImg,size=4) {
     // QRCode class consists of 'typeNumber' & 'errorCorrectionLevel'
-    const cQR = qrcode(4, 'L');
+    const cQR = qrcode(size, 'L');
     cQR.addData(strData);
     cQR.make();
     domImg.innerHTML = cQR.createImgTag();

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -36,7 +36,6 @@ const to_b58 = function (B) {
     var d = [],    //the array for storing the stream of base58 digits
         s = "",    //the result string variable that will be returned
         i,         //the iterator variable for the byte input
-
         j,         //the iterator variable for the base58 digit array (d)
         c,         //the carry amount variable that is used to overflow from the current base58 digit to the next base58 digit
         n;         //a temporary placeholder variable for the current base58 digit

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -103,10 +103,16 @@ importWallet = function (newWif = false, fRaw = false) {
     domGuiWallet.style.display = 'block';
     domPrivateTxt.value = privateKeyForTransactions;
     domGuiAddress.innerHTML = publicKeyForNetwork;
-
+    domPrivateCipheredTxt.value="Set a password first";
+    if(hasEncryptedWallet()) domPrivateCipheredTxt.value= `+${localStorage.getItem("encwif")}`;
+    
     // Private Key QR
     createQR(privateKeyForTransactions, domPrivateQr);
-
+    
+    // Ciphered Private Key  QR 
+    if(hasEncryptedWallet()) createQR(`+${localStorage.getItem("encwif")}`, domPrivateCipheredQr,12);
+    
+  
     // Address QR
     createQR('pivx:' + publicKeyForNetwork, domPublicQr);
 
@@ -157,7 +163,7 @@ generateWallet = async function (noUI = false) {
       domGenKeyWarning.style.display = 'block';
       domPrivateTxt.value = privateKeyForTransactions;
       domGuiAddress.innerHTML = publicKeyForNetwork;
-
+      domPrivateCipheredTxt.value="Set a password first";
       // Private Key QR
       createQR(privateKeyForTransactions, domPrivateQr);
 
@@ -220,6 +226,13 @@ encryptWallet = async function (strPassword = '') {
 
   // Remove the exit blocker, we can annoy the user less knowing the key is safe in their localstorage!
   removeEventListener("beforeunload", beforeUnloadListener, {capture: true});
+
+  //Add the new ciphered text QR
+  domPrivateCipheredTxt.value= `+${localStorage.getItem("encwif")}`;
+  
+  createQR(`+${localStorage.getItem("encwif")}`, domPrivateCipheredQr,12);
+  
+  
 }
 
 decryptWallet = async function (strPassword = '') {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -104,13 +104,13 @@ importWallet = function (newWif = false, fRaw = false) {
     domPrivateTxt.value = privateKeyForTransactions;
     domGuiAddress.innerHTML = publicKeyForNetwork;
     domPrivateCipheredTxt.value="Set a password first";
-    if(hasEncryptedWallet()) domPrivateCipheredTxt.value= `+${localStorage.getItem("encwif")}`;
+    if(hasEncryptedWallet()) domPrivateCipheredTxt.value= localStorage.getItem("encwif");
     
     // Private Key QR
     createQR(privateKeyForTransactions, domPrivateQr);
     
     // Ciphered Private Key  QR 
-    if(hasEncryptedWallet()) createQR(`+${localStorage.getItem("encwif")}`, domPrivateCipheredQr,12);
+    if(hasEncryptedWallet()) createQR(localStorage.getItem("encwif"), domPrivateCipheredQr,12);
     
   
     // Address QR
@@ -228,9 +228,9 @@ encryptWallet = async function (strPassword = '') {
   removeEventListener("beforeunload", beforeUnloadListener, {capture: true});
 
   //Add the new ciphered text QR
-  domPrivateCipheredTxt.value= `+${localStorage.getItem("encwif")}`;
+  domPrivateCipheredTxt.value= localStorage.getItem("encwif");
   
-  createQR(`+${localStorage.getItem("encwif")}`, domPrivateCipheredQr,12);
+  createQR(localStorage.getItem("encwif"), domPrivateCipheredQr,12);
   
   
 }


### PR DESCRIPTION
Abstract:
I added the possibility to import/export the wallet with the internal ciphered private key.

The input box recognize from the first character (which is the non-base58 character +) if the private key is ciphered or not and in case it allows to insert the password.

Closes #24 