### PR TITLE
Masternode list fix and rewards

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -619,6 +619,11 @@ button {
     font-size: large;
     height: 85%;
 }
+.masternode-rewards-list {
+    overflow: auto;
+    font-size: large;
+    height: 85%;
+}
 
 #staking-rectangle {
     position: relative;

--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -627,7 +627,7 @@ button {
 .masternode-rewards-list {
     overflow: auto;
     font-size: large;
-    height: 85%;
+    height: 55%;
 }
 
 #staking-rectangle {
@@ -688,6 +688,7 @@ button {
     margin-right: auto !important;
     height: 220px;
     margin: 30px 5px 10px;
+    display: inline-block;
 }
 
 

--- a/index.template.html
+++ b/index.template.html
@@ -951,7 +951,29 @@
                     </h4>
                     <h2 id="mnLastSeen" class="stake-balances" style="overflow-wrap: anywhere; top: 50%; left: 50%; transform: translate(-50%, -50%); position: absolute; width: 100%; padding: 10px; font-size: xx-large;" id="mnStatus"></h2>
                   </div>
+                  <div class="stake-box large-box col-md-4">
+                  <h4 class="stake-balances" style="background-color: #2c0044; border-radius: 10px;">
+                    Last Paid
+                  </h4>
+                  <h2 id="mnLastPaid" class="stake-balances" style="overflow-wrap: anywhere; top: 50%; left: 50%; transform: translate(-50%, -50%); position: absolute; width: 100%; padding: 10px; font-size: xx-large;" id="mnStatus"></h2>
+                  </div>
+                  <!-- // MASTERNODE REWARD LIST -->
+                  <div class="staking-banner-bottom">
+                    <div class="stake-box large-box col-md-4">
+                      <div id="masternode-rewards-title" class="staking-rewards-header">
+                      <h5><span data-i18n="masternode">Masternode</span> <span data-i18n="rewards">Rewards</span></h5>
+                      </div>
+                      <div class="masternode-rewards-list">
+                        <div id="masternode-rewards-content"></div>
+                          <button type="button" id="stakingLoadMore" onclick="MPW.updateMasternodeRewardsGUI()">
+                          <span class="buttoni-icon" id="stakingLoadMoreIcon"><i class="fas fa-sync fa-tiny-margin"></i></span>
+                          <span class="buttoni-text" data-i18n="stakingLoadMore">Load more</span>
+                          </button>
+                      </div>
+                    </div>
+                  </div>
                 </div>
+              </div>
 
                 <br />
 

--- a/index.template.html
+++ b/index.template.html
@@ -996,7 +996,6 @@
                     </div>
                   </div>
                 </div>
-              </div>
 
                 <br />
 
@@ -1012,6 +1011,7 @@
                   </button>
                 </center>
               </div>
+            </div>
 
               <div id="Settings" class="tabcontent">
                 <label for="currency" data-i18n="settingsCurrency">Choose a display currency:</label>

--- a/index.template.html
+++ b/index.template.html
@@ -983,18 +983,16 @@
                   <h2 id="mnLastPaid" class="stake-balances" style="overflow-wrap: anywhere; top: 50%; left: 50%; transform: translate(-50%, -50%); position: absolute; width: 100%; padding: 10px; font-size: xx-large;" id="mnStatus"></h2>
                   </div>
                   <!-- // MASTERNODE REWARD LIST -->
-                  <div class="staking-banner-bottom">
-                    <div class="stake-box large-box col-md-4">
-                      <div id="masternode-rewards-title" class="staking-rewards-header">
-                      <h5><span data-i18n="masternode">Masternode</span> <span data-i18n="rewards">Rewards</span></h5>
-                      </div>
-                      <div class="masternode-rewards-list">
-                        <div id="masternode-rewards-content"></div>
-                          <button type="button" id="stakingLoadMore" onclick="MPW.updateMasternodeRewardsGUI()">
-                          <span class="buttoni-icon" id="stakingLoadMoreIcon"><i class="fas fa-sync fa-tiny-margin"></i></span>
-                          <span class="buttoni-text" data-i18n="stakingLoadMore">Load more</span>
-                          </button>
-                      </div>
+                  <div class="stake-box large-box col-md-4">
+                    <div id="masternode-rewards-title">
+                    <h4 class="stake-balances" style="background-color: #2c0044; border-radius: 10px;"><span data-i18n="masternode">Masternode</span> <span data-i18n="rewards">Rewards</span></h4>
+                    </div>
+                    <div class="masternode-rewards-list">
+                      <div id="masternode-rewards-content"></div>
+                        <button type="button" id="masternodeLoadMore" onclick="MPW.updateMasternodeRewardsGUI()">
+                        <span class="buttoni-icon" id="stakingLoadMoreIcon"><i class="fas fa-sync fa-tiny-margin"></i></span>
+                        <span class="buttoni-text" data-i18n="masternodeLoadMore">Load more</span>
+                        </button>
                     </div>
                   </div>
                 </div>
@@ -1072,7 +1070,6 @@
             </div>
           </div>
         </div>
-      </div>
       <!--
       Alert
     -->

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -80,6 +80,9 @@ export const en_translation = {
     stakeUnstake:"Unstake",                //
     stakeLoadMore:"Load more",               //
 
+    // Masternode
+    masternodeLoadMore:"Load more",          //
+
     // Governance
     contestedProposalsTitle:"Contested Proposals",
     contestedProposalsDesc:"These are proposals that received an overwhelming amount of downvotes, making it likely spam or a highly contestable proposal.",

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -98,6 +98,9 @@ var translation = {
     stakeUnstake:"",                //Unstake
     stakeLoadMore:"",               //Load more
 
+    // Masternode
+    masternodeLoadMore:"",          //Load more
+
     // Governance
     contestedProposalsTitle:"",     //Contested Proposals
     contestedProposalsDesc:"",      //These are proposals that received an overwhelming amount of downvotes, making it likely spam or a highly contestable proposal.

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -80,6 +80,9 @@ export const uwu_translation = {
     stakeUnstake:"",                //Unstake
     stakeLoadMore:"Lowoad Mowore",               //Load more
 
+    // Masternode
+    masternodeLoadMore:"Lowoad Mowore",           //Load more
+
     // Governance
     contestedProposalsTitle:"Contwested Pwoposals",
     contestedProposalsDesc:"Dees are pwoposals dat received an overwhelming ameownt of downwotes, making it likely spam or a highly contwestable pwoposal.",

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -148,6 +148,12 @@ export function start() {
         domStakingRewardsTitle: document.getElementById(
             'staking-rewards-title'
         ),
+        domMasternodeRewardsList: document.getElementById(
+            'masternode-rewards-content'
+        ),
+        domMasternodeRewardsTitle: document.getElementById(
+            'masternode-rewards-title'
+        ),
         domMnemonicModalContent: document.getElementById(
             'ModalMnemonicContent'
         ),
@@ -495,6 +501,37 @@ export async function updateStakingRewardsGUI() {
     // UpdateDOMS.DOM
     doms.domStakingRewardsTitle.innerHTML = `Staking Rewards: ≥${nRewards} ${cChainParams.current.TICKER}`;
     doms.domStakingRewardsList.innerHTML = strList;
+}
+
+export async function updateMasternodeRewardsGUI() {
+    const network = getNetwork();
+    const masternodeRewards = await network.getMasternodeRewards();
+    if (network.areRewardsComplete) {
+        // Hide the load more button
+        doms.domGuiMasternodeLoadMore.style.display = 'none';
+    }
+
+    //DOMS.DOM-optimised list generation
+    const strList = masternodeRewards
+        .map(
+            (cReward) =>
+                `<i style="opacity: 0.75; cursor: pointer" onclick="window.open('${
+                    cExplorer.url + '/tx/' + cReward.id
+                }', '_blank')">${new Date(
+                    cReward.time * 1000
+                ).toLocaleDateString()}</i> <b>+${cReward.amount} ${
+                    cChainParams.current.TICKER
+                }</b>`
+        )
+        .join('<br>');
+    // Calculate total
+    const nRewards = masternodeRewards.reduce(
+        (total, reward) => total + reward.amount,
+        0
+    );
+    // UpdateDOMS.DOM
+    doms.domMasternodeRewardsTitle.innerHTML = `Masternode Rewards: ≥${nRewards} ${cChainParams.current.TICKER}`;
+    doms.domMasternodeRewardsList.innerHTML = strList;
 }
 
 /**

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -68,6 +68,7 @@ export function start() {
         domGuiBalanceBoxStaking: document.getElementById(
             'guiBalanceBoxStaking'
         ),
+        domGuiMasternodeLoadMore: document.getElementById('masternodeLoadMore'),
         domGuiDelegateAmount: document.getElementById('delegateAmount'),
         domGuiUndelegateAmount: document.getElementById('undelegateAmount'),
         domStakeTab: document.getElementById('stakeTab'),
@@ -125,6 +126,7 @@ export function start() {
         domMnNetType: document.getElementById('mnNetType'),
         domMnNetIP: document.getElementById('mnNetIP'),
         domMnLastSeen: document.getElementById('mnLastSeen'),
+        domMnLastPaid: document.getElementById('mnLastPaid'),
 
         domAccessWallet: document.getElementById('accessWallet'),
         domImportWallet: document.getElementById('importWallet'),
@@ -512,7 +514,7 @@ export async function updateStakingRewardsGUI() {
 export async function updateMasternodeRewardsGUI() {
     const network = getNetwork();
     const masternodeRewards = await network.getMasternodeRewards();
-    if (network.areRewardsComplete) {
+    if (network.areRewardsMasternodeComplete) {
         // Hide the load more button
         doms.domGuiMasternodeLoadMore.style.display = 'none';
     }
@@ -535,9 +537,12 @@ export async function updateMasternodeRewardsGUI() {
         (total, reward) => total + reward.amount,
         0
     );
-    // UpdateDOMS.DOM
-    doms.domMasternodeRewardsTitle.innerHTML = `Masternode Rewards: ≥${nRewards} ${cChainParams.current.TICKER}`;
-    doms.domMasternodeRewardsList.innerHTML = strList;
+    if(nRewards.length != 0) {
+        // UpdateDOMS.DOM
+        doms.domMasternodeRewardsTitle.style.cssText = 'background-color:#2c0044;border-radius:10px;margin-top:1rem;margin-bottom:0.75rem;padding:5px;font-size:22px;font-weight:500;line-height:1.2;font-family:Montserrat,sans-serif!important;';
+        doms.domMasternodeRewardsTitle.innerHTML = `Masternode Rewards: ≥ ${nRewards} ${cChainParams.current.TICKER}`;
+        doms.domMasternodeRewardsList.innerHTML = strList;
+    }
 }
 
 /**
@@ -1568,6 +1573,7 @@ export async function updateMasternodeTab() {
 
 async function refreshMasternodeData(cMasternode, fAlert = false) {
     const cMasternodeData = await cMasternode.getFullData();
+    const cMasternodeReward = await cMasternode.getNextMasternodePaymentInMinutes();
     if (debug) console.log(cMasternodeData);
 
     // If we have MN data available, update the dashboard
@@ -1584,6 +1590,14 @@ async function refreshMasternodeData(cMasternode, fAlert = false) {
         doms.domMnLastSeen.innerText = new Date(
             cMasternodeData.lastseen * 1000
         ).toLocaleTimeString();
+
+        if (cMasternodeReward > 30) {
+            doms.domMnLastPaid.innerText = "~" + cMasternodeReward + " blocks";
+        } else if (cMasternodeReward == 0) {
+            doms.domMnLastPaid.innerText = "Not yet paid";
+        } else {
+            doms.domMnLastPaid.innerText = "Coming soon";
+        }
     }
 
     if (cMasternodeData.status === 'MISSING') {

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -513,15 +513,16 @@ export async function updateStakingRewardsGUI() {
 
 export async function updateMasternodeRewardsGUI() {
     const network = getNetwork();
-    const masternodeRewards = await network.getMasternodeRewards();
+    const arrMasternodeRewards = await network.getMasternodeRewards();
+
     if (network.areRewardsMasternodeComplete) {
         // Hide the load more button
         doms.domGuiMasternodeLoadMore.style.display = 'none';
     }
 
     //DOMS.DOM-optimised list generation
-    const strList = masternodeRewards
-        .map(
+    const strList = arrMasternodeRewards
+       .map(
             (cReward) =>
                 `<i style="opacity: 0.75; cursor: pointer" onclick="window.open('${
                     cExplorer.url + '/tx/' + cReward.id
@@ -533,7 +534,7 @@ export async function updateMasternodeRewardsGUI() {
         )
         .join('<br>');
     // Calculate total
-    const nRewards = masternodeRewards.reduce(
+    const nRewards = arrMasternodeRewards.reduce(
         (total, reward) => total + reward.amount,
         0
     );

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -40,6 +40,7 @@ export {
     toggleBottomMenu,
     createProposal,
     updateStakingRewardsGUI,
+    updateMasternodeRewardsGUI,
 } from './global.js';
 export { generateWallet, getNewAddress, importWallet } from './wallet.js';
 export { toggleTestnet, toggleDebug } from './settings.js';

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -4,6 +4,7 @@ import { createAlert } from './misc.js';
 import { Mempool, UTXO } from './mempool.js';
 import { getEventEmitter } from './event_bus.js';
 import { STATS, cStatKeys, cAnalyticsLevel } from './settings.js';
+import { Masternode, getFullData } from './masternode.js';
 
 /**
  * Virtual class rapresenting any network backend
@@ -19,6 +20,7 @@ export class Network {
 
         this.lastWallet = 0;
         this.areRewardsComplete = false;
+        this.areRewardsMasternodeComplete = false;
     }
 
     /**
@@ -103,7 +105,9 @@ export class ExplorerNetwork extends Network {
         this.blocks = 0;
 
         this.arrRewards = [];
+        this.masternodeRewards = [];
         this.rewardsSyncing = false;
+        this.rewardsMasternodeSyncing = false;
     }
 
     error() {
@@ -336,6 +340,88 @@ export class ExplorerNetwork extends Network {
             console.error(e);
         } finally {
             this.rewardsSyncing = false;
+        }
+    }
+
+    /**
+     * Fetches Masternode Rewards per Local Storage
+     * @returns Filtered array of Masternode rewards
+     */
+    async getMasternodeRewards() {
+        const cMasternode = new Masternode(
+            JSON.parse(localStorage.getItem('masternode'))
+        );
+        const cMasternodeData = await cMasternode.getFullData();
+        if (this.rewardsMasternodeSyncing) {
+            return this.masternodeRewards;
+        }
+        try {
+            if (!this.enabled || this.areRewardsMasternodeComplete)
+                return this.masternodeRewards;
+            this.rewardsMasternodeSyncing = true;
+            const nHeight = this.masternodeRewards.length
+                ? this.masternodeRewards[this.masternodeRewards.length - 1].blockHeight
+                : 0;
+            const mapPaths = new Map();
+            const txSum = (v) =>
+                v.reduce(
+                    (t, s) =>
+                        t +
+                        (s.addresses
+                            .map((strAddr) => mapPaths.get(strAddr))
+                            .filter((v) => v).length && s.addresses.length === 2
+                            ? parseInt(s.value)
+                            : 0),
+                    0
+                );
+            let cData;
+            cData = await (
+                await fetch(
+                    `${
+                        this.strUrl
+                    }/api/v2/xpub/${cMasternodeData.addr}?details=txs&pageSize=500&to=${
+                        nHeight ? nHeight - 1 : 0
+                    }`
+                )
+            ).json();
+            cData = await (
+                await fetch(
+                    `${
+                        this.strUrl
+                    }/api/v2/address/${cMasternodeData.addr}?details=txs&pageSize=500&to=${
+                        nHeight ? nHeight - 1 : 0
+                    }`
+                )
+            ).json();
+            mapPaths.set(cMasternodeData.addr, ':)');
+        if (cData && cData.transactions) {
+            // Update rewards
+            this.masternodeRewards = this.masternodeRewards.concat(
+                cData.transactions
+                    .filter(
+                        (tx) => tx.vout[0].addresses[0] === 'CoinStake TX'
+                    )
+                    .map((tx) => {
+                        return {
+                            id: tx.txid,
+                            time: tx.blockTime,
+                            blockHeight: tx.blockHeight,
+                            amount: txSum(tx.vout.slice(-1)) / COIN,
+                        };
+                    })
+                    .filter((tx) => tx.amount != 0)
+                );
+
+                // If the results don't match the full 'max/requested results', then we know the rewards are complete
+                if (cData.transactions.length !== cData.itemsOnPage) {
+                    this.areMasternodeRewardsComplete = true;
+                }
+            }
+            return this.masternodeRewards;
+        } catch (e) {
+            console.error(e);
+        } finally {
+            this.rewardsMasternodeSyncing = false;
         }
     }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -3,6 +3,7 @@ import {
     getBalance,
     getStakingBalance,
     updateStakingRewardsGUI,
+    updateMasternodeRewardsGUI,
 } from './global.js';
 import { fWalletLoaded, masterKey } from './wallet.js';
 import { cChainParams } from './chain_params.js';
@@ -321,6 +322,7 @@ export function toggleTestnet() {
     getBalance(true);
     getStakingBalance(true);
     updateStakingRewardsGUI();
+    updateMasternodeRewardsGUI();
 }
 
 export function toggleDebug() {


### PR DESCRIPTION
Redo of #97 

I had issues with rebasing so took a slow period to bring it in line with other changes between review.

## Abstract

This PR is the start of adding a "Last Paid" section for the Masternode tab. It will also attempt to calculate when the next incoming reward is for the user. Math is fairly straightforward as we calculate the MN count and convert the last paid into minutes vs the next amount of time it should be rewarded. There is a masternode reward list which is mainly a clone of the staking list with changes that should read the masternode reward output. This understandably can still be broken, but have been struggling to test with masternodes to open this further to the group to get it moving forward.

## What does this PR address?
This PR helps users get more information about their masternode in the Masternode tab. Alongside this takes care of 2/3 from Issue #61 https://github.com/PIVX-Labs/MyPIVXWallet/issues/61

## What features or improvements were added?
Users now have their last paid time calculated and can get a roundabout time frame for the next payment.

## How does this benefit users?
More data == more power baby!
We need users to be empowered to have the information everyone feels they need inside MPW.