### PR TITLE
Improve Mnemonic + Password handling security

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1378,6 +1378,7 @@ export async function onPrivateKeyChanged() {
  * Imports a wallet using the GUI input, handling decryption via UI
  */
 export async function guiImportWallet() {
+    // Important: These fields will be wiped by importWallet();
     const strPrivKey = doms.domPrivKey.value;
     const strPassword = doms.domPrivKeyPassword.value;
     const fEncrypted = strPrivKey.length >= 128 && isBase64(strPrivKey);
@@ -1406,6 +1407,9 @@ export async function guiImportWallet() {
                     encWif: strPrivKey,
                 });
             }
+            // Destroy residue import data
+            doms.domPrivKey.value = '';
+            doms.domPrivKeyPassword.value = '';
             return;
         }
     }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -841,6 +841,10 @@ function informUserOfMnemonic(mnemonic) {
         doms.domMnemonicModalButton.onclick = () => {
             res(doms.domMnemonicModalPassphrase.value);
             $('#mnemonicModal').modal('hide');
+
+            // Wipe the mnemonic displays of sensitive data
+            doms.domMnemonicModalContent.innerText = '';
+            doms.domMnemonicModalPassphrase.value = '';
         };
         $('#mnemonicModal').modal('show');
     });


### PR DESCRIPTION
## Abstract

Previously, MPW left 'residue' of sensitive data such as Passwords and Mnemonics in memory (by keeping it in the HTML input values), thus, for example, after creating a new MPW wallet - as long as that initial session is open, your mnemonic is recoverable. The same goes for passwords; as long as the Prompt box was not reused, they were recoverable.

This PR fixes this by immediately wiping sensitive data from these input boxes as soon as possible.

## Testing

Try this console command after **Creating a new wallet**:
`document.getElementById('ModalMnemonicContent').innerText`

Try this console command after **Unlocking your wallet**:
`document.getElementById('restoreWalletPassword').value`

In `master` MPW, those will return sensitive data - in this PR, all sensitive input boxes should be cleanly empty immediately after completing an action (Unlock, New Wallet, etc).

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->

## What does this PR address?
It addresses a potential, and very simple security leak in the UI, which could've been exploited by malware or even a malicious user with access to one's device locally or remotely.

## What features or improvements were added?
N/A, security improvement only.

## How does this benefit users?
MPW is *slightly* more resilient to easy attacks - yay!