### PR TITLE
Fix CoinGecko spam (finally)

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -307,8 +307,9 @@ export function start() {
 
         const publicKey = localStorage.getItem('publicKey');
 
+        // Import the wallet, and toggle the startup flag, which delegates the chain data refresh to settingsStart();
         if (publicKey) {
-            importWallet({ newWif: publicKey });
+            importWallet({ newWif: publicKey, fStartup: true });
         } else {
             // Display the password unlock upfront
             accessOrImportWallet();
@@ -339,9 +340,6 @@ export function start() {
         // Fetch the PIVX prices
         refreshPriceDisplay();
     }, 15000);
-
-    // Initial price fetch
-    refreshPriceDisplay();
 
     // After reaching here; we know MPW's base is fully loaded!
     fIsLoaded = true;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -103,7 +103,7 @@ export function start() {
 
     // Fetch price data, then fetch chain data
     if (getNetwork().enabled) {
-        refreshPriceDisplay().then(refreshChainData);
+        refreshPriceDisplay().finally(refreshChainData);
     }
 
     // Add each analytics level into the UI selector

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -2,6 +2,7 @@ import {
     doms,
     getBalance,
     getStakingBalance,
+    refreshChainData,
     updateStakingRewardsGUI,
 } from './global.js';
 import { fWalletLoaded, masterKey } from './wallet.js';
@@ -14,7 +15,7 @@ import {
     translation,
     arrActiveLangs,
 } from './i18n.js';
-import { CoinGecko } from './prices.js';
+import { CoinGecko, refreshPriceDisplay } from './prices.js';
 
 // --- Default Settings
 /** A mode that emits verbose console info for internal MPW operations */
@@ -100,9 +101,9 @@ export function start() {
     fillNodeSelect();
     fillTranslationSelect();
 
-    // Fill all selection UIs with their options
+    // Fetch price data, then fetch chain data
     if (getNetwork().enabled) {
-        fillCurrencySelect();
+        refreshPriceDisplay().then(refreshChainData);
     }
 
     // Add each analytics level into the UI selector

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -488,6 +488,7 @@ export function deriveAddress({ pkBytes, publicKey, output = 'ENCODED' }) {
  * @param {boolean} options.isHardwareWallet - Whether the import is from a Hardware wallet or not
  * @param {boolean} options.skipConfirmation - Whether to skip the import UI confirmation or not
  * @param {boolean} options.fSavePublicKey - Whether to save the derived public key to disk (for View Only mode)
+ * @param {boolean} options.fStartup - Whether the import is at Startup or at Runtime
  * @returns {Promise<void>}
  */
 export async function importWallet({
@@ -496,6 +497,7 @@ export async function importWallet({
     isHardwareWallet = false,
     skipConfirmation = false,
     fSavePublicKey = false,
+    fStartup = false,
 } = {}) {
     const strImportConfirm =
         "Do you really want to import a new address? If you haven't saved the last private key, the wallet will be LOST forever.";
@@ -656,8 +658,8 @@ export async function importWallet({
             }
         }
 
-        // Fetch state from explorer
-        if (getNetwork().enabled) refreshChainData();
+        // Fetch state from explorer, if this import was post-startup
+        if (getNetwork().enabled && !fStartup) refreshChainData();
 
         // Hide all wallet starter options
         hideAllWalletOptions();


### PR DESCRIPTION
## Abstract

There were some redundant calls towards the CoinGecko API at startup (Both `global.js start()` and `settings.js start()` were fetching prices at startup, that was fixed).

Additionally, a race condition was possible where if CoinGecko did NOT sync prices prior to your UTXOs, then each UTXO would individually call CoinGecko due to cache not being fulfilled.

Now, the startup is guaranteed to only call once, and then the UTXOs syncs afterwards - if CoinGecko fails, UTXOs will continue to sync as normal.