### PR TITLE
Docker image CI FIX

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        
+      - name: Install npm/nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install packages
+        run: npm ci
+      - name: Build 
+        run: npm run webpack
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,9 @@ jobs:
         with:
           node-version: 18
       - name: Install packages
-        run: npm ci
+        run: npm install
       - name: Build 
-        run: npm run webpack
+        run: npm run build
 
       - name: Set up Docker Buildx
         id: buildx

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,6 @@ FROM nginx:alpine
 RUN apk add --update nodejs npm
 COPY . /src
 WORKDIR /src
-RUN npm i
-RUN npm run build
 COPY dist/ /usr/share/nginx/html/
 
 EXPOSE 80

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,5 @@
 FROM nginx:alpine
 
-RUN apk add --update nodejs npm
-COPY . /src
-WORKDIR /src
 COPY dist/ /usr/share/nginx/html/
 
 EXPOSE 80


### PR DESCRIPTION
## Abstract

Fixes the issue #77, while also improving the image size. This leads to saving in bandwidth and also enables hosters like me to again autopull the image without it being to big without reason.

## What does this PR address?
Fixes failing CI auto builds

## What features or improvements were added?
Nothing but reduced image size.

## How does this benefit users?
Not the users but the ones hosting an instance, as image pulling bandwidth is reduced.

I don't want anything for it keep it, like we would have done all along.

In love
Zozo the hellhound <3