### PR TITLE
Refactor Masternode key generation

### DIFF
--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -381,10 +381,9 @@ export async function createMasternode() {
     // Generate a Masternode private key if the user wants a self-hosted masternode
     const fGeneratePrivkey = doms.domMnCreateType.value === 'VPS';
     if (fGeneratePrivkey) {
-        const masternodePrivateKey = await generateMnPrivkey();
         await confirmPopup({
             title: ALERTS.CONFIRM_POPUP_MN_P_KEY,
-            html: masternodePrivateKey + ALERTS.CONFIRM_POPUP_MN_P_KEY_HTML,
+            html: generateMnPrivkey() + ALERTS.CONFIRM_POPUP_MN_P_KEY_HTML,
         });
     }
     createAlert(

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -10,7 +10,9 @@ export function bytesToHex(bytes) {
 }
 
 /**
-   @returns {Uint8Array} double sha256 or the buffer
+ * Double SHA256 hash a byte array
+ * @param {Array<number>} buff - Bytes to hash
+ * @returns {Uint8Array} Hash buffer
  */
 export function dSHA256(buff) {
     return sha256(sha256(new Uint8Array(buff)));


### PR DESCRIPTION
## Abstract

The previous MN private key generation code felt quite clunky and had a lot of redundancies, this PR is a simple cleanup that removes much of the clunky key encoding for neat and clear ByteArray manipulations, which should also be better performant (even if this function is rarely used, currently).

This cleanup also nukes the unnecessary `hash()` function in favor of our Noble SHA256 (Double) hash utility.

**To test this without using 10k PIV:**
I used `export { generateMnPrivkey };` in the index of both `master` and the PR to expose the key generation to the console, then hard-coded a 32 byte array in `generateMnPrivkey()` for `privkey/priv_key`, this tests the encoding process works properly, and that the output BEFORE and AFTER the PR is exactly the same, minus the new PR not needing to use async/await due to Noble hashing being synchronous.

## What does this PR address?
A slight cleanup of the Masternode private key generation and encoding functions.

## What features or improvements were added?
None, just a code refactor.

## How does this benefit users?
No direct benefit, aside from perhaps a few milliseconds shaven off the Masternode private key generation. :shrug: