### PR TITLE
Add Cold Staking customisation UI

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -893,6 +893,12 @@
                               <span class="reload noselect" onclick="MPW.refreshChainData()"><i id="balanceReloadStaking" class="fa-solid fa-rotate-right cur-pointer"></i></span>
                             </h3>
                           </div>
+
+                          <div class="col-6 d-flex dcWallet-topRightMenu" style="justify-content: flex-end;">
+                            <div class="btn-group dropleft">
+                              <i class="fa-solid fa-gear" style="width: 20px;" onclick="MPW.guiSetColdStakingAddress()"></i>
+                            </div>
+                          </div>
                         </div>
 
                         Staking<br>

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -20,7 +20,7 @@ import {
     cMarket,
     strCurrency,
     setColdStakingAddress,
-    cachedColdStakeAddr,
+    strColdStakingAddress,
 } from './settings.js';
 import { createAndSendTransaction, signTransaction } from './transactions.js';
 import {
@@ -1653,7 +1653,7 @@ export async function guiSetColdStakingAddress() {
     if (
         await confirmPopup({
             title: 'Set your Cold Staking address',
-            html: `<p>Current address:<br><span class="mono">${cachedColdStakeAddr}</span><br><br><span style="opacity: 0.65; margin: 10px;">A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!</span></p><br><input type="text" id="newColdAddress" placeholder="Example: ${cachedColdStakeAddr.substring(
+            html: `<p>Current address:<br><span class="mono">${strColdStakingAddress}</span><br><br><span style="opacity: 0.65; margin: 10px;">A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!</span></p><br><input type="text" id="newColdAddress" placeholder="Example: ${strColdStakingAddress.substring(
                 0,
                 6
             )}..." style="text-align: center;">`,

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -19,6 +19,8 @@ import {
     debug,
     cMarket,
     strCurrency,
+    setColdStakingAddress,
+    cachedColdStakeAddr,
 } from './settings.js';
 import { createAndSendTransaction, signTransaction } from './transactions.js';
 import {
@@ -433,9 +435,6 @@ function subscribeToNetworkEvents() {
 // WALLET STATE DATA
 export const mempool = new Mempool();
 let exportHidden = false;
-
-//                        PIVX Labs' Cold Pool
-export let cachedColdStakeAddr = 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy';
 
 /**
  * Open a UI 'tab' menu, and close all other tabs, intended for frontend use
@@ -1638,23 +1637,51 @@ export function toggleDropDown(id) {
     domID.style.display = domID.style.display === 'block' ? 'none' : 'block';
 }
 
-export function askForCSAddr(force = false) {
-    if (force) cachedColdStakeAddr = null;
-    if (cachedColdStakeAddr === '' || cachedColdStakeAddr === null) {
-        cachedColdStakeAddr = prompt(
-            'Please provide a Cold Staking address (either from your own node, or a 3rd-party!)'
-        ).trim();
-        if (cachedColdStakeAddr) return true;
-    } else {
-        return true;
-    }
-    return false;
-}
-
 export function isMasternodeUTXO(cUTXO, cMasternode) {
     if (cMasternode?.collateralTxId) {
         const { collateralTxId, outidx } = cMasternode;
         return collateralTxId === cUTXO.id && cUTXO.vout === outidx;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * Creates a GUI popup for the user to check or customise their Cold Address
+ */
+export async function guiSetColdStakingAddress() {
+    if (
+        await confirmPopup({
+            title: 'Set your Cold Staking address',
+            html: `<p>Current address:<br><span class="mono">${cachedColdStakeAddr}</span><br><br><span style="opacity: 0.65; margin: 10px;">A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!</span></p><br><input type="text" id="newColdAddress" placeholder="Example: ${cachedColdStakeAddr.substring(
+                0,
+                6
+            )}..." style="text-align: center;">`,
+        })
+    ) {
+        // Fetch address from the popup input
+        const strColdAddress = document.getElementById('newColdAddress').value;
+
+        // If it's empty, just return false
+        if (!strColdAddress) return false;
+
+        // Sanity-check, and set!
+        if (
+            strColdAddress[0] === cChainParams.current.STAKING_PREFIX &&
+            strColdAddress.length === 34
+        ) {
+            await setColdStakingAddress(strColdAddress);
+            createAlert(
+                'info',
+                '<b>Cold Address set!</b><br>Future stakes will use this address.',
+                [],
+                5000
+            );
+            return true;
+        } else {
+            createAlert('warning', 'Invalid Cold Staking address!', [], 2500);
+            return false;
+        }
     } else {
         return false;
     }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -18,6 +18,7 @@ export {
     openTab,
     accessOrImportWallet,
     guiImportWallet,
+    guiSetColdStakingAddress,
     onPrivateKeyChanged,
     toClipboard,
     toggleExportUI,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -37,6 +37,8 @@ export let cExplorer = cChainParams.current.Explorers[0];
 export let cNode = cChainParams.current.Nodes[0];
 /** A mode which allows MPW to automatically select it's data sources */
 export let fAutoSwitch = true;
+/** The active Cold Staking address: default is the PIVX Labs address */
+export let cachedColdStakeAddr = 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy';
 
 let transparencyReport;
 
@@ -58,6 +60,10 @@ export class Settings {
      */
     autoswitch;
     /**
+     * @type {String} The user's active Cold Staking address
+     */
+    coldAddress;
+    /**
      * @type {String} translation to use
      */
     translation;
@@ -70,6 +76,7 @@ export class Settings {
         explorer,
         node,
         autoswitch = true,
+        coldAddress = cachedColdStakeAddr,
         translation = 'en',
         displayCurrency = 'usd',
     } = {}) {
@@ -77,6 +84,7 @@ export class Settings {
         this.explorer = explorer;
         this.node = node;
         this.autoswitch = autoswitch;
+        this.coldAddress = coldAddress;
         this.translation = translation;
         this.displayCurrency = displayCurrency;
     }
@@ -165,8 +173,14 @@ export async function start() {
     const database = await Database.getInstance();
 
     // Fetch settings from Database
-    const { analytics: strSettingAnalytics, autoswitch } =
-        await database.getSettings();
+    const {
+        analytics: strSettingAnalytics,
+        autoswitch,
+        coldAddress,
+    } = await database.getSettings();
+
+    // Set the Cold Staking address
+    cachedColdStakeAddr = coldAddress;
 
     // Set any Toggles to their default or DB state
     fAutoSwitch = autoswitch;
@@ -275,6 +289,16 @@ async function setCurrency(currency) {
     database.setSettings({ displayCurrency: strCurrency });
     // Update the UI to reflect the new currency
     getBalance(true);
+}
+
+/**
+ * Sets and saves the active Cold Staking address
+ * @param {string} strColdAddress - The Cold Staking address
+ */
+export async function setColdStakingAddress(strColdAddress) {
+    cachedColdStakeAddr = strColdAddress;
+    const database = await Database.getInstance();
+    database.setSettings({ coldAddress: strColdAddress });
 }
 
 /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -38,7 +38,7 @@ export let cNode = cChainParams.current.Nodes[0];
 /** A mode which allows MPW to automatically select it's data sources */
 export let fAutoSwitch = true;
 /** The active Cold Staking address: default is the PIVX Labs address */
-export let cachedColdStakeAddr = 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy';
+export let strColdStakingAddress = 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy';
 
 let transparencyReport;
 
@@ -76,7 +76,7 @@ export class Settings {
         explorer,
         node,
         autoswitch = true,
-        coldAddress = cachedColdStakeAddr,
+        coldAddress = strColdStakingAddress,
         translation = 'en',
         displayCurrency = 'usd',
     } = {}) {
@@ -180,7 +180,7 @@ export async function start() {
     } = await database.getSettings();
 
     // Set the Cold Staking address
-    cachedColdStakeAddr = coldAddress;
+    strColdStakingAddress = coldAddress;
 
     // Set any Toggles to their default or DB state
     fAutoSwitch = autoswitch;
@@ -296,7 +296,7 @@ async function setCurrency(currency) {
  * @param {string} strColdAddress - The Cold Staking address
  */
 export async function setColdStakingAddress(strColdAddress) {
-    cachedColdStakeAddr = strColdAddress;
+    strColdStakingAddress = strColdAddress;
     const database = await Database.getInstance();
     database.setSettings({ coldAddress: strColdAddress });
 }

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -1,5 +1,5 @@
 import bitjs from './bitTrx.js';
-import { debug, cachedColdStakeAddr } from './settings.js';
+import { debug, strColdStakingAddress } from './settings.js';
 import { ALERTS } from './i18n.js';
 import {
     doms,
@@ -148,8 +148,8 @@ export async function delegateGUI() {
 
     // Ensure the user has an address set - if not, request one!
     if (
-        (!cachedColdStakeAddr ||
-            cachedColdStakeAddr[0] !== cChainParams.current.STAKING_PREFIX) &&
+        (!strColdStakingAddress ||
+            strColdStakingAddress[0] !== cChainParams.current.STAKING_PREFIX) &&
         (await guiSetColdStakingAddress()) === false
     )
         return;
@@ -157,7 +157,7 @@ export async function delegateGUI() {
     // Perform the TX
     const cTxRes = await createAndSendTransaction({
         amount: nAmount,
-        address: cachedColdStakeAddr,
+        address: strColdStakingAddress,
         isDelegation: true,
         useDelegatedInputs: false,
     });
@@ -205,7 +205,7 @@ export async function undelegateGUI() {
         isDelegation: false,
         useDelegatedInputs: true,
         delegateChange: true,
-        changeDelegationAddress: cachedColdStakeAddr,
+        changeDelegationAddress: strColdStakingAddress,
     });
 
     if (!cTxRes.ok && cTxRes.err === 'No change addr') {

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -1,12 +1,11 @@
 import bitjs from './bitTrx.js';
-import { debug } from './settings.js';
+import { debug, cachedColdStakeAddr } from './settings.js';
 import { ALERTS } from './i18n.js';
 import {
     doms,
     getBalance,
     mempool,
     isMasternodeUTXO,
-    cachedColdStakeAddr,
     restoreWallet,
     toggleBottomMenu,
     guiSetColdStakingAddress,
@@ -285,7 +284,7 @@ export async function createAndSendTransaction({
     if (nChange > 0) {
         if (delegateChange && nChange > 1.01 * COIN) {
             if (!changeDelegationAddress)
-                return { ok: false, error: 'No change addr' };
+                return { ok: false, err: 'No change addr' };
             cTx.addcoldstakingoutput(
                 changeAddress,
                 changeDelegationAddress,


### PR DESCRIPTION
## Abstract

This PR finally allows MPW users to customise (with persistence) their Cold Staking delegation address: allowing users to delegate to places outside of the PIVX Labs built-in Cold Pool.

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/8662623a-29e6-4cac-802b-24637e25b031)

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/9f91dc0a-aea7-4a5a-acd6-f1c15faa6107)

The UI is sleek and simple, it also displays the currently-set Cold Staking address, explains the system a little bit, and then provides the input box to change the address to a preferred external address.