### PR TITLE
Fix web metadata

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -4,7 +4,7 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=9" />
-    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <!-- Primary Meta Tags -->
     <title>My PIVX Wallet</title>
     <meta name="title" content="My PIVX Wallet" />
@@ -20,20 +20,20 @@
     <meta property="og:url" content="https://mypivxwallet.org/" />
     <meta property="og:title" content="My PIVX Wallet" />
     <meta property="og:description" content="The wallet of the future - Receive, Send, Stake and Exchange using a completely decentralized, open-source, battle-hardened PIVX wallet." />
-    <meta property="og:image" content="https://mypivxwallet.org/assets/logo_opaque-dark-bg.png" />
+    <meta property="og:image" content="logo_opaque-dark-bg.png" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://mypivxwallet.org/" />
     <meta property="twitter:title" content="My PIVX Wallet" />
     <meta property="twitter:description" content="The wallet of the future - Receive, Send, Stake and Exchange using a completely decentralized, open-source, battle-hardened PIVX wallet." />
-    <meta property="twitter:image" content="https://mypivxwallet.org/assets/logo_opaque-dark-bg.png" />
+    <meta property="twitter:image" content="logo_opaque-dark-bg.png" />
 
     <!-- Colour Theme -->
     <meta name="msapplication-TileColor" content="#470e75" />
     <meta name="theme-color" content="#470e75" />
 
-    <link rel="icon" type="image/png" href="https://mypivxwallet.org/assets/logo_opaque-dark-bg.png" />
+    <link rel="icon" type="image/png" href="logo_opaque-dark-bg.png" />
     <link rel="canonical" href="https://mypivxwallet.org/" />
 
     <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,8 @@ module.exports = {
             patterns: [
                 { from: "manifest.json" },
                 { from: "assets/icons" },
-                { from: "scripts/native-worker.js"}
+                { from: "assets/logo_opaque-dark-bg.png" },
+                { from: "scripts/native-worker.js" }
             ],
         }),
     ],


### PR DESCRIPTION
## Abstract

Since the merge of #68, some of MPW's metadata (icons, banner) were "lost" as the structure of the files was changed without corrections.

My edit simply removes the path "hardcoding" and makes them relative to the root directory.

## Testing
Simply check the metadata display of our [live MPW.](https://www.heymeta.com/url/mypivxwallet.org/)
Against the metadata display of my [modified MPW.](https://www.heymeta.com/url/jskitty-repos.github.io/MyPIVXWallet/)

You'll notice the missing brand image from the live site; this should also apply to Discord, but beware that Discord caches this stuff, so even an update MPW site may take some time before Discord registers the new metadata.

### Note:
I'm unsure if this is the best fix; since MPW is now essentially "flat" in it's file structure, this probably doesn't index well by search engines.

Should our images be in a public-facing `/assets/` directory? Icons? etc?

Open to suggestions, but if none are made, this small fix will suffice.