### PR TITLE
Fix missing image metadata (Add three slashes)

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -20,20 +20,20 @@
     <meta property="og:url" content="https://mypivxwallet.org/" />
     <meta property="og:title" content="My PIVX Wallet" />
     <meta property="og:description" content="The wallet of the future - Receive, Send, Stake and Exchange using a completely decentralized, open-source, battle-hardened PIVX wallet." />
-    <meta property="og:image" content="logo_opaque-dark-bg.png" />
+    <meta property="og:image" content="/logo_opaque-dark-bg.png" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://mypivxwallet.org/" />
     <meta property="twitter:title" content="My PIVX Wallet" />
     <meta property="twitter:description" content="The wallet of the future - Receive, Send, Stake and Exchange using a completely decentralized, open-source, battle-hardened PIVX wallet." />
-    <meta property="twitter:image" content="logo_opaque-dark-bg.png" />
+    <meta property="twitter:image" content="/logo_opaque-dark-bg.png" />
 
     <!-- Colour Theme -->
     <meta name="msapplication-TileColor" content="#470e75" />
     <meta name="theme-color" content="#470e75" />
 
-    <link rel="icon" type="image/png" href="logo_opaque-dark-bg.png" />
+    <link rel="icon" type="image/png" href="/logo_opaque-dark-bg.png" />
     <link rel="canonical" href="https://mypivxwallet.org/" />
 
     <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
## Abstract

This PR adds three slashes, 'nuff said.

This fixes our image metadata, which wasn't displaying properly as the URLs weren't explicitly relative.

The visual difference of this on Discord, for example:
![image](https://user-images.githubusercontent.com/42538664/229324391-e2ac87f5-83b5-4c89-99d4-ea44c0dc9fdd.png)

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
Incorrect URLs leading to metadata images failing to display on social media platforms.

## What features or improvements were added?
Three slashes.

## How does this benefit users?
They get to see our fancy recognisable logo - which is actually known to boost clicks and user attention.