### PR TITLE
Simplify primary app text UI

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -312,7 +312,7 @@
                           <span data-i18n="dCardOneTitle">Create a</span>
                           <div data-i18n="dCardOneSubTitle">New Wallet</div>
                         </h3>
-                        <p data-i18n="dCardOneDesc">This will create a new, random PIVX wallet that will contain no initial funds, you may transfer to-and-from this wallet with ease.</p>
+                        <p data-i18n="dCardOneDesc">Create a new PIVX wallet, offering the most secure backup & security methods.</p>
                       </div>
 
                       <button class="pivx-button-big" onclick="MPW.generateWallet()">
@@ -545,12 +545,10 @@
                             <span data-i18n="dCardTwoTitle">Create a new</span>
                             <div data-i18n="dCardTwoSubTitle">Vanity Wallet</div>
                           </h3>
-                          <span class="badge badge-warning" data-i18n="experimental">Experimental</span>
                           <p data-i18n="dCardTwoDesc">
-                            This will create a PIVX wallet with a customized prefix of your choosing, requiring more processing power to generate such addresses, it is recommended to generate a prefix of less than 6 characters, for example:
-                            "DAD" is a possible address prefix.
+                            Create a wallet with a custom prefix, this can take a long time!
                           </p>
-                          <span style="opacity: 0.75; font-size: small;">*Note: Generated addresses will automatically be preceded by the network prefix: <b id="prefixNetwork"></b></span>
+                          <span style="opacity: 0.75; font-size: small;">Note: addresses will always start with: <b id="prefixNetwork"></b></span>
                         </div>
 
                         <input class="center-text" style="display: none; opacity: 0;" type="text" id="prefix" placeholder="Address Prefix" onkeypress="MPW.checkVanity()" />
@@ -592,9 +590,9 @@
                         <div class="col-md-12 dashboard-title">
                           <h3 class="pivx-bold-title" style="font-size: 38px;">
                             <span data-i18n="dCardThreeTitle">Access your</span>
-                            <div data-i18n="dCardThreeSubTitle">Hardware Wallet</div>
+                            <div data-i18n="dCardThreeSubTitle">Ledger Wallet</div>
                           </h3>
-                          <p data-i18n="dCardThreeDesc">This will help managing the PIVX wallet on your ledger. Notice that the private key will remain safe in your hardware device</p>
+                          <p data-i18n="dCardThreeDesc">Use your Ledger Hardware wallet with MPW's familiar interface.</p>
                         </div>
 
                         <button class="pivx-button-big" onclick="MPW.importWallet({isHardwareWallet: true})">
@@ -607,7 +605,7 @@
                             </svg>
                           </span>
 
-                          <span class="buttoni-text" data-i18n="dCardThreeButton">Access my hardware wallet</span>
+                          <span class="buttoni-text" data-i18n="dCardThreeButton">Access my Ledger</span>
                         </button>
                       </div>
                     </div>
@@ -645,9 +643,7 @@
                             <div data-i18n="dCardFourSubTitle">My Wallet</div>
                           </h3>
                           <p data-i18n="dCardFourDesc">
-                            This will import a PIVX wallet that you hold via it's private key, loading the address and pulling your existing balance, if any, from an explorer node.
-                            <br />
-                            <span style="opacity: 0.75; font-size: small;" data-i18n="dCardFourSubDesc">*Note: MPW developers can NOT access your wallet, this wallet runs purely in YOUR browser using JavaScript.</span>
+                            Import a PIVX wallet using a Private Key, xpriv, or Seed Phrase.
                           </p>
                         </div>
 
@@ -694,10 +690,12 @@
               <div id="StakingTab" class="tabcontent">
                 <!-- STAKING FEATURES -->
                 <p id="info" class="minor-notif-subtext">
-                  <span data-i18n="stakeTitle"><b>New Feature!</b></span><br />
+                  <b data-i18n="stakeTitle">Stake your PIV to generate rewards!</b>
+                  <br>
                   <span data-i18n="stakeSubTitle">
-                    Please be aware MPW Cold Staking is a new, slightly experimental feature, it may be unstable, and is currently slow. Please have patience when using this feature, and wait for block confirmations before actions and
-                    balances are shown on-screen.
+                    Coins that you Stake are "Locked" seperately from your Available balance, and have a chance to generate rewards.
+                    <br>
+                    The more coins you stake, the more frequently you'll receive rewards.
                   </span>
                 </p>
                 <div class="add-frame">
@@ -724,7 +722,7 @@
                       <div class="button-padd">
                         <button class="pivx-button-big" onclick="MPW.delegateGUI()">
                           <span class="buttoni-icon"><i class="far fa-snowflake fa-tiny-margin"></i></span>
-                          <span class="buttoni-text" data-i18n="staking">Stake</span>
+                          <span class="buttoni-text" data-i18n="stake">Stake</span>
                           <span class="buttoni-arrow">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
                               <path d="M23.328 16.707L13.121 26.914a.5.5 0 01-.707 0l-2.828-2.828a.5.5 0 010-.707L16.964 16 9.586 8.621a.5.5 0 010-.707l2.828-2.828a.5.5 0 01.707 0l10.207 10.207a1 1 0 010 1.414z"></path>

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -58,23 +58,22 @@ export const en_translation = {
     dashboardTitle: "Dashboard",             //
     dCardOneTitle: "Create a",              //
     dCardOneSubTitle: "New Wallet",           //
-    dCardOneDesc: "This will create a new, random PIVX wallet that will contain no initial funds, you may transfer to-and-from this wallet with ease.",               //
+    dCardOneDesc: "Create a new PIVX wallet, offering the most secure backup & security methods.",               //
     dCardOneButton: "Create A New Wallet",             //
 
     dCardTwoTitle: "Create a new",              //
     dCardTwoSubTitle: "Vanity Wallet",           //
-    dCardTwoDesc: "This will create a PIVX wallet with a customized prefix of your choosing, requiring more processing power to generate such addresses, it is recommended to generate a prefix of less than 6 characters, for example: 'DAD' is a possible address prefix.",               //
+    dCardTwoDesc: "Create a wallet with a custom prefix, this can take a long time!",               //
     dCardTwoButton: "Create A Vanity Wallet",             //
 
     dCardThreeTitle: "Access your",            //
-    dCardThreeSubTitle: "Hardware Wallet",         //
-    dCardThreeDesc: "This will help managing the PIVX wallet on your ledger. Notice that the private key will remain safe in your hardware device",             //
-    dCardThreeButton: "Access my hardware wallet",           //
+    dCardThreeSubTitle: "Ledger Wallet",         //
+    dCardThreeDesc: "Use your Ledger Hardware wallet with MPW's familiar interface.",             //
+    dCardThreeButton: "Access my Ledger",           //
 
     dCardFourTitle: "Go to",             //
     dCardFourSubTitle: "My Wallet",          //
-    dCardFourDesc: "This will import a PIVX wallet that you hold via it's private key, loading the address and pulling your existing balance, if any, from an explorer node.",              //
-    dCardFourSubDesc:"*Note: MPW developers can NOT access your wallet, this wallet runs purely in YOUR browser using JavaScript.",            //
+    dCardFourDesc: "Import a PIVX wallet using a Private Key, xpriv, or Seed Phrase.",              //
     dCardFourButtonI:"Import Wallet",            //
     dCardFourButtonA:"Access My Wallet",            //
 
@@ -106,8 +105,9 @@ export const en_translation = {
     sendSignedTutorialAdvInfo:"Advanced Details: <br>locktime is set to 0, sequence is set to max. SIGHASH_ALL option is chosen for signing raw Transaction.",   //
 
     // Stake
-    stakeTitle:"<b>New Feature!<b>",                  //
-    stakeSubTitle:"Please be aware MPW Cold Staking is a new, slightly experimental feature, it may be unstable, and is currently slow. Please have patience when using this feature, and wait for block confirmations before actions and balances are shown on-screen.",               //
+    stakeTitle:"Stake your PIV to generate rewards!",                  //
+    stakeSubTitle:"Coins that you Stake are \"Locked\" seperately from your Available balance, and have a chance to generate rewards. <br> The more coins you stake, the more frequently you'll receive rewards.",               //
+    stake:"Stake",
     stakeUnstake:"Unstake",                //
     stakeLoadMore:"Load more",               //
 

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -76,23 +76,22 @@ var translation = {
     dashboardTitle: "",             //Dashboard
     dCardOneTitle: "",              //Create a
     dCardOneSubTitle: "",           //New Wallet
-    dCardOneDesc: "",               //This will create a new, random PIVX wallet that will contain no initial funds, you may transfer to-and-from this wallet with ease.
+    dCardOneDesc: "",               //Create a new PIVX wallet, offering the most secure backup & security methods.
     dCardOneButton: "",             //Create A New Wallet
 
     dCardTwoTitle: "",              //Create a new
     dCardTwoSubTitle: "",           //Vanity Wallet
-    dCardTwoDesc: "",               //This will create a PIVX wallet with a customized prefix of your choosing, requiring more processing power to generate such addresses, it is recommended to generate a prefix of less than 6 characters, for example: "DAD" is a possible address prefix.
+    dCardTwoDesc: "",               //Create a wallet with a custom prefix, this can take a long time!
     dCardTwoButton: "",             //Create A Vanity Wallet
 
     dCardThreeTitle: "",            //Access your
     dCardThreeSubTitle: "",         //Hardware Wallet
-    dCardThreeDesc: "",             //This will help managing the PIVX wallet on your ledger. Notice that the private key will remain safe in your hardware device
-    dCardThreeButton: "",           //Access my hardware wallet
+    dCardThreeDesc: "",             //Use your Ledger Hardware wallet with MPW's familiar interface.
+    dCardThreeButton: "",           //Access my Ledger
 
     dCardFourTitle: "",             //Go to
     dCardFourSubTitle: "",          //My Wallet
-    dCardFourDesc: "",              //This will import a PIVX wallet that you hold via it's private key, loading the address and pulling your existing balance, if any, from an explorer node.
-    dCardFourSubDesc:"",            //*Note: MPW developers can NOT access your wallet, this wallet runs purely in YOUR browser using JavaScript.
+    dCardFourDesc: "",              //Import a PIVX wallet using a Private Key, xpriv, or Seed Phrase.
     dCardFourButtonI:"",            //Import Wallet
     dCardFourButtonA:"",            //Access My Wallet
 
@@ -124,8 +123,9 @@ var translation = {
     sendSignedTutorialAdvInfo:"",   //Advanced Details: <br>locktime is set to 0, sequence is set to max. SIGHASH_ALL option is chosen for signing raw Transaction.
 
     // Stake
-    stakeTitle:"",                  //<b>New Feature!<b>
-    stakeSubTitle:"",               //Please be aware MPW Cold Staking is a new, slightly experimental feature, it may be unstable, and is currently slow. Please have patience when using this feature, and wait for block confirmations before actions and balances are shown on-screen.
+    stakeTitle:"",                  //Stake your PIV to generate rewards!
+    stakeSubTitle:"",               //Coins that you Stake are \"Locked\" seperately from your Available balance, and have a chance to generate rewards. <br> The more coins you stake, the more frequently you'll receive rewards.
+    stake:"",                       //Stake
     stakeUnstake:"",                //Unstake
     stakeLoadMore:"",               //Load more
 

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -11,7 +11,7 @@ export const uwu_translation = {
     amount:"a<i>meow</i>nt",                      //Amount
     staking:"",                     //Staking
     rewards:"rewowods",                     //rewards
-    available:"avawable",                   //Available
+    available:"Avawable",                   //Available
 
     // Nav Bar
     navIntro: "Intwo",                   //Intro
@@ -58,23 +58,22 @@ export const uwu_translation = {
     dashboardTitle: "Dashbowod",             //Dashboard
     dCardOneTitle: "Cweate a",              //Create a
     dCardOneSubTitle: "New Wawwet!",           //New Wallet
-    dCardOneDesc: "Dis will cweate a new, wandom, PIVX wawwet dat will contain no initial funds, uwu. Yowou may twansfer to-and-fwom dis wawwet with ease! ",               //This will create a new, random PIVX wallet that will contain no initial funds, you may transfer to-and-from this wallet with ease.
+    dCardOneDesc: "Cweate a new PIVX wawwet, offewing da most secuwur backup & securrrity methods.",               //Create a new PIVX wallet, offering the most secure backup & security methods.
     dCardOneButton: "Cweate A New Wawwet",             //Create A New Wallet
 
     dCardTwoTitle: "Cweate a new",              //Create a new
     dCardTwoSubTitle: "Vanity Wawwet",           //Vanity Wallet
-    dCardTwoDesc: "Dis will cweate a PIVX wawwet with a customizabwe pwefix of yowour choosing, requiweing mowore pwocessing power to genewate such addwesses, it is weccomended to genewate a pwefix of wess den six, fow example: 'DADDY' is a pawsibwe addwess pwefix.",               //This will create a PIVX wallet with a customized prefix of your choosing, requiring more processing power to generate such addresses, it is recommended to generate a prefix of less than 6 characters, for example: "DAD" is a possible address prefix.
+    dCardTwoDesc: "Cweate a wawwet wiv a custom pwefix, dis can take a long twime!",               //Create a wallet with a custom prefix, this can take a long time!
     dCardTwoButton: "Cweate A Vanity Wawwet",             //Create A Vanity Wallet
 
     dCardThreeTitle: "Access yowour",            //Access your
     dCardThreeSubTitle: "Hawdware Wawwet",         //Hardware Wallet
-    dCardThreeDesc: "Dis will help managing da PIVX wawwet on your wedger. Nowotice dat de pwivate key will wemaine safe in yowour hawdware device",             //This will help managing the PIVX wallet on your ledger. Notice that the private key will remain safe in your hardware device
-    dCardThreeButton: "Access my hawdware wawwet",           //Access my hardware wallet
+    dCardThreeDesc: "Use ur Ledger Hardware wawwet wiv MPW's famiwiar intwerface.",             //Use your Ledger Hardware wallet with MPW's familiar interface.
+    dCardThreeButton: "Access my Ledger",           //Access my Ledger
 
     dCardFourTitle: "Go to",             //Go to
     dCardFourSubTitle: "My Wawwet",          //My Wallet
-    dCardFourDesc: "Dis will impowt a PIVX wawwet dat you howd via it's pwivate key, woading da adwess and puwwing your existing bawance, if any, fwom an expwowor node.",              //This will import a PIVX wallet that you hold via it's private key, loading the address and pulling your existing balance, if any, from an explorer node.
-    dCardFourSubDesc:"♡Nowote: MPW devewepers can NOT access yowour wawwet, dis wawwet wuns purewy in YOWOUR bwowser using JavaScwipt.",            //*Note: MPW developers can NOT access your wallet, this wallet runs purely in YOUR browser using JavaScript.
+    dCardFourDesc: "Impowt a PIVX wawwet using a Pwivate Key, xpriv, or Seed Phrase.",              //Import a PIVX wallet using a Private Key, xpriv, or Seed Phrase.
     dCardFourButtonI:"Impowt Wawwet",            //Import Wallet
     dCardFourButtonA:"Access My Wawwet",            //Access My Wallet
 
@@ -106,8 +105,9 @@ export const uwu_translation = {
     sendSignedTutorialAdvInfo:"Advanced Detaiws: <br>wocktime is set to zewo, sequence is set to max. SIGHASH_ALL option is chosen for signing rawr Twansaction.",   //Advanced Details: <br>locktime is set to 0, sequence is set to max. SIGHASH_ALL option is chosen for signing raw Transaction.
 
     // Stake
-    stakeTitle:"New Feature!♡",                  //<b>New Feature!<b>
-    stakeSubTitle:"Pwease be aware MPW Cold staking is new, slightly expewimental, feature. It may be unstabwe, and is cuwwentwy slow. Pwease have patience when using dis feature, and wait for bwock confiwmations befowore actions and bawances are showown on-scween.",               //Please be aware MPW Cold Staking is a new, slightly experimental feature, it may be unstable, and is currently slow. Please have patience when using this feature, and wait for block confirmations before actions and balances are shown on-screen.
+    stakeTitle:"Stake ur PIV to genewwate wewards!",                  //Stake your PIV to generate rewards!
+    stakeSubTitle:"Coins dat you Stake are \"Locked\" sepewately from ur Avaiwable bwalance, and havs a chance to genewwate rewawrds. <br> Da more coins you stake, da more frequwuntly you'll receive rewawrds.",               // Coins that you Stake are \"Locked\" seperately from your Available balance, and have a chance to generate rewards. <br> The more coins you stake, the more frequently you'll receive rewards.
+    stake:"", //Stake
     stakeUnstake:"",                //Unstake
     stakeLoadMore:"Lowoad Mowore",               //Load more
 


### PR DESCRIPTION
## Abstract

To improve UX and onboarding, MPW needs to simplify it's interface; the text especially, reduce it, and just generally make it a little dumber.

This commit simply reduces the Dashboard text, fixes some i18n tags/text, removes an outdated Staking message and replaces it with a more useful explanation of the Staking feature.

Once we're at a state where we are fully happy with MPW's text-UI, we can begin pulling in Translators to translate the entire app; as it makes no sense to onboard translators **before** double-checking all of MPW's text for outdated info, or text which should be simplified, changed, etc.

## Example

The Dashboard had a **massive** reduction in text, which is both easier for new users to digest, and also reduces the space taken by the menus, thus improving the Mobile experience with less scrolling too.

**Before**
![image](https://user-images.githubusercontent.com/42538664/218808357-405a0965-716f-41ba-bdde-0eee05577f94.png)

**After**
![image](https://user-images.githubusercontent.com/42538664/218808526-9f261832-0f11-435e-a437-d49112f0c9b2.png)