### PR TITLE
Disable Analytics (until server is fixed)

### DIFF
--- a/scripts/network.js
+++ b/scripts/network.js
@@ -576,6 +576,10 @@ export class ExplorerNetwork extends Network {
     submitAnalytics(strType, cData = {}) {
         if (!this.enabled) return;
 
+        // TODO: rebuild Labs Analytics, submitAnalytics() will be disabled at code-level until this is live again
+        /* eslint-disable */
+        return;
+
         // Limit analytics here to prevent 'leakage' even if stats are implemented incorrectly or forced
         let i = 0,
             arrAllowedKeys = [];


### PR DESCRIPTION
## Abstract

This PR simply disables the "Labs Analytics" system at code-level, incapacitating Network Requests to a now-defunct server.

The previous system relied on a 3rd-party server setup, in which is no longer running; in the future once we have more time and resources, I'll build a new Labs Analytics server, domain, and data-crunching system along with stats displays, and hook it back in to this MPW Analytics function.

No need for reviews, as this is a one-liner change which is clear to analyse.