### PR TITLE
Testnet toggler now follows network state

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -1152,8 +1152,8 @@
                       </div>
 
                       <div class="custom-control custom-switch">
-                        <input type="checkbox" class="custom-control-input" id="tesnetToggler" onclick="MPW.toggleTestnet()">
-                        <label class="custom-control-label" for="tesnetToggler">Testnet Mode</label>
+                        <input type="checkbox" class="custom-control-input" id="testnetToggler" onclick="MPW.toggleTestnet()">
+                        <label class="custom-control-label" for="testnetToggler">Testnet Mode</label>
                       </div>
 
                     </div>

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -292,6 +292,7 @@ export async function start() {
         domDisplaySettingsBtn: document.getElementById('settingsDisplayBtn'),
         domVersion: document.getElementById('version'),
         domFlipdown: document.getElementById('flipdown'),
+        domTesnetToggler: document.getElementById('tesnetToggler'),
     };
     await i18nStart();
     await loadImages();

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -292,7 +292,7 @@ export async function start() {
         domDisplaySettingsBtn: document.getElementById('settingsDisplayBtn'),
         domVersion: document.getElementById('version'),
         domFlipdown: document.getElementById('flipdown'),
-        domTesnetToggler: document.getElementById('tesnetToggler'),
+        domTestnetToggler: document.getElementById('testnetToggler'),
     };
     await i18nStart();
     await loadImages();

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -388,7 +388,7 @@ async function setAnalytics(level, fSilent = false) {
 export function toggleTestnet() {
     if (fWalletLoaded) {
         // Revert testnet toggle
-        doms.domTesnetToggler.checked = !doms.domTesnetToggler.checked;
+        doms.domTestnetToggler.checked = !doms.domTestnetToggler.checked;
         return createAlert('warning', ALERTS.UNABLE_SWITCH_TESTNET, [], 3250);
     }
 
@@ -408,11 +408,7 @@ export function toggleTestnet() {
         cChainParams.current.PUBKEY_PREFIX.join(' or ');
 
     // Update testnet toggle in settings
-    if (cChainParams.current.isTestnet) {
-        doms.domTesnetToggler.checked = true;
-    } else {
-        doms.domTesnetToggler.checked = false;
-    }
+    doms.domTestnetToggler.checked = cChainParams.current.isTestnet;
 
     fillExplorerSelect();
     fillNodeSelect();

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -386,8 +386,11 @@ async function setAnalytics(level, fSilent = false) {
 }
 
 export function toggleTestnet() {
-    if (fWalletLoaded)
+    if (fWalletLoaded) {
+        // Revert testnet toggle
+        doms.domTesnetToggler.checked = !doms.domTesnetToggler.checked;
         return createAlert('warning', ALERTS.UNABLE_SWITCH_TESTNET, [], 3250);
+    }
 
     // Update current chain config
     cChainParams.current = cChainParams.current.isTestnet
@@ -403,6 +406,14 @@ export function toggleTestnet() {
     doms.domGuiBalanceStakingTicker.innerText = cChainParams.current.TICKER;
     doms.domPrefixNetwork.innerText =
         cChainParams.current.PUBKEY_PREFIX.join(' or ');
+    
+    // Update testnet toggle in settings
+    if(cChainParams.current.isTestnet) {
+        doms.domTesnetToggler.checked = true;
+    } else {
+        doms.domTesnetToggler.checked = false;
+    }
+    
     fillExplorerSelect();
     fillNodeSelect();
     getBalance(true);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -406,14 +406,14 @@ export function toggleTestnet() {
     doms.domGuiBalanceStakingTicker.innerText = cChainParams.current.TICKER;
     doms.domPrefixNetwork.innerText =
         cChainParams.current.PUBKEY_PREFIX.join(' or ');
-    
+
     // Update testnet toggle in settings
-    if(cChainParams.current.isTestnet) {
+    if (cChainParams.current.isTestnet) {
         doms.domTesnetToggler.checked = true;
     } else {
         doms.domTesnetToggler.checked = false;
     }
-    
+
     fillExplorerSelect();
     fillNodeSelect();
     getBalance(true);


### PR DESCRIPTION
## What does this PR address?
When clicking on the testnet toggle in settings it was not following the network state. For example, when it failed to switch to testnet because of a loaded wallet, it still switched the toggle. This has now been fixed right now

## How does this benefit users?
The users can now see the real state of the network with the toggler.

## PIVX Address
`DDS5v6mPqUN3rdzkp3268LV7TKjHCZqy8c`