### PR TITLE
Switch Google Fonts to Bunny.net

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Chivo&display=swap');
+@import url('https://fonts.bunny.net/css?family=Chivo');
 
 html {
     font-family: Chivo, sans-serif;

--- a/index.template.html
+++ b/index.template.html
@@ -36,8 +36,8 @@
     <link rel="icon" type="image/png" href="logo_opaque-dark-bg.png" />
     <link rel="canonical" href="https://mypivxwallet.org/" />
 
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.bunny.net">
+  <link href="https://fonts.bunny.net/css?family=chivo:900i|montserrat:100,200,300,400,500,600,700,800,900" rel="stylesheet" />
   </head>
 
   <body>


### PR DESCRIPTION
## Abstract

For better privacy (removing the last direct Google dependency) and better performance, de-bloating in general, I've switched our Fonts CDN to Bunny.net, which has a [FAR better privacy policy](https://fonts.bunny.net/about), is [GDPR compliant](https://bunny.net/gdpr/) and is also a recognised service for it's speed and quality.


<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
It addresses the last dependency on Google, by switching to an improved fonts CDN provider.

## What features or improvements were added?
A privacy improvement and *slight* performance boost.

## How does this benefit users?
Privacy and performance! :ninja: :zap: :rabbit: