### PR TITLE
Fix long UTXO sync on wallet import

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -742,7 +742,10 @@ export async function importWallet({
         }
 
         // Fetch state from explorer, if this import was post-startup
-        if (getNetwork().enabled && !fStartup) refreshChainData();
+        if (getNetwork().enabled && !fStartup) {
+            refreshChainData();
+            getNetwork().getUTXOs();
+        }
 
         // Hide all wallet starter options
         hideAllWalletOptions();


### PR DESCRIPTION
## Abstract

This is a tiny, last minute PR to fix a new bug in which imported wallets take a long time to synchronize their balance.

This sneaky bug came from f91f1ab0f30ec78237b1c39325db0a9eee22a1bf, since MPW relied on the Block Count changing before each UTXO sync, if MPW had already synced the block count PRIOR to importing, then post-import MPW would wait until the NEXT block to finally sync the user's balance.

Now, MPW will force a UTXO refresh on all Imports, reliably syncing the balance regardless of if the wallet is Encrypted, or was newly Imported.

**LGTM before v1.0.**