### PR TITLE
Add Explorer auto-switch (fallback mechanism)

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -1182,6 +1182,13 @@
 
                       <br />
 
+                      <div class="custom-control custom-switch" style="margin-bottom:15px;">
+                        <input type="checkbox" class="custom-control-input" id="autoSwitchToggler" onclick="MPW.toggleAutoSwitch()">
+                        <label class="custom-control-label" for="autoSwitchToggler">Auto-select Explorers and Nodes</label>
+                      </div>
+
+                      <br />
+
                       <label for="analytics" data-i18n="settingsAnalytics">Choose your analytics contribution level:</label>
                       <br />
                       <select id="analytics" class="form-control" name="analytics">

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -261,6 +261,7 @@ export async function start() {
         domCurrencySelect: document.getElementById('currency'),
         domExplorerSelect: document.getElementById('explorer'),
         domNodeSelect: document.getElementById('node'),
+        domAutoSwitchToggle: document.getElementById('autoSwitchToggler'),
         domTranslationSelect: document.getElementById('translation'),
         domBlackBack: document.getElementById('blackBack'),
         domWalletSettings: document.getElementById('settingsWallet'),
@@ -423,7 +424,9 @@ function subscribeToNetworkEvents() {
             // If allowed by settings: submit a simple 'tx' ping to Labs Analytics
             getNetwork().submitAnalytics('transaction');
         } else {
-            createAlert('warning', 'Transaction Failed!', 1250);
+            console.error('Error sending transaction:');
+            console.error(result);
+            createAlert('warning', 'Transaction Failed!', 2500);
         }
     });
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -45,7 +45,7 @@ export {
     updateActivityGUI,
 } from './global.js';
 export { generateWallet, getNewAddress, importWallet } from './wallet.js';
-export { toggleTestnet, toggleDebug } from './settings.js';
+export { toggleTestnet, toggleDebug, toggleAutoSwitch } from './settings.js';
 export {
     createTxGUI,
     undelegateGUI,

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -3,7 +3,7 @@ import { cChainParams, COIN } from './chain_params.js';
 import { createAlert } from './misc.js';
 import { Mempool, UTXO } from './mempool.js';
 import { getEventEmitter } from './event_bus.js';
-import { STATS, cStatKeys, cAnalyticsLevel } from './settings.js';
+import { STATS, cStatKeys, cAnalyticsLevel, setExplorer, fAutoSwitch } from './settings.js';
 
 /**
  * A historical transaction type.
@@ -178,7 +178,7 @@ export class ExplorerNetwork extends Network {
         try {
             getEventEmitter().emit('sync-status', 'start');
             const { backend } = await (
-                await fetch(`${this.strUrl}/api/v2/api`)
+                await retryWrapper(fetchBlockbook, `/api/v2/api`)
             ).json();
             if (backend.blocks > this.blocks) {
                 console.log(
@@ -238,7 +238,7 @@ export class ExplorerNetwork extends Network {
 
             // Fetch UTXOs for the key
             const arrUTXOs = await (
-                await fetch(`${this.strUrl}/api/v2/utxo/${publicKey}`)
+                await retryWrapper(fetchBlockbook, `/api/v2/utxo/${publicKey}`)
             ).json();
 
             // If using MPW's wallet, then sync the UTXOs in MPW's state
@@ -260,7 +260,10 @@ export class ExplorerNetwork extends Network {
      */
     async getUTXOFullInfo(cUTXO) {
         const cTx = await (
-            await fetch(`${this.strUrl}/api/v2/tx-specific/${cUTXO.txid}`)
+            await retryWrapper(
+                fetchBlockbook,
+                `/api/v2/tx-specific/${cUTXO.txid}`
+            )
         ).json();
         const cVout = cTx.vout[cUTXO.vout];
 
@@ -299,23 +302,21 @@ export class ExplorerNetwork extends Network {
     async sendTransaction(hex) {
         try {
             const data = await (
-                await fetch(this.strUrl + '/api/v2/sendtx/', {
+                await retryWrapper(fetchBlockbook, '/api/v2/sendtx/', {
                     method: 'post',
                     body: hex,
                 })
             ).json();
-            if (data.result && data.result.length === 64) {
-                console.log('Transaction sent! ' + data.result);
-                getEventEmitter().emit('transaction-sent', true, data.result);
-                return data.result;
-            } else {
-                console.log('Error sending transaction: ' + data.result);
-                getEventEmitter().emit('transaction-sent', false, data.error);
-                return false;
-            }
+
+            // Throw and catch if the data is not a TXID
+            if (!data.result || data.result.length !== 64) throw data;
+
+            console.log('Transaction sent! ' + data.result);
+            getEventEmitter().emit('transaction-sent', true, data.result);
+            return data.result;
         } catch (e) {
-            console.error(e);
-            this.error();
+            getEventEmitter().emit('transaction-sent', false, e);
+            return false;
         }
     }
 
@@ -349,13 +350,16 @@ export class ExplorerNetwork extends Network {
                 : await this.masterKey.getAddress();
             const strRoot = `/api/v2/${fHD ? 'xpub/' : 'address/'}${strKey}`;
             const strCoreParams = `?details=txs&tokens=derived&pageSize=200`;
-            const strAPI = this.strUrl + strRoot + strCoreParams;
+            const strAPI = strRoot + strCoreParams;
 
             // If we have a known block height, check for incoming transactions within the last 60 blocks
             const cRecentTXs =
                 this.blocks > 0
                     ? await (
-                          await fetch(`${strAPI}&from=${this.blocks - 60}`)
+                          await retryWrapper(
+                              fetchBlockbook,
+                              `${strAPI}&from=${this.blocks - 60}`
+                          )
                       ).json()
                     : {};
 
@@ -363,7 +367,8 @@ export class ExplorerNetwork extends Network {
             const cData =
                 !fNewOnly && !this.isHistorySynced
                     ? await (
-                          await fetch(
+                          await retryWrapper(
+                              fetchBlockbook,
                               `${strAPI}&to=${nHeight ? nHeight - 1 : 0}`
                           )
                       ).json()
@@ -551,7 +556,7 @@ export class ExplorerNetwork extends Network {
     }
 
     async getTxInfo(txHash) {
-        const req = await fetch(`${this.strUrl}/api/v2/tx/${txHash}`);
+        const req = await retryWrapper(fetchBlockbook, `/api/v2/tx/${txHash}`);
         return await req.json();
     }
 
@@ -600,4 +605,67 @@ export function setNetwork(network) {
  */
 export function getNetwork() {
     return _network;
+}
+
+/**
+ * A Fetch wrapper which uses the current Blockbook Network's base URL
+ * @param {string} api - The specific Blockbook api to call
+ * @param {RequestInit} options - The Fetch options
+ * @returns {Promise<Response>} - The unresolved Fetch promise
+ */
+export function fetchBlockbook(api, options) {
+    if (_network.strUrl === 'https://explorer.duddino.com') throw new Error('Fake error for testing, heh');
+    return fetch(_network.strUrl + api, options);
+}
+
+/**
+ * A wrapper for Blockbook calls which can, in the event of an unresponsive explorer, 
+ * seamlessly attempt the same call on multiple other explorers until success.
+ * @param {Function} func - The function to re-attempt with
+ * @param  {...any} args - The arguments to pass to the function
+ */
+async function retryWrapper(func, ...args) {
+    // Track internal errors from the wrapper
+    let err;
+
+    // If allowed by the user, Max Tries is ALL MPW-supported explorers, otherwise, restrict to only the current one.
+    let nMaxTries = cChainParams.current.Explorers.length;
+    let retries = 0;
+
+    // The explorer index we started at
+    let nIndex = cChainParams.current.Explorers.findIndex(
+        (a) => a.url === getNetwork().strUrl
+    );
+
+    // Run the call until successful, or all attempts exhausted
+    while (retries < nMaxTries) {
+        try {
+            // Call the passed function with the arguments
+            const res = await func(...args);
+
+            // If the endpoint is non-OK, assume it's an error
+            if (!res.ok) throw res;
+
+            // Return the result if successful
+            return res;
+        } catch (error) {
+            err = error;
+
+            // If allowed, switch explorers
+            if (!fAutoSwitch) throw err;
+            nIndex = (nIndex + 1) % cChainParams.current.Explorers.length;
+            const cNewExplorer = cChainParams.current.Explorers[nIndex];
+
+            // Set the explorer at Network-class level, then as a hacky workaround for the current callback; we
+            // ... adjust the internal URL to the new explorer.
+            getNetwork().strUrl = cNewExplorer.url;
+            setExplorer(cNewExplorer, true);
+
+            // Bump the attempts, and re-try next loop
+            retries++;
+        }
+    }
+
+    // Throw an error so the calling code knows the operation failed
+    throw err;
 }

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -614,7 +614,6 @@ export function getNetwork() {
  * @returns {Promise<Response>} - The unresolved Fetch promise
  */
 export function fetchBlockbook(api, options) {
-    if (_network.strUrl === 'https://explorer.duddino.com') throw new Error('Fake error for testing, heh');
     return fetch(_network.strUrl + api, options);
 }
 

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -3,7 +3,13 @@ import { cChainParams, COIN } from './chain_params.js';
 import { createAlert } from './misc.js';
 import { Mempool, UTXO } from './mempool.js';
 import { getEventEmitter } from './event_bus.js';
-import { STATS, cStatKeys, cAnalyticsLevel, setExplorer, fAutoSwitch } from './settings.js';
+import {
+    STATS,
+    cStatKeys,
+    cAnalyticsLevel,
+    setExplorer,
+    fAutoSwitch,
+} from './settings.js';
 
 /**
  * A historical transaction type.
@@ -618,7 +624,7 @@ export function fetchBlockbook(api, options) {
 }
 
 /**
- * A wrapper for Blockbook calls which can, in the event of an unresponsive explorer, 
+ * A wrapper for Blockbook calls which can, in the event of an unresponsive explorer,
  * seamlessly attempt the same call on multiple other explorers until success.
  * @param {Function} func - The function to re-attempt with
  * @param  {...any} args - The arguments to pass to the function

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -35,6 +35,8 @@ export let cMarket = new CoinGecko();
 export let cExplorer = cChainParams.current.Explorers[0];
 /** The user-selected MPW node, used for alternative blockchain data */
 export let cNode = cChainParams.current.Nodes[0];
+/** A mode which allows MPW to automatically select it's data sources */
+export let fAutoSwitch = true;
 
 let transparencyReport;
 
@@ -52,6 +54,10 @@ export class Settings {
      */
     node;
     /**
+     * @type {Boolean} The Auto-Switch mode state
+     */
+    autoswitch;
+    /**
      * @type {String} translation to use
      */
     translation;
@@ -63,12 +69,14 @@ export class Settings {
         analytics,
         explorer,
         node,
+        autoswitch = true,
         translation = 'en',
         displayCurrency = 'usd',
     } = {}) {
         this.analytics = analytics;
         this.explorer = explorer;
         this.node = node;
+        this.autoswitch = autoswitch;
         this.translation = translation;
         this.displayCurrency = displayCurrency;
     }
@@ -155,8 +163,13 @@ export async function start() {
     }
 
     const database = await Database.getInstance();
+
     // Fetch settings from Database
-    const { analytics: strSettingAnalytics } = await database.getSettings();
+    const { analytics: strSettingAnalytics, autoswitch } = await database.getSettings();
+
+    // Set any Toggles to their default or DB state
+    fAutoSwitch = autoswitch;
+    doms.domAutoSwitchToggle.checked = fAutoSwitch;
 
     // Apply translations to the transparency report
     STATS = {
@@ -202,7 +215,7 @@ export async function start() {
     domAnalyticsSelect.value = cAnalyticsLevel.name;
 }
 // --- Settings Functions
-async function setExplorer(explorer, fSilent = false) {
+export async function setExplorer(explorer, fSilent = false) {
     const database = await Database.getInstance();
     database.setSettings({ explorer: explorer.url });
     cExplorer = explorer;
@@ -210,6 +223,9 @@ async function setExplorer(explorer, fSilent = false) {
     // Enable networking + notify if allowed
     const network = new ExplorerNetwork(cExplorer.url, masterKey);
     setNetwork(network);
+
+    // Update the selector UI
+    doms.domExplorerSelect.value = cExplorer.url;
 
     if (!fSilent)
         createAlert(
@@ -371,6 +387,17 @@ export function toggleTestnet() {
 export function toggleDebug() {
     debug = !debug;
     doms.domDebug.style.display = debug ? '' : 'none';
+}
+
+/**
+ * Toggle the Auto-Switch mode at runtime and in DB
+ */
+export async function toggleAutoSwitch() {
+    fAutoSwitch = !fAutoSwitch;
+
+    // Update the setting in the DB
+    const database = await Database.getInstance();
+    await database.setSettings({ autoswitch: fAutoSwitch });
 }
 
 async function fillExplorerSelect() {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -165,7 +165,8 @@ export async function start() {
     const database = await Database.getInstance();
 
     // Fetch settings from Database
-    const { analytics: strSettingAnalytics, autoswitch } = await database.getSettings();
+    const { analytics: strSettingAnalytics, autoswitch } =
+        await database.getSettings();
 
     // Set any Toggles to their default or DB state
     fAutoSwitch = autoswitch;


### PR DESCRIPTION
## Abstract

This PR adds a well-needed enhancement for MPW's stability and UX; it's now capable of automatically switching between Explorers when issues occur with the current (either default, or user-set) explorer.

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/8200041e-0dfd-40d8-8911-22afbdddc3b7)

This system effectively is a seamless fallback, it's completely silent, continuing requests in the background even if one (or multiple) explorers fail, as long as one explorer works, MPW will always work.

Auto-Switch is **enabled** by default, but for the privacy-conscious who prefer to remain to a single explorer, to avoid leaking `xpubs` and balance information; the mechanic can be completely disabled via the Settings; where if an error occurs, MPW will just immediately drop in to Offline mode until the user requests otherwise.

### Note
It is known that there are some 'hacky' workarounds involved, primarily due to the structure of MPW's net code (i.e: hot-swapping Network URLs halfway through requests), however, I believe that revamping the net code in this PR would be beyond scope, and additionally; this is a safe workaround only **until** non-Blockbook explorers are integrated, which is unlikely in the near future.

The feature, as-is, is currently more valuable for MPW than without, given if our default explorer goes down, many users immediately conclude that MPW is broken, not fun and not good for marketing!