### PR TITLE
Centre Align modals + Add modern X button to one

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -78,7 +78,7 @@
 
         <!-- // QR MODAL -->
         <div class="modal fade" id="qrModal" tabindex="-1" role="dialog" aria-labelledby="qrModalLabel" aria-hidden="true">
-          <div class="modal-dialog" role="document">
+          <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content exportKeysModalColor">
               <div class="modal-header">
                 <h5 class="modal-title" id="qrModalLabel">Address QR</h5>
@@ -96,7 +96,7 @@
 
         <!-- // QR Reader -->
         <div class="modal fade" id="qrReaderModal" tabindex="-1" role="dialog" aria-labelledby="qrReaderModalLabel" aria-hidden="true">
-          <div class="modal-dialog" role="document">
+          <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content exportKeysModalColor">
               <div class="modal-header">
                 <h5 class="modal-title" id="qrReaderModalLabel">QR Scanner</h5>
@@ -113,12 +113,12 @@
 
         <!-- // Wallet Breakdown -->
         <div class="modal fade" id="walletBreakdownModal" tabindex="-1" aria-labelledby="walletBreakdownModalLabel" role="dialog" aria-hidden="true">
-          <div class="modal-dialog" role="document">
+          <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content exportKeysModalColor">
               <div class="modal-header">
                 <h5 class="modal-title" id="walletBreakdownModalLabel">Wallet Breakdown</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">&times;</span>
+                  <i class="fa-solid fa-xmark closeCross"></i>
                 </button>
               </div>
               <div class="modal-body center-text">
@@ -131,7 +131,7 @@
         <br />
         <!-- // MNEMONIC MODAL -->
         <div class="modal fade" id="mnemonicModal" tabindex="-1" role="dialog" aria-labelledby="qrModalLabel" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-          <div class="modal-dialog" role="document">
+          <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
               <div class="modal-body center-text">
                 <p id="ModalMnemonicLabel" class="modal-label"></p>
@@ -258,7 +258,7 @@
                   </div>
 
                   <div class="modal fade" id="encryptWalletModal" tabindex="-1" role="dialog" aria-labelledby="encryptWalletLabel" aria-hidden="true">
-                    <div class="modal-dialog" role="document">
+                    <div class="modal-dialog modal-dialog-centered" role="document">
                       <div class="modal-content exportKeysModalColor">
                         <div class="modal-header">
                           <h5 class="modal-title" id="encryptWalletLabel">Encrypt wallet</h5>
@@ -508,7 +508,7 @@
 
                     <!-- Export Private Key Modal -->
                     <div class="modal fade" id="exportPrivateKeysModal" tabindex="-1" role="dialog" aria-labelledby="exportPrivateKeysLabel" aria-hidden="true">
-                      <div class="modal-dialog modal-full" role="document">
+                      <div class="modal-dialog modal-dialog-centered modal-full" role="document">
                         <div class="modal-content exportKeysModalColor">
                           <div class="modal-header">
                             <h5 class="modal-title" id="exportPrivateKeysLabel">Private Key</h5>


### PR DESCRIPTION
## Abstract

This is a minor PR that fixes a couple modal inconsistencies across MPW:
- The 'X' being too dark and not using the modern MPW X classes.
- The modals not being equally aligned to the centre of the screen.

The aligning will be especially noticable on Mobile where it looks rather strange to have modals appearing at the top of the screen, instead of the centre, having to shift phone grip to interact with the modals easier.

**Before:**
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/e7218aff-ab56-464f-9882-b8403c0c47b8)

**After:**
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/8e521b84-5a1f-4be9-9a6d-e0705353af58)