### PR TITLE
[Docs] GitHub Pull Request guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Abstract
+
+> Add any useful and detailed information for other Labs developers and reviewers to consume, this will help get your PR merged faster, as we won't need to reverse-engineer the changes as much.
+
+---
+
+- Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
+
+---
+
+## What does this PR address?
+> Here, describe the problem (or lack of a feature) which this PR aims to address, in as simple terms/concepts as possible to the reader.
+
+## What features or improvements were added?
+> Here, describe the new improvement; what it does, and how it does it, in as simple terms/concepts as possible to the reader.
+
+## How does this benefit users?
+> Here, describe how the user will benefit from the change, if at all; it may not be noticable to the user (i.e: code cleanup), in that case you may simply state so.


### PR DESCRIPTION
To bring order in the midst of our chaos, we now have a neat little template for each PR devs submit, and here's a few reasons it's neat:
- It's standardised: we can all use a familiar, digestible format.
- Devs get a breakdown: allowing them to dig in to add/improve the PR without guess-work.
- Reviewers get a high-level overview: so they know the functionality to expect, and can test + verify.
- Easier for our LMP team to 'convert' each PR in to a Proposal: making it easier for devs to be rewarded.

GitHub will automatically display this template for all future PRs post this one's merge, so no copy/pasting required, just filling a few areas and pushing.