### PR TITLE
Handle exceptions

### DIFF
--- a/scripts/charting.js
+++ b/scripts/charting.js
@@ -118,8 +118,8 @@ export async function generateWalletBreakdown(arrBreakdown) {
                     labels: {
                         color: '#FFFFFF',
                         font: {
-                            size: 16
-                        }
+                            size: 16,
+                        },
                     },
                 },
             },

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1732,7 +1732,7 @@ export const beforeUnloadListener = (evt) => {
 };
 
 function errorHandler(e) {
-    const message = `Unhandled exception. ${e.message || e.reason}`;
+    const message = `Unhandled exception. <br> ${sanitizeHTML(e.message || e.reason)}`;
     try {
         createAlert('warning', message);
     } catch (_) {

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1730,3 +1730,18 @@ export const beforeUnloadListener = (evt) => {
     // Most browsers ignore this nowadays, but still, keep it 'just incase'
     return (evt.returnValue = translation.BACKUP_OR_ENCRYPT_WALLET);
 };
+
+function errorHandler(e) {
+    const message = `Unhandled exception. ${e.message || e.reason}`;
+    console.log(e);
+    try {
+        createAlert('warning', message);
+    } catch (_) {
+        // Something as gone wrong, so we fall back to the default alert
+        // This can happen on early errors for example
+        alert(message);
+    }
+}
+
+window.addEventListener('error', errorHandler);
+window.addEventListener('unhandledrejection', errorHandler);

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1733,7 +1733,6 @@ export const beforeUnloadListener = (evt) => {
 
 function errorHandler(e) {
     const message = `Unhandled exception. ${e.message || e.reason}`;
-    console.log(e);
     try {
         createAlert('warning', message);
     } catch (_) {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -498,7 +498,7 @@ export async function importWallet({
     fSavePublicKey = false,
 } = {}) {
     const strImportConfirm =
-        "Do you really want to import a new address? If you haven't saved the last private key, the wallet will be LOST forever.";
+          "Do you really want to import a new address? If you haven't saved the last private key, the wallet will be LOST forever.";
     const walletConfirm =
         fWalletLoaded && !skipConfirmation
             ? await confirmPopup({ html: strImportConfirm })


### PR DESCRIPTION
## Abstract

Handle all exceptions by showing an alert.
This is useful for less tech savvy users, or for phones that don't have a proper dev console
<!--- Add any useful and detailed information for other Labs developers and reviewers to consume, this will help get your PR merged faster, as we won't need to reverse-engineer the changes as much.
--->

## Testing

Throw an early exception (Before createAlert has been properly initialized) inside or outside a promise.
Test that a raw alert is shown.
Throw a late exception (For example when importing the wallet), test that an MPW alert is shown
