### PR TITLE
Add tor masternodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@noble/hashes": "^1.1.5",
         "@noble/secp256k1": "^1.7.0",
         "@popperjs/core": "^2.11.6",
+        "base32": "^0.0.7",
         "bech32": "^2.0.0",
         "biginteger": "^1.0.3",
         "bip39": "^3.0.4",
@@ -1281,6 +1282,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/base32": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/base32/-/base32-0.0.7.tgz",
+      "integrity": "sha512-ire9Jmh+BsUk4Idu0wu6aKeJJr/2j28Mlu0qqJBd1SyOGxW/VRotkfwAv3/KE/entVlNwCefs9bxi7kBeCIxTQ==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "base32": "bin/base32.js"
+      },
+      "engines": {
+        "node": ">0.10"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5106,6 +5121,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@noble/hashes": "^1.1.5",
     "@noble/secp256k1": "^1.7.0",
     "@popperjs/core": "^2.11.6",
+    "base32": "^0.0.7",
     "bech32": "^2.0.0",
     "biginteger": "^1.0.3",
     "bip39": "^3.0.4",

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1213,20 +1213,23 @@ export async function destroyMasternode() {
 
 /**
  * Takes an ip address and adds the port.
+ * If it's a tor address, ip.onion will be used (e.g. expyuzz4wqqyqhjn.onion)
  * If it's an IPv4 address, ip:port will be used, (e.g. 127.0.0.1:12345)
  * If it's an IPv6 address, [ip]:port will be used, (e.g. [::1]:12345)
  * @param {String} ip - Ip address with or without port
  * @returns {String}
  */
 function parseIpAddress(ip) {
-    // IPv4 without port
-    if (ip.match(/\d+\.\d+\.\d+\.\d+/)) {
+    // IPv4 or tor without port
+    if (ip.match(/\d+\.\d+\.\d+\.\d+/) || ip.match(/\w+\.onion/)) {
         return `${ip}:${cChainParams.current.MASTERNODE_PORT}`;
     }
-    // IPv4 with port
-    if (ip.match(/\d+\.\d+\.\d+\.\d+:\d+/)) {
+
+    // IPv4 or tor with port
+    if (ip.match(/\d+\.\d+\.\d+\.\d+:\d+/) || ip.match(/\w+\.onion:\d+/)) {
         return ip;
     }
+
     // IPv6 without port
     if (Address6.isValid(ip)) {
         return `[${ip}]:${cChainParams.current.MASTERNODE_PORT}`;

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1213,7 +1213,7 @@ export async function destroyMasternode() {
 
 /**
  * Takes an ip address and adds the port.
- * If it's a tor address, ip.onion will be used (e.g. expyuzz4wqqyqhjn.onion)
+ * If it's a tor address, ip.onion:port will be used (e.g. expyuzz4wqqyqhjn.onion:12345)
  * If it's an IPv4 address, ip:port will be used, (e.g. 127.0.0.1:12345)
  * If it's an IPv6 address, [ip]:port will be used, (e.g. [::1]:12345)
  * @param {String} ip - Ip address with or without port

--- a/scripts/masternode.js
+++ b/scripts/masternode.js
@@ -12,6 +12,7 @@ import { Address6 } from 'ip-address';
 import * as nobleSecp256k1 from '@noble/secp256k1';
 import { OP } from './script.js';
 import bs58 from 'bs58';
+import base32 from 'base32';
 
 /**
  * Construct a Masternode
@@ -74,15 +75,38 @@ export default class Masternode {
     }
 
     /**
-     * @param {String} ip
-     * @param {Number} port
+     * @param {string} ip
+     * @param {number} port
      * @returns {string} hex representation of the IP + port pair
      */
     static _decodeIpAddress(ip, port) {
-        const address = ip.includes('.')
-            ? Address6.fromAddress4(ip)
-            : new Address6(ip);
-        const bytes = address.toUnsignedByteArray();
+        /**
+         * @type {Array<Number>?}
+         */
+        let bytes;
+        if (ip.endsWith('.onion')) {
+            bytes = [
+                0xfd,
+                0x87,
+                0xd8,
+                0x7e,
+                0xeb,
+                0x43,
+                ...base32
+                    .decode(ip.slice(0, -6))
+                    .split('')
+                    .map((c) => c.charCodeAt(0)),
+            ];
+            console.log(bytes);
+            if (bytes.length !== 16) {
+                throw new Error('Invalid tor address');
+            }
+        } else {
+            const address = ip.includes('.')
+                ? Address6.fromAddress4(ip)
+                : new Address6(ip);
+            bytes = address.toUnsignedByteArray();
+        }
         const res =
             bytesToHex([...new Array(16 - bytes.length).fill(0), ...bytes]) +
             bytesToHex(Masternode._numToBytes(port, 2, false));

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -41,6 +41,9 @@ module.exports = {
         alias: {
             'bn.js': path.join(__dirname, 'node_modules/bn.js/lib/bn.js'),
         },
+        fallback: {
+            fs: false,
+        },
     },
     plugins: [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
## Abstract

Add TOR support to masternodes.
This should be the last "secondary" features of masternodes; after this and #143 are merged, MPW should have feature parity with PET4L.
