### PR TITLE
Add View on Explorer button

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -422,6 +422,9 @@
                                   <div class="dropdown">
                                     <div class="dropdown-move">
                                       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                        <a class="dropdown-item" href="#" onclick="MPW.openExplorer()">
+                                          <i class="fa-solid fa-magnifying-glass"></i> View on Explorer
+                                        </a>
                                         <a id="guiExportWalletItem" class="dropdown-item" href="#" data-toggle="modal" data-target="#exportPrivateKeysModal" data-backdrop="static" data-keyboard="false" onclick="MPW.toggleExportUI()">
                                           <i class="fas fa-key"></i> Export
                                         </a>

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -398,6 +398,23 @@ export function updateStakingRewardsGUI(fCallback = false) {
     doms.domStakingRewardsList.innerHTML = strList;
 }
 
+/**
+ * Open the Explorer in a new tab for the loaded master public key
+ */
+export async function openExplorer() {
+    if (masterKey.isHD) {
+        const derivationPath = getDerivationPath(masterKey.isHardwareWallet)
+            .split('/')
+            .slice(0, 4)
+            .join('/');
+        const xpub = await masterKey.getxpub(derivationPath);
+        window.open(cExplorer.url + '/xpub/' + xpub, '_blank');
+    } else {
+        const address = await masterKey.getAddress();
+        window.open(cExplorer.url + '/address/' + address, '_blank');
+    }
+}
+
 async function loadImages() {
     // Promise.all is useless since we only need to load one image, but we might need to load more in the future
     Promise.all([

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -8,6 +8,7 @@ import {
     importWallet,
     encryptWallet,
     decryptWallet,
+    getDerivationPath,
 } from './wallet.js';
 import {
     submitAnalytics,

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -20,6 +20,7 @@ export {
     refreshChainData,
     playMusic,
     selectMaxBalance,
+    openExplorer,
     guiEncryptWallet,
     guiPreparePayment,
     doms,

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -560,9 +560,6 @@ export async function importWallet({
                         // Lastly, attempt to parse as a WIF private key
                         const pkBytes = parseWIF(privateImportValue);
 
-                        // Hide the 'new address' button, since non-HD wallets are essentially single-address MPW wallets
-                        doms.domNewAddress.style.display = 'none';
-
                         // Import the raw private key
                         masterKey = new LegacyMasterKey({ pkBytes });
                     }
@@ -587,6 +584,9 @@ export async function importWallet({
                 doms.domRestoreWallet.hidden = false;
             }
         }
+
+        // For non-HD wallets: hide the 'new address' button, since these are essentially single-address MPW wallets
+        if (!masterKey.isHD) doms.domNewAddress.style.display = 'none';
 
         getNewAddress({ updateGUI: true });
         // Display Text


### PR DESCRIPTION
## Abstract

This PR adds a simple button to the wallet UI to open the current 'master public key' in the user-preferred explorer.
Currently MPW offers no easy way of viewing the `xpub`, this is a quick workaround while also allowing an easy shortcut to the explorer.

![image](https://user-images.githubusercontent.com/42538664/224694335-2cfee87c-53f3-4194-9437-10ce1c5d7b3a.png)

Additionally this PR fixes a small bug in which a non-HD wallet in view-only mode would fail to hide the "Refresh Address" button, this is only intended for HD wallets.

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
It assists with the inability to view the `xpub` as well as granting an explorer shortcut.

## What features or improvements were added?
A Dashboard shortcut to the explorer page of the current wallet public key.

## How does this benefit users?
Users can access their `xpub` easier or simply quick-access an integrated PIVX explorer, alongside monitoring their address for transactions while away/outside from MPW.

Alternatively, users could find it useful to import their xpub in to another MPW instance, purely for View-Only monitoring purposes.