### PR TITLE
Ran npm audit --fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7657,9 +7657,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
+      "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",


### PR DESCRIPTION
npm audit was reporting a high severity vulnerability
```
# npm audit report

webpack  5.0.0 - 5.75.0
Severity: high
Cross-realm object access in Webpack 5 - https://github.com/advisories/GHSA-hc6q-2mpp-qw7j
fix available via `npm audit fix`
node_modules/webpack

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```
This PR just runs `npm audit --fix`