### PR TITLE
Status Icons Redesign

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -111,16 +111,17 @@ button {
     font-size: 16px;
 }
 
-.nav-item {
-    margin-left: 15px;
-}
-
 .navButton {
     color: #999;
 }
 
 .navButton:hover {
     color: #334758 !important;
+}
+
+.small-dark-bg {
+    border-radius: 20px;
+    background-color: #2c0044;
 }
 
 .alert-danger {
@@ -2115,9 +2116,14 @@ a {
   box-shadow: 0 0 0 0.2rem #cba7fa40;
 }
 
-
-
 .navbar-nav .nav-item a {
+  margin-left: 16px;
+  transition: all .2s ease-in-out;
+}
+
+.navbar-nav .nav-item span {
+  margin-left: 5px;
+  margin-right: 5px;
   transition: all .2s ease-in-out;
 }
 

--- a/index.template.html
+++ b/index.template.html
@@ -64,10 +64,10 @@
               <div class="form-inline my-2 my-lg-0">
                 <ul class="navbar-nav mr-auto small-dark-bg ptr">
                   <li class="nav-item">
-                    <span class="nav-link" id="Debug" onclick="MPW.toggleDebug()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Debug Mode</b><br>You're in debug mode, which is logging additional verbose data in the console"><i class="fa-solid fa-bug"></i></span>
+                    <span class="nav-link" style="display: none;" id="Debug" onclick="MPW.toggleDebug()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Debug Mode</b><br>You're in debug mode, which is logging additional verbose data in the console"><i class="fa-solid fa-bug"></i></span>
                   </li>
                   <li class="nav-item">
-                    <span class="nav-link" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-cubes"></i></span>
+                    <span class="nav-link" style="display: none;" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-cubes"></i></span>
                   </li>
                   <li class="nav-item">
                     <span class="nav-link" id="Network" onclick="MPW.toggleNetwork()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Internet Access</b><br>Whether or not your node is connected to the internet"><i class="fa-solid fa-wifi"></i></span>

--- a/index.template.html
+++ b/index.template.html
@@ -62,15 +62,15 @@
 
               <!-- SIDE NAVBAR -->
               <div class="form-inline my-2 my-lg-0">
-                <ul class="navbar-nav mr-auto small-dark-bg ptr">
+                <ul class="navbar-nav mr-auto small-dark-bg">
                   <li class="nav-item">
-                    <span class="nav-link" style="display: none;" id="Debug" onclick="MPW.toggleDebug()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Debug Mode</b><br>You're in debug mode, which is logging additional verbose data in the console"><i class="fa-solid fa-bug"></i></span>
+                    <span class="nav-link ptr" style="display: none;" id="Debug" onclick="MPW.toggleDebug()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Debug Mode</b><br>You're in debug mode, which is logging additional verbose data in the console"><i class="fa-solid fa-bug"></i></span>
                   </li>
                   <li class="nav-item">
-                    <span class="nav-link" style="display: none;" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-cubes"></i></span>
+                    <span class="nav-link ptr" style="display: none;" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-cubes"></i></span>
                   </li>
                   <li class="nav-item">
-                    <span class="nav-link" id="Network" onclick="MPW.toggleNetwork()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Internet Access</b><br>Whether or not your node is connected to the internet"><i class="fa-solid fa-wifi"></i></span>
+                    <span class="nav-link ptr" id="Network" onclick="MPW.toggleNetwork()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Internet Access</b><br>Whether or not your node is connected to the internet"><i class="fa-solid fa-wifi"></i></span>
                   </li>
                 </ul>
               </div>

--- a/index.template.html
+++ b/index.template.html
@@ -67,7 +67,7 @@
                     <span class="nav-link ptr" style="display: none;" id="Debug" onclick="MPW.toggleDebug()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Debug Mode</b><br>You're in debug mode, which is logging additional verbose data in the console"><i class="fa-solid fa-bug"></i></span>
                   </li>
                   <li class="nav-item">
-                    <span class="nav-link ptr" style="display: none;" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-cubes"></i></span>
+                    <span class="nav-link ptr" style="display: none;" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-network-wired"></i></span>
                   </li>
                   <li class="nav-item">
                     <span class="nav-link ptr" id="Network" onclick="MPW.toggleNetwork()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Internet Access</b><br>Whether or not your node is connected to the internet"><i class="fa-solid fa-wifi"></i></span>

--- a/index.template.html
+++ b/index.template.html
@@ -62,17 +62,15 @@
 
               <!-- SIDE NAVBAR -->
               <div class="form-inline my-2 my-lg-0">
-                <ul class="navbar-nav mr-auto ptr">
+                <ul class="navbar-nav mr-auto small-dark-bg ptr">
                   <li class="nav-item">
-                    <a class="nav-link tablinks active" id="Testnet" onclick="MPW.toggleTestnet()" data-i18n="navTestnet"><b>Testnet Mode On</b></a>
+                    <span class="nav-link" id="Debug" onclick="MPW.toggleDebug()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Debug Mode</b><br>You're in debug mode, which is logging additional verbose data in the console"><i class="fa-solid fa-bug"></i></span>
                   </li>
                   <li class="nav-item">
-                    <a class="nav-link tablinks active" id="Network" onclick="MPW.toggleNetwork()">
-                      <span data-i18n="navNetwork">Network:</span> <span id="NetworkE" data-i18n="enabled">Enabled</span><span id="NetworkD" data-i18n="disabled">Disabled</span>
-                    </a>
+                    <span class="nav-link" id="Testnet" onclick="MPW.toggleTestnet()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Testnet Mode</b><br>You're currently using MPW on the Testnet Network"><i class="fa-solid fa-cubes"></i></span>
                   </li>
                   <li class="nav-item">
-                    <a class="nav-link tablinks active" id="Debug" onclick="MPW.toggleDebug()"><b>DEBUG MODE ON</b></a>
+                    <span class="nav-link" id="Network" onclick="MPW.toggleNetwork()" data-toggle="tooltip" data-html="true" data-placement="bottom" title="<b>Internet Access</b><br>Whether or not your node is connected to the internet"><i class="fa-solid fa-wifi"></i></span>
                   </li>
                 </ul>
               </div>

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -21,11 +21,6 @@ export const en_translation = {
     navGovernance:"Governance",               //
     navSettings: "Settings",                //
 
-    navTestnet: "<b>Testnet Mode On</b>",                 //
-    navNetwork: "<b>Network:</b>",                 //
-    navDebug: "Debug",                   //
-    navExperimentalSync:"<b>Experimental Sync Active</b>",         //
-
     // Footer
     footerBuiltWithPivxLabs: "Built with 💜 by PIVX Labs",    //
 

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -39,11 +39,6 @@ var translation = {
     navGovernance:"",               //Governance
     navSettings: "",                //Settings
 
-    navTestnet: "",                 //<b>Testnet Mode On</b>
-    navNetwork: "",                 //<b>Network:</b>
-    navDebug: "",                   //Debug
-    navExperimentalSync:"",         //<b>Experimental Sync Active</b>
-
     // Footer
     footerBuiltWithPivxLabs: "",    //Built with 💜 by PIVX Labs
 

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -21,11 +21,6 @@ export const uwu_translation = {
     navGovernance:"",               //Governance
     navSettings: "",                //Settings
 
-    navTestnet: "Testnet Mowode On",                 //<b>Testnet Mode On</b>
-    navNetwork: "<b>Netwowork</b>",                 //<b>Network:</b>
-    navDebug: "Debuwug",                   //Debug
-    navExperimentalSync:"<b>Dangewous sync actiwated!</b>",         //<b>Experimental Sync Active</b>
-
     // Footer
     footerBuiltWithPivxLabs: "Built with wuv by PIVX Wabs❣",    //Built with 💜 by PIVX Labs
 

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -181,6 +181,7 @@ export function start() {
     i18nStart();
     loadImages();
 
+    // Enable all Bootstrap Tooltips
     $(function () {
         $('[data-toggle="tooltip"]').tooltip()
     });

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -170,8 +170,6 @@ export function start() {
         // Alert DOM element
         domAlertPos: document.getElementsByClassName('alertPositioning')[0],
         domNetwork: document.getElementById('Network'),
-        domNetworkE: document.getElementById('NetworkE'),
-        domNetworkD: document.getElementById('NetworkD'),
         domDebug: document.getElementById('Debug'),
         domTestnet: document.getElementById('Testnet'),
         domCurrencySelect: document.getElementById('currency'),
@@ -182,6 +180,10 @@ export function start() {
     };
     i18nStart();
     loadImages();
+
+    $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+    });
 
     // Register Input Pair events
     doms.domSendAmountCoins.oninput = () => {

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -183,7 +183,7 @@ export function start() {
 
     // Enable all Bootstrap Tooltips
     $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
+        $('[data-toggle="tooltip"]').tooltip();
     });
 
     // Register Input Pair events
@@ -215,7 +215,9 @@ export function start() {
     const reqTo = urlParams.has('pay') ? urlParams.get('pay') : '';
 
     // Check for a payment request amount
-    const reqAmount = urlParams.has('amount') ? parseFloat(urlParams.get('amount')) : 0;
+    const reqAmount = urlParams.has('amount')
+        ? parseFloat(urlParams.get('amount'))
+        : 0;
 
     // Customise the UI if a saved wallet exists
     if (hasEncryptedWallet()) {

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -16,7 +16,8 @@ export function disableNetwork() {
 
 export function toggleNetwork() {
     networkEnabled = !networkEnabled;
-    doms.domNetwork.innerHTML = '<i class="fa-solid fa-' + (networkEnabled ? 'wifi' : 'ban') + '"></i>';
+    doms.domNetwork.innerHTML =
+        '<i class="fa-solid fa-' + (networkEnabled ? 'wifi' : 'ban') + '"></i>';
     return networkEnabled;
 }
 

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -16,10 +16,7 @@ export function disableNetwork() {
 
 export function toggleNetwork() {
     networkEnabled = !networkEnabled;
-    //TRANSLATION CHANGE
-    //doms.domNetwork.innerHTML = '<b>Network:</b> ' + (networkEnabled ? 'Enabled' : 'Disabled');
-    doms.domNetworkE.style.display = networkEnabled ? '' : 'none';
-    doms.domNetworkD.style.display = networkEnabled ? 'none' : '';
+    doms.domNetwork.innerHTML = '<i class="fa-solid fa-' + (networkEnabled ? 'wifi' : 'ban') + '"></i>';
     return networkEnabled;
 }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -68,7 +68,8 @@ export let cAnalyticsLevel = arrAnalytics[2];
 // --- DOM Cache
 export function start() {
     // Initialise status icons as their default variables
-    doms.domNetwork.innerHTML = '<i class="fa-solid fa-' + (networkEnabled ? 'wifi' : 'ban') + '"></i>';
+    doms.domNetwork.innerHTML =
+        '<i class="fa-solid fa-' + (networkEnabled ? 'wifi' : 'ban') + '"></i>';
     doms.domTestnet.style.display = cChainParams.current.isTestnet
         ? ''
         : 'none';

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -67,10 +67,8 @@ export let cAnalyticsLevel = arrAnalytics[2];
 
 // --- DOM Cache
 export function start() {
-    //TRANSLATIONS
-    //to make translations work we need to change it so that we just enable or disable the visibility of the text
-    doms.domNetworkE.style.display = networkEnabled ? '' : 'none';
-    doms.domNetworkD.style.display = networkEnabled ? 'none' : '';
+    // Initialise status icons as their default variables
+    doms.domNetwork.innerHTML = '<i class="fa-solid fa-' + (networkEnabled ? 'wifi' : 'ban') + '"></i>';
     doms.domTestnet.style.display = cChainParams.current.isTestnet
         ? ''
         : 'none';
@@ -320,8 +318,6 @@ export function toggleTestnet() {
 
 export function toggleDebug() {
     debug = !debug;
-    //TRANSLATION CHANGES
-    //doms.domDebug.innerHTML = debug ? '<b>DEBUG MODE ON</b>' : '';
     doms.domDebug.style.display = debug ? '' : 'none';
 }
 


### PR DESCRIPTION
## Abstract

The old 'status' system for MPW looked extremely clunky, inconsistent, and used too much "screen space".

This PR redesigns MPW 'statuses' to be FontAwesome icon-based with descriptive Bootstrap Tooltips upon hover, all icons are clickable, some will totally hide when disabled (i.e: Debug Mode), and some will switch icon accordingly to their mode, like Internet Access.

**Production:**
![image](https://user-images.githubusercontent.com/42538664/223406222-8aa18c83-229a-4f86-bda8-17d5965a4802.png)

**Pull Request:**
![image](https://user-images.githubusercontent.com/42538664/223406470-8eb5d1c1-95c6-45e6-8370-06a9e16b6d24.png)

## What does this PR address?
This PR redesigns the Status system to an 'icon bar' with status icons and descriptive tooltips, massively reducing screen-space used, and giving full consistency to any existing and future MPW statuses that need to be displayed to the user.

## What features or improvements were added?
A redesigned Status Bar with icons and descriptive tooltips.

## How does this benefit users?
It's much nicer on the eyes, easy to understand, and uses far less screen real-estate, which helps draw the user's focus to where it's needed (the core app), only displaying verbose info upon hover.