### PR TITLE
[Wallet] Add full WIF integrity checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,9 @@
       // Set default chain
       cChainParams.current = cChainParams.main;
 
+      // <[network_byte] [32_byte_payload] [0x01] [4_byte_checksum]>
+      const PRIVKEY_BYTE_LENGTH = 38;
+
       const COIN_DECIMALS = 8;
       const COIN = 10**8;
 
@@ -969,22 +972,23 @@
     }
 
     async function guiImportWallet() {
-      const isEncrypted = domPrivKey.value.length === 128;
+      const fEncrypted = domPrivKey.value.length === 128;
+
       // If we are in testnet: prompt an import
       if (cChainParams.current.isTestnet) return importWallet();
 
       // If we don't have a DB wallet and the input is plain: prompt an import
-      if (!hasEncryptedWallet() && !isEncrypted) return importWallet();
+      if (!hasEncryptedWallet() && !fEncrypted) return importWallet();
 
       // If we don't have a DB wallet and the input is ciphered: 
-      const privateKey = domPrivKey.value
+      const strPrivKey = domPrivKey.value
       const strPassword = domPrivKeyPassword.value;
-      if (!hasEncryptedWallet() && isEncrypted) {
-        const strDecWIF = await decrypt(privateKey, strPassword);
+      if (!hasEncryptedWallet() && fEncrypted) {
+        const strDecWIF = await decrypt(strPrivKey, strPassword);
         if (!strDecWIF || strDecWIF === "decryption failed!") {
           return createAlert('warning', '<b>Failed to import!</b> Invalid password',6000);
         } else {
-          localStorage.setItem("encwif", privateKey);
+          localStorage.setItem("encwif", strPrivKey);
           return importWallet({
             newWif: strDecWIF
           });


### PR DESCRIPTION
## Rationale
There was previously ZERO WIF integrity checks: meaning you could, somewhat successfully, import a completely empty input, or total gibberish: this PR now applies full checksum integrity tests, as well as network byte identification, with a detailed error handler which pipes human-readable errors directly to the UI via alerts.

#### For example, entering a Testnet private key while in Mainnet mode:
![image](https://user-images.githubusercontent.com/42538664/199146539-754d7af1-5cd0-4554-a2e2-eab008ed5e18.png)

#### Or entering a private key from a different coin:
![image](https://user-images.githubusercontent.com/42538664/199146676-6538a6be-bd1f-42e8-a0f8-e6320cf45627.png)

... and many more alternative checks to ensure total integrity of one's import.

This PR introduces two new methods for dealing with both WIF validation and WIF parsing (for Secp256k1 keys):
`verifyWIF(strWIF: string, fParseBytes: bool)` - a method used for both verifying *and* parsing raw secret bytes.
`parseWIF(strWIF: string)` - a convenience/alias method used to quickly verify + import a key with cleaner code.


## Testing
Simply become a human fuzzer: input whatever gibberish you want into the private key importer.
- Use real private keys, but modify a letter or two.
- Use private keys from another coin (f.e; Bitcoin).
- Use the wrong network private key (f.e; a testnet private key on mainnet, or vise-versa).
- Smash your keyboard and try to import it (entropy!).