### PR TITLE
Added passphrase to bip39

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -115,7 +115,6 @@
                   This is your seed phrase:
                   <b>
                     <div class="seed-phrase noselect" id="ModalMnemonicContent">
-                      <!-- Test1 Test2 Test1 Test2 Test1 Test2 Test1 Test2 Test1 Test2 Test1 Test2 -->
                     </div>
                   </b>
                   <br />
@@ -128,7 +127,9 @@
                   <a href="https://www.ledger.com/blog/how-to-protect-your-seed-phrase" target="_blank">
                     <i>It is <b>NOT</b> advised to store this digitally.</i>
                   </a>
-                  <br />
+		  <br />
+		  <br />
+		  <input class="center-text" type="password" id="ModalMnemonicPassphrase" placeholder="Optional Passphrase" />
                   <br />
                 </div>
                 <div class="modal-footer">

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -144,6 +144,9 @@ export function start() {
         domMnemonicModalButton: document.getElementById(
             'modalMnemonicConfirmButton'
         ),
+        domMnemonicModalPassphrase: document.getElementById(
+            'ModalMnemonicPassphrase'
+        ),
         domExportPrivateKey: document.getElementById('exportPrivateKeyText'),
         domExportWallet: document.getElementById('guiExportWalletItem'),
         domWipeWallet: document.getElementById('guiWipeWallet'),
@@ -802,8 +805,11 @@ export function onPrivateKeyChanged() {
     // and it doesn't have any spaces (would be a mnemonic seed)
     const fContainsSpaces = doms.domPrivKey.value.includes(' ');
     doms.domPrivKeyPassword.hidden =
-        doms.domPrivKey.value.length !== 128 || fContainsSpaces;
+        doms.domPrivKey.value.length !== 128 && !fContainsSpaces;
 
+    doms.domPrivKeyPassword.placeholder = fContainsSpaces
+        ? 'Optional Passphrase'
+        : 'Password';
     // Uncloak the private input IF spaces are detected, to make Seed Phrases easier to input and verify
     doms.domPrivKey.setAttribute('type', fContainsSpaces ? 'text' : 'password');
 }


### PR DESCRIPTION
## Abstract

Adds the ability to create and import wallet with a user generated passphrase

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
MPW was missing the optional passphrase included in bip39 

## What features or improvements were added?
An optional passphrase input both when creating an importing a wallet

## How does this benefit users?
This increases support with other wallets.

