### PR TITLE
Add date-commit hash as a tag to images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,11 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
+          
+      - name: Set tag date-SHA
+        id: tag
+        run: echo "tag=$(date +'%Y-%m-%d')-$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+        
       - name: Build image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
@@ -56,6 +60,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/pivx-labs/mypivxwallet:latest
+            ghcr.io/pivx-labs/mypivxwallet:${{ env.tag }}
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: release=1


### PR DESCRIPTION
## Abstract

Enables better versioning and the ability for maintainer of instances to easily rollback a version, as its good practice to version docker images too. Also relates to #55

## What does this PR address?

Right now one can only choose:
ghcr.io/pivx-labs/mypivxwallet:latest
or
ghcr.io/pivx-labs/mypivxwallet:master

But what if latest goes bad? There is no way to automatically rollback without manually getting the last known good image digest.

## What features or improvements were added?

With this change one can use e.g watchtower to automatically update to the next version tagged e.g
ghcr.io/pivx-labs/mypivxwallet:2023-02-19-223d6a4
If now `2023-02-20-313c5ag` goes bad, an automatic rollback can be done.
## How does this benefit users?

Minimal down time for selfhosted/external hosted instances and better choosing of features one wants or don't.
It can also be used for easier debugging!

