### PR TITLE
Various import fixes

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -20,7 +20,13 @@ import {
     strCurrency,
 } from './settings.js';
 import { createAndSendTransaction } from './transactions.js';
-import { createAlert, confirmPopup, sanitizeHTML, MAP_B58, isBase64 } from './misc.js';
+import {
+    createAlert,
+    confirmPopup,
+    sanitizeHTML,
+    MAP_B58,
+    isBase64,
+} from './misc.js';
 import { cChainParams, COIN, MIN_PASS_LENGTH } from './chain_params.js';
 import { decrypt } from './aes-gcm.js';
 
@@ -856,7 +862,7 @@ export function accessOrImportWallet() {
 }
 /**
  * An event function triggered apon private key UI input changes
- * 
+ *
  * Useful for adjusting the input types or displaying password prompts depending on the import scheme
  */
 export function onPrivateKeyChanged() {
@@ -865,7 +871,9 @@ export function onPrivateKeyChanged() {
     // and it doesn't have any spaces (would be a mnemonic seed)
     const fContainsSpaces = doms.domPrivKey.value.includes(' ');
     doms.domPrivKeyPassword.hidden =
-        (doms.domPrivKey.value.length < 128 || !isBase64(doms.domPrivKey.value)) && !fContainsSpaces;
+        (doms.domPrivKey.value.length < 128 ||
+            !isBase64(doms.domPrivKey.value)) &&
+        !fContainsSpaces;
 
     doms.domPrivKeyPassword.placeholder = fContainsSpaces
         ? 'Optional Passphrase'
@@ -878,7 +886,8 @@ export function onPrivateKeyChanged() {
  * Imports a wallet using the GUI input, handling decryption via UI
  */
 export async function guiImportWallet() {
-    const fEncrypted = doms.domPrivKey.value.length >= 128 && isBase64(doms.domPrivKey.value);
+    const fEncrypted =
+        doms.domPrivKey.value.length >= 128 && isBase64(doms.domPrivKey.value);
 
     // If we are in testnet: prompt an import
     if (cChainParams.current.isTestnet) return importWallet();
@@ -898,7 +907,7 @@ export async function guiImportWallet() {
             return importWallet({
                 newWif: strDecWIF,
                 // Save the public key to disk for future View Only mode post-decryption
-                fSavePublicKey: true
+                fSavePublicKey: true,
             });
         }
     }

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -20,7 +20,7 @@ import {
     strCurrency,
 } from './settings.js';
 import { createAndSendTransaction } from './transactions.js';
-import { createAlert, confirmPopup, sanitizeHTML, MAP_B58 } from './misc.js';
+import { createAlert, confirmPopup, sanitizeHTML, MAP_B58, isBase64 } from './misc.js';
 import { cChainParams, COIN, MIN_PASS_LENGTH } from './chain_params.js';
 import { decrypt } from './aes-gcm.js';
 
@@ -854,14 +854,18 @@ export function accessOrImportWallet() {
         doms.domPrivKey.focus();
     }
 }
-
+/**
+ * An event function triggered apon private key UI input changes
+ * 
+ * Useful for adjusting the input types or displaying password prompts depending on the import scheme
+ */
 export function onPrivateKeyChanged() {
     if (hasEncryptedWallet()) return;
-    // Check whether the length of the string is 128 bytes (that's the length of ciphered plain texts)
+    // Check whether the string is Base64 (would likely be an MPW-encrypted import)
     // and it doesn't have any spaces (would be a mnemonic seed)
     const fContainsSpaces = doms.domPrivKey.value.includes(' ');
     doms.domPrivKeyPassword.hidden =
-        doms.domPrivKey.value.length !== 128 && !fContainsSpaces;
+        (doms.domPrivKey.value.length < 128 || !isBase64(doms.domPrivKey.value)) && !fContainsSpaces;
 
     doms.domPrivKeyPassword.placeholder = fContainsSpaces
         ? 'Optional Passphrase'
@@ -870,8 +874,11 @@ export function onPrivateKeyChanged() {
     doms.domPrivKey.setAttribute('type', fContainsSpaces ? 'text' : 'password');
 }
 
+/**
+ * Imports a wallet using the GUI input, handling decryption via UI
+ */
 export async function guiImportWallet() {
-    const fEncrypted = doms.domPrivKey.value.length === 128;
+    const fEncrypted = doms.domPrivKey.value.length >= 128 && isBase64(doms.domPrivKey.value);
 
     // If we are in testnet: prompt an import
     if (cChainParams.current.isTestnet) return importWallet();

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -890,6 +890,8 @@ export async function guiImportWallet() {
             localStorage.setItem('encwif', strPrivKey);
             return importWallet({
                 newWif: strDecWIF,
+                // Save the public key to disk for future View Only mode post-decryption
+                fSavePublicKey: true
             });
         }
     }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -52,4 +52,3 @@ export { Masternode };
 export { getNetwork } from './network.js';
 const toggleNetwork = () => getNetwork().toggle();
 export { toggleNetwork };
-

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -206,19 +206,19 @@ export function isBase64(str) {
 
     // Check if the string contains only Base64 characters:
     if (!base64Regex.test(str)) {
-      return false;
+        return false;
     }
 
     // Check if the length is a multiple of 4 (required for Base64):
     if (str.length % 4 !== 0) {
-      return false;
+        return false;
     }
 
     // Try decoding the Base64 string to check for errors:
     try {
-      atob(str);
+        atob(str);
     } catch (e) {
-      return false;
+        return false;
     }
 
     // The string is likely Base64-encoded:

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -197,6 +197,35 @@ export function sanitizeHTML(text) {
 }
 
 /**
+ * Check if a string is valid Base64 encoding
+ * @param {string} str - String to check
+ * @returns {boolean}
+ */
+export function isBase64(str) {
+    const base64Regex = /^[A-Za-z0-9+/=]+$/;
+
+    // Check if the string contains only Base64 characters:
+    if (!base64Regex.test(str)) {
+      return false;
+    }
+
+    // Check if the length is a multiple of 4 (required for Base64):
+    if (str.length % 4 !== 0) {
+      return false;
+    }
+
+    // Try decoding the Base64 string to check for errors:
+    try {
+      atob(str);
+    } catch (e) {
+      return false;
+    }
+
+    // The string is likely Base64-encoded:
+    return true;
+}
+
+/**
  * An artificial sleep function to pause code execution
  *
  * @param {Number} ms - The milliseconds to sleep

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -636,11 +636,13 @@ export async function importWallet({
                 masterKey.isViewOnly
             )
         ) {
-            if (// If the wallet was internally imported (not UI pasted), like via vanity, display the encryption prompt
-                ((fRaw && newWif.length) || newWif) && !hasEncryptedWallet() ||
+            if (
+                // If the wallet was internally imported (not UI pasted), like via vanity, display the encryption prompt
+                (((fRaw && newWif.length) || newWif) &&
+                    !hasEncryptedWallet()) ||
                 // If the wallet was pasted and is an unencrypted key, then display the encryption prompt
                 !hasEncryptedWallet()
-                ) {
+            ) {
                 doms.domGenKeyWarning.style.display = 'block';
             } else if (hasEncryptedWallet()) {
                 // If the wallet was pasted and is an encrypted import, display the lock wallet UI
@@ -782,7 +784,7 @@ export async function decryptWallet(strPassword = '') {
             newWif: strDecWIF,
             skipConfirmation: true,
             // Save the public key to disk for View Only mode
-            fSavePublicKey: true
+            fSavePublicKey: true,
         });
         return true;
     }


### PR DESCRIPTION
## Abstract

MPW's import schemes have evolved quite dramatically these few months, and it's left a few residue bugs, *all* importing issues should be resolved with this PR, for a breakdown:
- Fixed longer encrypted MPW import strings from rejecting entirely.
- Fixed Vanity and other 'internal' imports to display backup prompts.
- Fixed Encrypted imports from hiding the 'Lock Wallet' button after first import.
- Fixed 'View Only' mode not activating first try for Encrypted imports.
- JSDocs added for all changed functions.


<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
Bugs! A whole bunch of bugs and edge-cases for importing wallets in MPW.

## What features or improvements were added?
Purely bug fixes.

## How does this benefit users?
Less bugs, and a smoother experience for certain import styles (i.e: less steps like re-trying for View Only mode to activate in certain cases, or the Lock/Unlock button disappearing in to the void after an encrypted import).