### PR TITLE
Intro, navbar & footer improvements

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -1038,7 +1038,7 @@
         <div class="footer">
           <div>
             <span> © MIT 2023 </span> - <span style="cursor: pointer;" onclick="MPW.playMusic()" data-i18n="footerBuiltWithPivxLabs">Built with 💜 by PIVX Labs</span><br />
-            <a href="https://github.com/PIVX-Labs/MyPIVXWallet" target="_blank">GitHub</a> - <a href="https://discord.gg/zTScGaGtgv" target="_blank">Discord</a> - <a href="https://medium.com/@pivx-labs" target="_blank">Medium</a>
+            <a href="https://github.com/PIVX-Labs/MyPIVXWallet" target="_blank"><i class="fa-brands fa-github"></i></i> GitHub</a> - <a href="https://discord.gg/zTScGaGtgv" target="_blank"><i class="fa-brands fa-discord"></i></i> Discord</a> - <a href="https://medium.com/@pivx-labs" target="_blank"><i class="fa-brands fa-medium"></i></i> Medium</a>
           </div>
         </div>
       </footer>

--- a/index.template.html
+++ b/index.template.html
@@ -46,14 +46,13 @@
         <!-- NAVBAR -->
         <nav class="navbar navbar-expand-lg sticky-top navbar-dark navbarSpecial">
           <div class="container">
-            <img onclick="MPW.playMusic()" class="nav-logo navbar-brand noselect" alt="PIVX" id="mpw-main-logo" />
+            <img onclick="MPW.openTab(event, 'home')" style="cursor: pointer;" class="nav-logo navbar-brand noselect" alt="PIVX" id="mpw-main-logo" />
             <button id="navbarToggler" class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse noselect" id="navbarNav">
               <!-- MAIN NAVBAR -->
               <ul class="navbar-nav mr-auto ptr">
-                <li class="nav-item"><a id="start" class="nav-link tablinks" onclick="MPW.openTab(event, 'home')" data-i18n="navIntro">Intro</a></li>
                 <li class="nav-item"><a class="nav-link tablinks" onclick="MPW.openTab(event, 'keypair')" data-i18n="navDashboard">Dashboard</a></li>
                 <li class="nav-item"><a id="txTab" class="nav-link tablinks" onclick="MPW.openTab(event, 'Transaction')" data-i18n="navSend">Send</a></li>
                 <li class="nav-item"><a id="stakeTab" class="nav-link tablinks" onclick="MPW.openTab(event, 'StakingTab')" data-i18n="navStake">Stake</a></li>
@@ -164,7 +163,7 @@
         <div class="container">
           <div class="row no-gutters">
             <div class="col-md-12 rm-pd">
-              <div id="home" class="tabcontent">
+              <div id="home" class="tabcontent" style="display: block;">
                 <!-- PIVX TITLE SECTION -->
                 <div class="col-md-12 title-section float-left rm-pd">
                   <h1 class="pivx-bold-title center-text">
@@ -1038,8 +1037,8 @@
       <footer id="foot">
         <div class="footer">
           <div>
-            <span> © MIT 2023 </span> - <span data-i18n="footerBuiltWithPivxLabs">Built with 💜 by PIVX Labs</span><br />
-            <a href="https://github.com/PIVX-Labs/MyPIVXWallet" data-i18n="footerGithubLink">MyPIVXWallet</a>
+            <span> © MIT 2023 </span> - <span style="cursor: pointer;" onclick="MPW.playMusic()" data-i18n="footerBuiltWithPivxLabs">Built with 💜 by PIVX Labs</span><br />
+            <a href="https://github.com/PIVX-Labs/MyPIVXWallet" target="_blank">GitHub</a> - <a href="https://discord.gg/zTScGaGtgv" target="_blank">Discord</a> - <a href="https://medium.com/@pivx-labs" target="_blank">Medium</a>
           </div>
         </div>
       </footer>

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -14,7 +14,6 @@ export const en_translation = {
     available:"Available",                   //
 
     // Nav Bar
-    navIntro: "Intro",                   //
     navDashboard: "Dashboard",               //
     navSend: "Send",                    //
     navStake: "Stake",                   //

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -29,7 +29,6 @@ export const en_translation = {
 
     // Footer
     footerBuiltWithPivxLabs: "Built with 💜 by PIVX Labs",    //
-    footerGithubLink: "MyPIVXWallet",           //
 
     // Intro
     title: "Welcome to",                      //

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -47,7 +47,6 @@ var translation = {
 
     // Footer
     footerBuiltWithPivxLabs: "",    //Built with 💜 by PIVX Labs
-    footerGithubLink: "",           //MyPIVXWallet
 
     // Intro
     title: "",                      //Welcome to

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -32,7 +32,6 @@ var translation = {
     available:"",                   //Available
 
     // Nav Bar
-    navIntro: "",                   //Intro
     navDashboard: "",               //Dashboard
     navSend: "",                    //Send
     navStake: "",                   //Stake

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -29,7 +29,6 @@ export const uwu_translation = {
 
     // Footer
     footerBuiltWithPivxLabs: "Built with wuv by PIVX Wabs❣",    //Built with 💜 by PIVX Labs
-    footerGithubLink: "",           //MyPIVXWallet
 
     // Intro
     title: "Wewcome to",                      //Welcome to

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -14,7 +14,6 @@ export const uwu_translation = {
     available:"Avawable",                   //Available
 
     // Nav Bar
-    navIntro: "Intwo",                   //Intro
     navDashboard: "Dashbowed",               //Dashboard
     navSend: "Send❣",                    //Send
     navStake: "",                   //Stake

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -35,7 +35,6 @@ export let doms = {};
 
 export function start() {
     doms = {
-        domStart: document.getElementById('start'),
         domInstall: document.getElementById('installTab'),
         domNavbarToggler: document.getElementById('navbarToggler'),
         domGuiStaking: document.getElementById('guiStaking'),
@@ -181,7 +180,6 @@ export function start() {
     };
     i18nStart();
     loadImages();
-    doms.domStart.click();
 
     // Register native app service
     registerWorker();


### PR DESCRIPTION
## Abstract

This small PR simply cleans up the navbar and footer slightly!

- Navbar "Intro" button removed, MPW logo can now be clicked to see the Intro.
- The "MPW Logo" easter-egg has been moved to the footer "made with :purple_heart:" text.
- The Intro is now displayed at CSS-level, rather than needing a `.click()`, which also fixes the "blank page" issue upon a cacheless load of MPW.
- The footer now has GitHub, Discord and Medium links with font-awesome icons.
- Unnecessary residue i18n translations were removed.

![image](https://user-images.githubusercontent.com/42538664/222804770-62eacce9-04b2-4437-b290-dc1e679080f6.png)

---

![image](https://user-images.githubusercontent.com/42538664/222860680-e2ff6ee5-c488-43f3-8e00-1dfb557b0471.png)

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
It helps remove out current over-clutter of the navbar, as well as some page loading issues, and gives users better connectivity to PIVX Labs itself via additional footer links.

## What features or improvements were added?
No new features, just general cleanup and fixes for an improved UX.

## How does this benefit users?
Less UI clutter, slightly easier navigation, and less surprises when clicking the logo starts rapping at you!