### PR TITLE
Add "Change Password" functionality

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -1147,22 +1147,12 @@
                       </select>
                       <div id="analyticsDescriptor"></div>
 
-                      <br />
-
                       <div id="changePassword-container">
                         <hr>
-
-                        <br />
-
-                        <div onclick="MPW.doms.domGettingStartedBtn.click()" style="cursor: pointer; border: 0px; border-radius: 7px; padding: 6px 10px; margin: 0px 1px; background: linear-gradient(183deg, #9621ff9c, #7d21ffc7); color: #fff; font-weight: bold; width: fit-content;">
+                        <div onclick="MPW.doms.domGettingStartedBtn.click()" style="cursor: pointer; border: 0px; border-radius: 7px; padding: 6px 10px; margin: 0px 1px; background: linear-gradient(183deg, #9621ff9c, #7d21ffc7); color: #fff; font-weight: bold; width: fit-content; margin: 20px 0px;">
                           Change Password
                         </div>
-
-                        <br />
-
                         <hr>
-
-                        <br />
                       </div>
 
                       <!-- Default switch -->

--- a/index.template.html
+++ b/index.template.html
@@ -182,6 +182,42 @@
           </div>
         </div>
 
+        <div class="modal fade" id="encryptWalletModal" tabindex="-1" role="dialog" aria-labelledby="encryptWalletLabel" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content exportKeysModalColor">
+              <div class="modal-header">
+                <h5 class="modal-title" id="encryptWalletLabel">Encrypt wallet</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <i class="fa-solid fa-xmark closeCross"></i>
+                </button>
+              </div>
+              <div class="modal-body">
+                <div class="row m-0">
+                  <input class="center-text textboxTransparency" data-i18n="encryptPasswordCurrent" style="width: 100%; font-family: monospace;" type="password" id="changePassword-current" placeholder="Current Password" />
+                  <div class="col-12 col-md-6 p-0 pr-0 pr-md-1">
+                    <input class="center-text textboxTransparency" data-i18n="encryptPasswordFirst" style="width: 100%; font-family: monospace;" type="password" id="newPassword" placeholder="Enter Password" />
+                  </div>
+                  <div class="col-12 col-md-6 p-0 pl-0 pl-md-1">
+                    <input class="center-text textboxTransparency" data-i18n="encryptPasswordSecond" style="width: 100%; font-family: monospace;" type="password" id="newPasswordRetype" placeholder="Re-enter Password" />
+                  </div>
+                </div>
+              </div>
+              <div class="modal-footer text-right">
+                <button class="pivx-button-small" onclick="MPW.guiEncryptWallet()">
+                  <span class="dcWallet-svgIconPurple">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                      <path
+                        d="M85.967 10.65l-32.15-9.481a13.466 13.466 0 00-7.632 0l-32.15 9.48C11.661 11.351 10 13.567 10 16.042v26.623c0 12.321 3.67 24.186 10.609 34.31 6.774 9.885 16.204 17.49 27.264 21.99a5.612 5.612 0 004.251 0c11.061-4.5 20.491-12.104 27.266-21.99C86.329 66.85 90 54.985 90 42.664V16.042a5.656 5.656 0 00-4.033-5.392zM69 68.522C69 70.907 67.03 72 64.584 72H34.092C31.646 72 30 70.907 30 68.522v-23.49C30 42.647 31.646 41 34.092 41H37v-9.828C37 24.524 41.354 18.5 49.406 18.5 57.37 18.5 62 24.066 62 31.172V41h2.584C67.03 41 69 42.647 69 45.032v23.49zM58 41v-9.828c0-4.671-3.708-8.472-8.5-8.472-4.791 0-8.5 3.8-8.5 8.472V41h17z"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span data-i18n="encrypt">Encrypt</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="container">
           <div class="row no-gutters">
             <div class="col-md-12 rm-pd">
@@ -239,7 +275,7 @@
                   <!-- WARNING -->
                   <div class="col-12" id='genKeyWarning' style='display: none;'>
                     <center>
-                      <div class="dcWallet-warningMessage" data-toggle="modal" data-target="#encryptWalletModal">
+                      <div id="gettingStartedBtn" class="dcWallet-warningMessage" data-toggle="modal" data-target="#encryptWalletModal">
                         <div class="shieldLogo">
                           <div class="shieldBackground">
                             <span class="dcWallet-svgIconPurple" style="top: 14px; left: 7px;">
@@ -257,40 +293,6 @@
                     </center>
                   </div>
 
-                  <div class="modal fade" id="encryptWalletModal" tabindex="-1" role="dialog" aria-labelledby="encryptWalletLabel" aria-hidden="true">
-                    <div class="modal-dialog modal-dialog-centered" role="document">
-                      <div class="modal-content exportKeysModalColor">
-                        <div class="modal-header">
-                          <h5 class="modal-title" data-i18n="encryptWallet" id="encryptWalletLabel">Encrypt wallet</h5>
-                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <i class="fa-solid fa-xmark closeCross"></i>
-                          </button>
-                        </div>
-                        <div class="modal-body">
-                          <div class="row m-0">
-                            <div class="col-12 col-md-6 p-0 pr-0 pr-md-1">
-                              <input class="center-text textboxTransparency" data-i18n="encryptPasswordFirst" style="width: 100%; font-family: monospace;" type="password" id="newPassword" placeholder="Enter Password" />
-                            </div>
-                            <div class="col-12 col-md-6 p-0 pl-0 pl-md-1">
-                              <input class="center-text textboxTransparency" data-i18n="encryptPasswordSecond" style="width: 100%; font-family: monospace;" type="password" id="newPasswordRetype" placeholder="Re-enter Password" />
-                            </div>
-                          </div>
-                        </div>
-                        <div class="modal-footer text-right">
-                          <button class="pivx-button-small" onclick="MPW.guiEncryptWallet()">
-                            <span class="dcWallet-svgIconPurple">
-                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-                                <path
-                                  d="M85.967 10.65l-32.15-9.481a13.466 13.466 0 00-7.632 0l-32.15 9.48C11.661 11.351 10 13.567 10 16.042v26.623c0 12.321 3.67 24.186 10.609 34.31 6.774 9.885 16.204 17.49 27.264 21.99a5.612 5.612 0 004.251 0c11.061-4.5 20.491-12.104 27.266-21.99C86.329 66.85 90 54.985 90 42.664V16.042a5.656 5.656 0 00-4.033-5.392zM69 68.522C69 70.907 67.03 72 64.584 72H34.092C31.646 72 30 70.907 30 68.522v-23.49C30 42.647 31.646 41 34.092 41H37v-9.828C37 24.524 41.354 18.5 49.406 18.5 57.37 18.5 62 24.066 62 31.172V41h2.584C67.03 41 69 42.647 69 45.032v23.49zM58 41v-9.828c0-4.671-3.708-8.472-8.5-8.472-4.791 0-8.5 3.8-8.5 8.472V41h17z"
-                                ></path>
-                              </svg>
-                            </span>
-                            <span data-i18n="encrypt">Encrypt</span>
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
                   <!-- // WARNING -->
                   <br />
 
@@ -1144,6 +1146,24 @@
                         <!-- Populated via JS at DOM load (settings.js) -->
                       </select>
                       <div id="analyticsDescriptor"></div>
+
+                      <br />
+
+                      <div id="changePassword-container">
+                        <hr>
+
+                        <br />
+
+                        <div onclick="MPW.doms.domGettingStartedBtn.click()" style="cursor: pointer; border: 0px; border-radius: 7px; padding: 6px 10px; margin: 0px 1px; background: linear-gradient(183deg, #9621ff9c, #7d21ffc7); color: #fff; font-weight: bold; width: fit-content;">
+                          Change Password
+                        </div>
+
+                        <br />
+
+                        <hr>
+
+                        <br />
+                      </div>
 
                       <!-- Default switch -->
                       <div class="custom-control custom-switch" style="margin-bottom:15px;">

--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -73,9 +73,11 @@ export const de_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Verschlüssel deine Brieftasche', //Encrypt wallet
+    encryptPasswordCurrent: '', //Current Password
     encryptPasswordFirst: 'Gib dein Passwort ein', //Enter Password
     encryptPasswordSecond: 'Wiederhole dein Passwort', //Re-enter Password
     encrypt: 'Verschlüsseln', //Encrypt
+    changePassword: '', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Aufgeschlüsselter Kontostand', //Balance Breakdown

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -70,9 +70,11 @@ export const en_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Encrypt wallet', //
+    encryptPasswordCurrent: 'Current Password', //
     encryptPasswordFirst: 'Enter Password', //
     encryptPasswordSecond: 'Re-enter Password', //
     encrypt: 'Encrypt', //
+    changePassword: 'Change Password', //
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Balance Breakdown', //

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -73,9 +73,11 @@ export const fr_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Cryptage du portefeuille', //Encrypt wallet
+    encryptPasswordCurrent: '', //Current Password
     encryptPasswordFirst: 'Entrer le mot de passe', //Enter Password
     encryptPasswordSecond: 'Réintroduire le mot de passe', //Re-enter Password
     encrypt: 'Crypter', //Encrypt
+    changePassword: '', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Composition de la balance', //Balance Breakdown

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -74,9 +74,11 @@ export const ph_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Encrypt wallet', //Encrypt wallet
+    encryptPasswordCurrent: '', //Current Password
     encryptPasswordFirst: 'Ilagay ang Password', //Enter Password
     encryptPasswordSecond: 'Ilagay ulit ang Password', //Re-enter Password
     encrypt: 'Encrypt', //Encrypt
+    changePassword: '', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Kabuoang Balanse', //Balance Breakdown

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -73,9 +73,11 @@ export const pt_br_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Criptografar carteira', //Encrypt wallet
+    encryptPasswordCurrent: '', //Current Password
     encryptPasswordFirst: 'Digite a senha', //Enter Password
     encryptPasswordSecond: 'Digite a senha novamente', //Re-enter Password
     encrypt: 'Criptografar', //Encrypt
+    changePassword: '', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Composição do Saldo', //Balance Breakdown

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -72,9 +72,11 @@ export const pt_pt_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Criptografar carteira', //Encrypt wallet
+    encryptPasswordCurrent: '', //Current Password
     encryptPasswordFirst: 'Digite a senha', //Enter Password
     encryptPasswordSecond: 'Digite novamente a senha', //Re-enter Password
     encrypt: 'Criptografar', //Encrypt
+    changePassword: '', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Composição do Saldo', //Balance Breakdown

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -85,9 +85,11 @@ var translation = {
 
     // Encrypt wallet
     encryptWallet: '', //Encrypt wallet
+    encryptPasswordCurrent: '', //Current Password
     encryptPasswordFirst: '', //Enter Password
     encryptPasswordSecond: '', //Re-enter Password
     encrypt: '', //Encrypt
+    changePassword: '', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: '', //Balance Breakdown

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -72,9 +72,11 @@ export const uwu_translation = {
 
     // Encrypt wallet
     encryptWallet: 'Encwypt wawwet', //Encrypt wallet
+    encryptPasswordCurrent: 'Cuwwent Password', //Current Password
     encryptPasswordFirst: 'Entwer Password', //Enter Password
     encryptPasswordSecond: 'Re-entwer Password', //Re-enter Password
     encrypt: 'Encwypt', //Encrypt
+    changePassword: 'Change Passwoword', //Change Password
 
     // Wallet Dashboard Sub-menu
     balanceBreakdown: 'Bwalance Bweakdown', //Balance Breakdown

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -895,7 +895,7 @@ export async function decryptWallet(strPassword = '') {
 }
 
 /**
- * @returns {Promise<bool>} If the wallet is unlocked
+ * @returns {Promise<bool>} If the wallet has an encrypted database backup
  */
 export async function hasEncryptedWallet() {
     const database = await Database.getInstance();


### PR DESCRIPTION
## Abstract

This PR adds the ability for users to change their MPW encryption password at runtime; this button is located in the Wallet Settings, and is only shown when a wallet is locally encrypted in the database already (i.e: immediately after encrypting, the setting becomes available).
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/8ff11d57-447f-4556-ad0c-9d481e7622ad)

This PR re-uses the "Encrypt Wallet" code and UI flow, by a hidden "Current Password" input that reveals itself when necessary, and updating the modal title accordingly.

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/425465ab-cbda-4bed-81de-9ceb4f8dae56)

In the backend, it essentially is just calling 'encryptWallet' and overwriting the existing wallet `encWif` in the database.

---

# Testing

To test this PR, it's suggested to attempt these user flows, or variations of these:
- Create a new wallet.
- Encrypt your wallet (note your address down).
- Visit `Settings -> Wallet`, and Change Password.
- Reload MPW, unlock using your new password, check that your address is correct.

Feel free to try various testing methods: like changing your password multiple times, or trying to break the "Change Password" UI or functionality.

---

## What does this PR address?
It allows users to finally change their MPW password, which previously, was unchangeable and permanent.

## What features or improvements were added?
It adds a simple "Change Password" button to the Wallet Settings.

## How does this benefit users?
Sometimes, users just want to change their password: perhaps they dislike the old one, would like a more complex/simple one, or they just routinely change passwords for security, this fits all of such usecases.