### PR TITLE
Fix stake reward error when shield txs

### DIFF
--- a/scripts/network.js
+++ b/scripts/network.js
@@ -314,7 +314,7 @@ export class ExplorerNetwork extends Network {
                 this.arrRewards = this.arrRewards.concat(
                     cData.transactions
                         .filter(
-                            (tx) => tx.vout[0].addresses[0] === 'CoinStake TX'
+                            (tx) => tx?.vout[0]?.addresses[0] === 'CoinStake TX'
                         )
                         .map((tx) => {
                             return {


### PR DESCRIPTION
## Abstract

Shield txs don't have vouts.
Test address: `xpub6CVzXM7bjMc5nmFs8HbeMreCh6STspbunZ8UJ5RXPGfpsMyyXWeVRHhth7JsCZ5P4CUkzeSeYi75aLjYEgG14NBP6uwRQxVMDxo6e9dkeoU` (mainnet)
Go to stake page => MPW doesn't throw an exception
