### PR TITLE
Fix password modal on front

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -165,7 +165,7 @@
         </div>
         <br />
         <!-- // CONFIRM MODAL -->
-        <div class="modal" id="confirmModal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
+        <div class="modal" id="confirmModal" tabindex="-1" style="z-index: 2000; background-color: #00000063;" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
           <div class="modal-dialog modal-dialog-centered max-w-600" role="document">
             <div class="modal-content">
               <div class="modal-header" id="confirmModalHeader">


### PR DESCRIPTION
## What does this PR address?
Make sure the password modal comes up front instead of behind the sending modal.

## What features or improvements were added?
Single line to fix the `z-index` and add a `background-color`

## How does this benefit users?
The users are finally able to enter the password on mobile.

## PIVX Address
`DDS5v6mPqUN3rdzkp3268LV7TKjHCZqy8c`