### PR TITLE
Bump to v1.1.1 + Update Changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,24 +1,11 @@
 # New Features
-- i18n System: with full multi-lang support.
-- PIVX Promos: added CSV exports for codes.
-- New Setting: customise your balance decimals.
-
-# New Languages
-- 🇫🇷 French (miguelc030, _hellthere77 & sylvain).
-- 🇩🇪 German (by billytheone).
-- 🇵🇹 Portuguese (by miguelc030).
-- 🇧🇷 Brazilian PT (by invic1337 & miguelc030).
-- 🇵🇭 Filipino Tagalog (by clover1221).
+- New Setting: change your encryption password.
 
 # Improvements
-- New 'Congrats' popup for Proposal Submissions.
-- Show Vote Hash after Proposal Submission.
-- New Governance Dashboard colours, fonts, style.
-- Added clickable Address to each proposal.
-- Centre-aligned all modals and prompts.
-- PIVX Promos shows 'syncing' on loading codes.
+- Improved 'Debug Mode' verbosity.
 
 # Bug Fixes
-- Fixed PIVX Promos 'lag' with high code qty.
-- Fixed 'Staking' balance showing wrong currency.
-- Fixed black 'X' on certain modals.
+- Fixed critical proposal creation 'crashing'.
+- Fixed destructive multi-proposal finalisation.
+- Fixed Tx failures with Debug Mode on.
+- Disabled Labs Analytics (stops console errors).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mypivxwallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mypivxwallet",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource/chivo": "^4.5.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mypivxwallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Wallet for PIVX",
   "main": "scripts/index.js",
   "scripts": {


### PR DESCRIPTION
## Abstract

This PR bumps MPW to v1.1.1, a Patch update, releasing early to patch the critical #178 Governance bugs, and other Tx-related failures and errors.

To give users a little more than just a patch, a "Change Password" feature was quickly QC-tested and will be included with v1.1.1 as well!