### PR TITLE
Move flags to the end of the footer

### DIFF
--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -21,7 +21,7 @@ export const de_translation = {
     navSettings: 'Einstellungen', //Settings
 
     // Footer
-    footerBuiltWithPivxLabs: 'Mit 💜 🇩🇪 erstellt - PIVX Labs', //Built with 💜 by PIVX Labs
+    footerBuiltWithPivxLabs: 'Mit 💜 erstellt - PIVX Labs 🇩🇪', //Built with 💜 by PIVX Labs
 
     // Intro
     loading: '...lädt...', //Loading

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -20,7 +20,7 @@ export const fr_translation = {
     navSettings: 'Configurations', //Settings
 
     // Footer
-    footerBuiltWithPivxLabs: 'Construit avec 💜 🇫🇷 par PIVX Labs FR', //Built with 💜 by PIVX Labs
+    footerBuiltWithPivxLabs: 'Construit avec 💜 par PIVX Labs FR 🇫🇷', //Built with 💜 by PIVX Labs
 
     // Intro
     loading: 'Chargement', //Loading

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -21,7 +21,7 @@ export const ph_translation = {
     navSettings: 'Settings', //Settings
 
     // Footer
-    footerBuiltWithPivxLabs: 'Binuo nang may 💜 🇵🇭 ng PIVX Labs', //Built with 💜 🇵🇭 by PIVX Labs
+    footerBuiltWithPivxLabs: 'Binuo nang may 💜 ng PIVX Labs 🇵🇭', //Built with 💜 by PIVX Labs
 
     // Intro
     loading: 'Loading', //Loading

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -20,7 +20,7 @@ export const pt_br_translation = {
     navSettings: 'Configurações', //Settings
 
     // Footer
-    footerBuiltWithPivxLabs: 'Construido com 💜 🇧🇷 por PIVX Labs', //Built with 💜 by PIVX Labs
+    footerBuiltWithPivxLabs: 'Construido com 💜 por PIVX Labs 🇧🇷', //Built with 💜 by PIVX Labs
 
     // Intro
     loading: 'Carregando', //Loading

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -20,7 +20,7 @@ export const pt_pt_translation = {
     navSettings: 'Configurações', //Settings
 
     // Footer
-    footerBuiltWithPivxLabs: 'Construido com 💜 🇵🇹 por PIVX Labs', //Built with 💜 by PIVX Labs
+    footerBuiltWithPivxLabs: 'Construido com 💜 por PIVX Labs 🇵🇹', //Built with 💜 by PIVX Labs
 
     // Intro
     loading: 'Carregar', //Loading


### PR DESCRIPTION
## Abstract

This tiny PR simply moves the flags to the end of the footer, suggested by Ambassador Miguel. :purple_heart: