### PR TITLE
Add support for testnet addresses starting with x 

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,11 +428,12 @@
                   <div class="col-md-12 dashboard-title">
                     <h3 class="pivx-bold-title" style="font-size:38px;"><span>Create a new</span>Vanity Wallet</h3>
                     <span class="badge badge-warning">Experimental</span>
-                    <p>This will create a PIVX wallet with a customized prefix of your choosing, requiring more processing power to generate such addresses, it is recommended to generate a prefix of less than 6 characters, for example: "DAD" is a possible address prefix.</p>
+                    <p>This will create a PIVX wallet with a customized prefix of your choosing, requiring more processing power to generate such addresses, it is recommended to generate a prefix of less than 6 characters, for example: "DAD" is a possible address prefix.<br>
+                    <span style="opacity: 0.75; font-size: small;">*Note: Generated addresses will automatically be preceded by the network prefix: <b id='prefixNetwork'></b></span></p>
                   </div>
 
 
-                  <input style="display:none;" type="text" id='prefix' placeholder="Address Prefix" onkeyup="checkVanity()">
+                  <input class="center-text" style="display:none;" type="text" id='prefix' placeholder="Address Prefix" onkeypress="checkVanity()">
 
                   <button class="pivx-button-big" onclick="generateVanityWallet()">
                               <span class="buttoni-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 70"><path d="M3.497 25.717C1.401 25.588 0 23.847 0 21.753v-2.535c0-.775.149-1.593.925-1.593h22.719c2.173 0 3.941 1.861 3.941 4.034 0 2.174-1.769 3.988-3.941 3.988l-20.207.048c-.02 0 .08.023.06.022z"></path><path d="M5.229 69.625C4.455 69.625 4 68.494 4 67.719V38.661c0-1.911 1.447-3.731 3.258-3.989.175-.029.285-.047.483-.047h21.525c7.137 0 12.751-5.86 12.751-13.027 0-7.096-5.528-12.841-12.586-13.177-.002 0-.671.016-1.41.016l-20.335.066C5.529 8.373 4 6.652 4 4.558V2.023C4 1.247 4.407.625 5.183.625h24.059c11.57 0 20.654 9.546 20.706 21.104 0 9.378-6.307 17.727-15.337 20.311-1.622.445-3.122.705-4.735.778L12 42.842v22.485c0 2.156-2.141 4.298-4.235 4.298H5.229z"></path></svg></span>
@@ -766,6 +767,7 @@
     const domModalQR = document.getElementById('ModalQR');
     const domModalQrLabel = document.getElementById('ModalQRLabel');
     const domPrefix = document.getElementById('prefix');
+    const domPrefixNetwork = document.getElementById('prefixNetwork');
     const domWalletToggle = document.getElementById("wToggle");
     const domGenerateWallet = document.getElementById('generateWallet');
     const domGenVanityWallet = document.getElementById('generateVanityWallet');
@@ -929,7 +931,7 @@
 
     function hideAllWalletOptions() {
       // Hide and Reset the Vanity address input
-      domPrefix.value = cChainParams.current.PUBKEY_PREFIX;
+      domPrefix.value = "";
       domPrefix.style.display = 'none';
 
       // Hide all "*Wallet" buttons
@@ -942,7 +944,7 @@
 
     function accessOrImportWallet() {
       // Hide and Reset the Vanity address input
-      domPrefix.value = cChainParams.current.PUBKEY_PREFIX;
+      domPrefix.value = "";
       domPrefix.style.display = 'none';
 
       // Show Import button, hide access button
@@ -1051,12 +1053,17 @@
     }
 
     function checkVanity() {
-      // Loosely check if the vanity address is valid
-      if (!domPrefix.value.length) return domPrefix.value = cChainParams.current.PUBKEY_PREFIX;
-      if (!domPrefix.value.startsWith(cChainParams.current.PUBKEY_PREFIX)) {
-        // Prefix doesnt match, splice it into the string
-        domPrefix.value = cChainParams.current.PUBKEY_PREFIX + domPrefix.value.substr(1);
-      }
+        var e = event || window.event;  // get event object
+        var key = e.keyCode || e.which; // get key cross-browser
+        var char = String.fromCharCode(key).trim(); // convert key to char
+        if(char.length == 0) return;
+
+        // Ensure the input is base58 compatible
+        if (!MAP_B58.toLowerCase().includes(char.toLowerCase())) {
+          if (e.preventDefault) e.preventDefault();
+          e.returnValue = false;
+          return createAlert('warning',"The character '" + char + "' is unsupported in addresses! (Not Base58 compatible)", 3500);
+        }
     }
 
     let isVanityGenerating = false;
@@ -1076,27 +1083,30 @@
 
     async function generateVanityWallet() {
       if (isVanityGenerating) return stopSearch();
-      if (typeof(Worker) === "undefined") return alert('This browser doesn\'t support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!');
+      if (typeof(Worker) === "undefined") return createAlert('error', 'This browser doesn\'t support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!', 7500);
       // Generate a vanity address with the given prefix
       if (domPrefix.value.length === 0 || domPrefix.style.display === 'none') {
         // No prefix, display the intro!
-        domPrefix.placeholder = 'Custom Prefix (' + cChainParams.current.PUBKEY_PREFIX + ' ...)';
         domPrefix.style.display = 'block';
         domGenKeyWarning.style.display = 'none';
         domGuiAddress.innerHTML = "~";
         domPrefix.focus();
       } else {
+        // Remove spaces from prefix
+        domPrefix.value = domPrefix.value.replace(/ /g, "");
+
+        // Cache a lowercase equivilent for lower-entropy comparisons (a case-insensitive search is ALOT faster!) and strip accidental spaces
+        const nInsensitivePrefix = domPrefix.value.toLowerCase();
+        const nPrefixLen = nInsensitivePrefix.length;
+
         // Ensure the input is base58 compatible
         for (const char of domPrefix.value) {
-          if (!MAP_B58.includes(char)) return alert("The character '" + char + "' is unsupported in addresses! (Not Base58 compatible)");
+          if (!MAP_B58.toLowerCase().includes(char.toLowerCase())) return createAlert('warning',"The character '" + char + "' is unsupported in addresses! (Not Base58 compatible)", 3500);
         }
         // We also don't want users to be mining addresses for years... so cap the letters to four until the generator is more optimized
-        if (domPrefix.value.length > 6) return alert("This is a long name! This would take a LONG time to find, please choose a shorter name!");
+        if (domPrefix.value.length > 5) return createAlert('warning', "This is a long name! This would take a LONG time to find, please choose a shorter name!", 3500);
         isVanityGenerating = true;
         domPrefix.disabled = true;
-        // Cache a lowercase equivilent for lower-entropy comparisons (a case-insensitive search is ALOT faster!) and strip accidental spaces
-        const nInsensitivePrefix = domPrefix.value.toLowerCase().replace(/ /g, "");
-        const nPrefixLen = nInsensitivePrefix.length;
         let attempts = 0;
 
         // Setup workers
@@ -1116,7 +1126,7 @@
 
         function checkResult(data) {
           attempts++;
-          if (data.pub.substr(0, nPrefixLen).toLowerCase() == nInsensitivePrefix) {
+          if (data.pub.substr(1, nPrefixLen).toLowerCase() == nInsensitivePrefix) {
             importWallet({
               newWif: data.priv,
               fRaw: true
@@ -1632,7 +1642,8 @@
     });
 
     setInterval(refreshChainData, 15000);
-    domPrefix.value = cChainParams.current.PUBKEY_PREFIX;
+    domPrefix.value = ""
+    domPrefixNetwork.innerText = cChainParams.current.PUBKEY_PREFIX;
   </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -1401,6 +1401,7 @@
       }
       if (address.length !== 34) return createAlert('warning', '<b>Invalid PIVX address!<b><br>Bad length (' + address.length + ')', 2500);
       if (!address.startsWith(cChainParams.current.PUBKEY_PREFIX)) return createAlert('warning', '<b>Invalid PIVX address!<b><br>Bad prefix ' + address[0] + ' (Should start with ' + cChainParams.current.PUBKEY_PREFIX + ')', 3500);
+      if (!bitjs.isValidDestination(address,cChainParams.current.PUBKEY_ADDRESS)) return createAlert('warning', '<b>Invalid PIVX address!<b><br>' + address, 3500);
       
       // Sanity check the amount
       let nValue = Math.round(Number(domValue1s.value.trim()) * COIN);

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
           main: {
               isTestnet         : false,
               TICKER            : "PIV",
-              PUBKEY_PREFIX     : "D",
+              PUBKEY_PREFIX     : ["D"],
               STAKING_PREFIX    : "S",
               PUBKEY_ADDRESS    : 30,
               SECRET_KEY        : 212,
@@ -74,7 +74,7 @@
           testnet: {
               isTestnet         : true,
               TICKER            : "tPIV",
-              PUBKEY_PREFIX     : "y",  //FIXME: x is also valid
+              PUBKEY_PREFIX     : ["x","y"],
               STAKING_PREFIX    : "W",
               PUBKEY_ADDRESS    : 139,
               SECRET_KEY        : 239,
@@ -463,8 +463,6 @@
                     <h3 class="pivx-bold-title" style="font-size:38px;"><span>Access your</span>Hardware Wallet</h3>
                     <p>This will help managing the PIVX wallet on your ledger. Notice that the private key will remain safe in your hardware device</p>
                   </div>
-
-                  <input style="display:none;" type="text" placeholder="Address Prefix" onkeyup="checkVanity()">
 
                   <button class="pivx-button-big" onclick="importWallet({isHardwareWallet: true})">
                     <span class="buttoni-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 70">
@@ -1410,7 +1408,7 @@
 	return domStakeTab.click();
       }
       if (address.length !== 34) return createAlert('warning', '<b>Invalid PIVX address!<b><br>Bad length (' + address.length + ')', 2500);
-      if (!address.startsWith(cChainParams.current.PUBKEY_PREFIX)) return createAlert('warning', '<b>Invalid PIVX address!<b><br>Bad prefix ' + address[0] + ' (Should start with ' + cChainParams.current.PUBKEY_PREFIX + ')', 3500);
+      if (!cChainParams.current.PUBKEY_PREFIX.includes(address[0])) return createAlert('warning', '<b>Invalid PIVX address!<b><br>Bad prefix ' + address[0] + ' (Should start with ' + cChainParams.current.PUBKEY_PREFIX.join(' or ') + ')', 3500);
       if (!bitjs.isValidDestination(address,cChainParams.current.PUBKEY_ADDRESS)) return createAlert('warning', '<b>Invalid PIVX address!<b><br>' + address, 3500);
       
       // Sanity check the amount
@@ -1643,7 +1641,7 @@
 
     setInterval(refreshChainData, 15000);
     domPrefix.value = ""
-    domPrefixNetwork.innerText = cChainParams.current.PUBKEY_PREFIX;
+    domPrefixNetwork.innerText = cChainParams.current.PUBKEY_PREFIX.join(' or ');
   </script>
 
 </body>

--- a/scripts/bitTrx.js
+++ b/scripts/bitTrx.js
@@ -426,6 +426,20 @@
 		return temp;
 	}
 
+	bitjs.isValidDestination = function (address, base58Prefix) {
+		const bytes = B58.decode(address);
+		if (bytes[0] != base58Prefix) {
+			return false;
+		}
+		const front = bytes.slice(0, bytes.length-4);
+		const back  = bytes.slice(bytes.length-4);
+		const checksum = Crypto.SHA256(Crypto.SHA256(front, {asBytes: true}), {asBytes: true}).slice(0, 4);
+		if (checksum + "" == back + "") {
+			return true;
+		}
+		return false;
+	}
+
 		var B58 = bitjs.Base58 = {
 		alphabet: "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz",
 		validRegex: /^[1-9A-HJ-NP-Za-km-z]+$/,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -92,7 +92,7 @@ function toggleTestnet() {
     domTestnet.innerHTML = (cChainParams.current.isTestnet ? '<b>Testnet Mode On</b>' : '');
     domGuiBalanceTicker.innerText        = cChainParams.current.TICKER;
     domGuiBalanceStakingTicker.innerText = cChainParams.current.TICKER;
-    domPrefix.value = cChainParams.current.PUBKEY_PREFIX + domPrefix.value.substr(1);
+    domPrefixNetwork.innerText = cChainParams.current.PUBKEY_PREFIX;
     fillExplorerSelect();
     getBalance(true);
     getStakingBalance(true);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -92,7 +92,7 @@ function toggleTestnet() {
     domTestnet.innerHTML = (cChainParams.current.isTestnet ? '<b>Testnet Mode On</b>' : '');
     domGuiBalanceTicker.innerText        = cChainParams.current.TICKER;
     domGuiBalanceStakingTicker.innerText = cChainParams.current.TICKER;
-    domPrefixNetwork.innerText = cChainParams.current.PUBKEY_PREFIX;
+    domPrefixNetwork.innerText = cChainParams.current.PUBKEY_PREFIX.join(' or ');
     fillExplorerSelect();
     getBalance(true);
     getStakingBalance(true);


### PR DESCRIPTION
## Issue being fixed #37
Destination addresses are validated with the first letter. 
## What was done
Destination validation was added
Vanity Wallet generation was refactored to automatically precede the user defined prefix with the network prefix
Support for x prefix in testnet addresses was added
## How Has This Been Tested
Successful transactions were made to destination addresses starting with x and y
Vanity Wallets where generated with the appropriate network prefix
## Noticeable Changes
New user workflow to generate Vanity Wallet
