### PR TITLE
Improved DB + Full Testnet DB support

### DIFF
--- a/scripts/accounts.js
+++ b/scripts/accounts.js
@@ -1,0 +1,61 @@
+import { Contact } from './contacts-book';
+
+/**
+ * A local Account, containing sensitive user-data
+ */
+export class Account {
+    /**
+     * Create an Account.
+     * @param {Object} accountData - The account data.
+     * @param {String} accountData.publicKey - The public key.
+     * @param {String} [accountData.encWif] - The encrypted WIF.
+     * @param {Array<Object>} [accountData.localProposals] - The local proposals.
+     * @param {Array<Contact>} [accountData.contacts] - The Contacts saved in this account.
+     * @param {String} [account.name] - The Contact Name of the account.
+     */
+    constructor(accountData) {
+        // Keys take the Constructor as priority, but if missing, default to their "Type" in empty form for type-safety
+        this.publicKey = accountData?.publicKey || '';
+        this.encWif = accountData?.encWif || '';
+        this.localProposals = accountData?.localProposals || [];
+        this.contacts = accountData?.contacts || [];
+        this.name = accountData?.name || '';
+    }
+
+    /** @type {String} The public key. */
+    publicKey = '';
+
+    /** @type {String} The encrypted WIF. */
+    encWif = '';
+
+    /** @type {Array<Object>} The local proposals. */
+    localProposals = [];
+
+    /** @type {Array<Contact>} The Contacts saved in this account. */
+    contacts = [];
+
+    /** @type {String} The Contact Name of the account. */
+    name = '';
+
+    /**
+     * Search for a Contact in this account, by specific properties
+     * @param {Object} settings
+     * @param {string?} settings.name - The Name of the contact to search for
+     * @param {string?} settings.pubkey - The Pubkey of the contact to search for
+     * @returns {Contact?} - A Contact, if found
+     */
+    getContactBy({ name, pubkey }) {
+        if (!name && !pubkey)
+            throw Error(
+                'getContactBy(): At least ONE search parameter MUST be set!'
+            );
+
+        // Get by Name
+        if (name) return this.contacts.find((a) => a.label === name);
+        // Get by Pubkey
+        if (pubkey) return this.contacts.find((a) => a.pubkey === pubkey);
+
+        // Nothing found
+        return null;
+    }
+}

--- a/scripts/contacts-book.js
+++ b/scripts/contacts-book.js
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import { Account } from './accounts';
 import { Database } from './database';
 import { doms, toClipboard } from './global';
 import { ALERTS, translation } from './i18n';
@@ -56,7 +57,7 @@ export class Contact {
 
 /**
  * Add a Contact to an Account's contact list
- * @param {{publicKey: String, encWif: String?, localProposals: Array<any>, contacts: Array<Contact>}} account - The account to add the Contact to
+ * @param {Account} account - The account to add the Contact to
  * @param {Contact} contact - The contact object
  */
 export async function addContact(account, contact) {
@@ -64,46 +65,15 @@ export async function addContact(account, contact) {
     const cDB = await Database.getInstance();
 
     // Push contact in to the account
-    const arrContacts = account?.contacts || [];
-    arrContacts.push(contact);
+    account.contacts.push(contact);
 
     // Save to the DB
-    await cDB.addAccount({
-        publicKey: account.publicKey,
-        encWif: account.encWif,
-        localProposals: account?.localProposals || [],
-        contacts: arrContacts,
-        name: account?.name || '',
-    });
-}
-
-/**
- * Search for a Contact in a given Account, by specific properties
- * @param {{publicKey: String, encWif: String?, localProposals: Array<any>, contacts: Array<Contact>}} account - The account to search for a Contact
- * @param {Object} settings
- * @param {string?} settings.name - The Name of the contact to search for
- * @param {string?} settings.pubkey - The Pubkey of the contact to search for
- * @returns {Contact?} - A Contact, if found
- */
-export function getContactBy(account, { name, pubkey }) {
-    if (!name && !pubkey)
-        throw Error(
-            'getContactBy(): At least ONE search parameter MUST be set!'
-        );
-    const arrContacts = account?.contacts || [];
-
-    // Get by Name
-    if (name) return arrContacts.find((a) => a.label === name);
-    // Get by Pubkey
-    if (pubkey) return arrContacts.find((a) => a.pubkey === pubkey);
-
-    // Nothing found
-    return null;
+    await cDB.updateAccount(account);
 }
 
 /**
  * Remove a Contact from an Account's contact list
- * @param {{publicKey: String, encWif: String?, localProposals: Array<any>, contacts: Array<Contact>}} account - The account to remove the Contact from
+ * @param {Account} account - The account to remove the Contact from
  * @param {string} pubkey - The contact pubkey
  */
 export async function removeContact(account, pubkey) {
@@ -111,24 +81,17 @@ export async function removeContact(account, pubkey) {
     const cDB = await Database.getInstance();
 
     // Find the contact by index, if it exists; splice it away
-    const arrContacts = account?.contacts || [];
-    const nIndex = arrContacts.findIndex((a) => a.pubkey === pubkey);
+    const nIndex = account.contacts.findIndex((a) => a.pubkey === pubkey);
     if (nIndex > -1) {
         // Splice out the contact, and save to DB
-        arrContacts.splice(nIndex, 1);
-        await cDB.addAccount({
-            publicKey: account.publicKey,
-            encWif: account.encWif,
-            localProposals: account?.localProposals || [],
-            contacts: account?.contacts || [],
-            name: account?.name || '',
-        });
+        account.contacts.splice(nIndex, 1);
+        await cDB.updateAccount(account, true);
     }
 }
 
 /**
  * Render an Account's contact list
- * @param {{publicKey: String, encWif: String?, localProposals: Array<any>, contacts: Array<Contact>}} account
+ * @param {Account} account
  * @param {boolean} fPrompt - If this is a Contact Selection prompt
  */
 export async function renderContacts(account, fPrompt = false) {
@@ -348,20 +311,17 @@ export async function guiRenderContacts() {
 
 /**
  * Set the current Account's Contact name
- * @param {{publicKey: String, encWif: String?, localProposals: Array<any>, contacts: Array<Contact>, name: String?}} account - The account to add the new Name to
+ * @param {Account} account - The account to add the new Name to
  * @param {String} name - The name to set
  */
 export async function setAccountContactName(account, name) {
     const cDB = await Database.getInstance();
 
+    // Set the name
+    account.name = name;
+
     // Save name to the DB
-    await cDB.addAccount({
-        publicKey: account.publicKey,
-        encWif: account.encWif,
-        localProposals: account?.localProposals || [],
-        contacts: account?.contacts || [],
-        name: name,
-    });
+    await cDB.updateAccount(account);
 }
 
 /**
@@ -597,8 +557,8 @@ export async function guiAddContact() {
     const cAccount = await cDB.getAccount();
 
     // Check this Contact isn't already saved, either fully or partially
-    const cContactByName = getContactBy(cAccount, { name: strName });
-    const cContactByPubkey = getContactBy(cAccount, { pubkey: strAddr });
+    const cContactByName = cAccount.getContactBy({ name: strName });
+    const cContactByPubkey = cAccount.getContactBy({ pubkey: strAddr });
 
     // If both Name and Key are saved, then they just tried re-adding the same Contact twice
     if (cContactByName && cContactByPubkey) {
@@ -698,8 +658,8 @@ export async function guiAddContactPrompt(
     const cAccount = await cDB.getAccount();
 
     // Check this Contact isn't already saved, either fully or partially
-    const cContactByName = getContactBy(cAccount, { name: strName });
-    const cContactByPubkey = getContactBy(cAccount, { pubkey: strPubkey });
+    const cContactByName = cAccount.getContactBy({ name: strName });
+    const cContactByPubkey = cAccount.getContactBy({ pubkey: strPubkey });
 
     // If both Name and Key are saved, then they just tried re-adding the same Contact twice
     if (cContactByName && cContactByPubkey) {
@@ -813,7 +773,7 @@ export async function guiEditContactNamePrompt(nIndex) {
     }
 
     // Check this new Name isn't already saved
-    const cContactByNewName = getContactBy(cAccount, { name: strNewName });
+    const cContactByNewName = cAccount.getContactBy({ name: strNewName });
     if (cContactByNewName) {
         createAlert(
             'warning',
@@ -828,13 +788,7 @@ export async function guiEditContactNamePrompt(nIndex) {
     cContact.label = strNewName;
 
     // Commit to DB
-    await cDB.addAccount({
-        publicKey: cAccount.publicKey,
-        encWif: cAccount.encWif,
-        localProposals: cAccount?.localProposals || [],
-        contacts: cAccount?.contacts || [],
-        name: cAccount?.name,
-    });
+    await cDB.updateAccount(cAccount);
 
     // Re-render the Contacts UI
     await renderContacts(cAccount);
@@ -863,13 +817,7 @@ export async function guiAddContactImage(nIndex) {
     cContact.icon = strImage;
 
     // Commit to DB
-    await cDB.addAccount({
-        publicKey: cAccount.publicKey,
-        encWif: cAccount.encWif,
-        localProposals: cAccount?.localProposals || [],
-        contacts: cAccount?.contacts || [],
-        name: cAccount?.name,
-    });
+    await cDB.updateAccount(cAccount);
 
     // Re-render the Contacts UI
     await renderContacts(cAccount);
@@ -1003,7 +951,7 @@ export async function guiCheckRecipientInput(event) {
     const cAccount = await cDB.getAccount();
 
     // Check if this is a Contact
-    const cContact = getContactBy(cAccount, {
+    const cContact = cAccount.getContactBy({
         name: strInput,
         pubkey: strInput,
     });
@@ -1024,7 +972,7 @@ export async function guiCheckRecipientInput(event) {
 
 /**
  * Search for a Name of a Contact from a given Account and Address
- * @param {object} cAccount - The Account to search for the Contact
+ * @param {Account} cAccount - The Account to search for the Contact
  * @param {string} address - The address to search for a Contact with
  * @returns {string} - The Name of the address Contact, or just the address if none is found
  */
@@ -1036,8 +984,8 @@ export function getNameOrAddress(cAccount, address) {
 
 /**
  * Convert the current Account's Contact to a Share URI
- * @param {object?} - An optional Account to construct the Contact URI from, if omitted, the current DB account is used
- * @param {string?} - An optional Master Public Key to attach to the Contact URI
+ * @param {Account?} account - An optional Account to construct the Contact URI from, if omitted, the current DB account is used
+ * @param {string?} pubkey - An optional Master Public Key to attach to the Contact URI
  */
 export async function localContactToURI(account, pubkey) {
     // Fetch the current Account

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -841,6 +841,9 @@ export async function createActivityListHTML(arrTXs, fRewards = false) {
 
     // Generate the TX list
     for (const cTx of arrTXs) {
+        // If no account is loaded, we render nothing!
+        if (!masterKey) break;
+
         const dateTime = new Date(cTx.time * 1000);
 
         // If this Tx is older than 24h, then hit the `Date` cache logic, otherwise, use a `Time` and skip it
@@ -1273,17 +1276,21 @@ export function guiPreparePayment(strTo = '', nAmount = 0, strDesc = '') {
     }
 }
 
-export function hideAllWalletOptions() {
-    // Hide and Reset the Vanity address input
+/**
+ * Set the "Wallet Options" menu visibility
+ * @param {String} strDisplayCSS - The `display` CSS option to set the Wallet Options to
+ */
+export function setDisplayForAllWalletOptions(strDisplayCSS) {
+    // Set the display and Reset the Vanity address input
     doms.domPrefix.value = '';
-    doms.domPrefix.style.display = 'none';
+    doms.domPrefix.style.display = strDisplayCSS;
 
-    // Hide all "*Wallet" buttons
-    doms.domGenerateWallet.style.display = 'none';
-    doms.domImportWallet.style.display = 'none';
-    doms.domGenVanityWallet.style.display = 'none';
-    doms.domAccessWallet.style.display = 'none';
-    doms.domGenHardwareWallet.style.display = 'none';
+    // Set all "*Wallet" buttons
+    doms.domGenerateWallet.style.display = strDisplayCSS;
+    doms.domImportWallet.style.display = strDisplayCSS;
+    doms.domGenVanityWallet.style.display = strDisplayCSS;
+    doms.domAccessWallet.style.display = strDisplayCSS;
+    doms.domGenHardwareWallet.style.display = strDisplayCSS;
 }
 
 export async function govVote(hash, voteCode) {
@@ -1569,19 +1576,10 @@ export async function guiImportWallet() {
     const fHasWallet = await decryptWallet(doms.domPrivKey.value);
 
     // If the wallet was successfully loaded, hide all options and load the dash!
-    if (fHasWallet) hideAllWalletOptions();
+    if (fHasWallet) setDisplayForAllWalletOptions('none');
 }
 
 export async function guiEncryptWallet() {
-    // Disable wallet encryption in testnet mode
-    if (cChainParams.current.isTestnet)
-        return createAlert(
-            'warning',
-            ALERTS.TESTNET_ENCRYPTION_DISABLED,
-            [],
-            2500
-        );
-
     // Fetch our inputs, ensure they're of decent entropy + match eachother
     const strPass = doms.domEncryptPasswordFirst.value,
         strPassRetype = doms.domEncryptPasswordSecond.value;
@@ -2819,8 +2817,7 @@ export function refreshChainData() {
 export const beforeUnloadListener = (evt) => {
     evt.preventDefault();
     // Disable Save your wallet warning on unload
-    if (!cChainParams.current.isTestnet)
-        createAlert('warning', ALERTS.SAVE_WALLET_PLEASE, [], 10000);
+    createAlert('warning', ALERTS.SAVE_WALLET_PLEASE, [], 10000);
     // Most browsers ignore this nowadays, but still, keep it 'just incase'
     return (evt.returnValue = translation.BACKUP_OR_ENCRYPT_WALLET);
 };

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -434,6 +434,44 @@ export function isBase64(str) {
 }
 
 /**
+ * Checks if two values are of the same type.
+ *
+ * @param {any} a - The first value.
+ * @param {any} b - The second value.
+ * @returns {boolean} - `true` if the values are of the same type, `false` if not or if there was an error comparing.
+ */
+export function isSameType(a, b) {
+    try {
+        if (a === null || b === null) return a === b;
+        if (typeof a !== typeof b) return false;
+        if (typeof a === 'object')
+            return Object.getPrototypeOf(a) === Object.getPrototypeOf(b);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
+ * Checks if a value is 'empty'.
+ *
+ * @param {any} val - The value to check.
+ * @returns {boolean} - `true` if the value is 'empty', `false` otherwise.
+ * ---
+ * Values **considered 'empty'**: `null`, `undefined`, empty strings, empty arrays, empty objects.
+ *
+ * Values **NOT considered 'empty'**: Any non-nullish primitive value: numbers (including `0` and `NaN`), `true`, `false`, `Symbol()`, `BigInt()`.
+ */
+export function isEmpty(val) {
+    return (
+        val == null ||
+        val === '' ||
+        (Array.isArray(val) && val.length === 0) ||
+        (typeof val === 'object' && Object.keys(val).length === 0)
+    );
+}
+
+/**
  * An artificial sleep function to pause code execution
  *
  * @param {Number} ms - The milliseconds to sleep

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -596,7 +596,7 @@ export class ExplorerNetwork extends Network {
         // If the public Master Key (xpub, address...) is different, then wipe TX history
         if (
             (await this.masterKey?.keyToExport) !==
-            (await masterKey.keyToExport)
+            (await masterKey?.keyToExport)
         ) {
             this.arrTxHistory = [];
         }

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -31,7 +31,6 @@ import {
 } from './misc.js';
 import { bytesToHex, hexToBytes, dSHA256 } from './utils.js';
 import { Database } from './database.js';
-import { getContactBy } from './contacts-book.js';
 
 function validateAmount(nAmountSats, nMinSats = 10000) {
     // Validate the amount is a valid number, and meets the minimum (if any)
@@ -92,7 +91,7 @@ export async function createTxGUI() {
     // Check for any contacts that match the input
     const cDB = await Database.getInstance();
     const cAccount = await cDB.getAccount();
-    const cContact = getContactBy(cAccount, {
+    const cContact = cAccount.getContactBy({
         name: strRawReceiver,
         pubkey: strRawReceiver,
     });


### PR DESCRIPTION
## Abstract

This critical PR introduces two large changes to MPW, the prior of which need ***the most in-depth auditing and review*** that we can conceive, as a bad DB change could lead to catastrophic data loss.
- A full revamp of the Database system.
- - Now with `addAccount()` and `updateAccount()`, each with very tight limits, checks and guard-rails.
- - Removed the ability for `addAccount()` to override accounts or parts of accounts.
- - `updateAccount()` can update keys of accounts, but not delete them, without explicit `allowDeletion` permission.

- Full Testnet support for Encryption and Databasing.
- - Added the ability to switch between Mainnet and Testnet any time, even with wallets loaded.
- - Added the ability to Encrypt your Testnet wallet.

The new `updateAccount()` function is designed to be used **EXCLUSIVELY** by using an `Account` class as it's input, and will outright refuse any `type` that differs from the class, this ensures that there is absolutely no way, even with badly written code, to accidentally overwrite an Account or it's properties.

The new database ensures that ALL keys of an Account are ALWAYS present; meaning no more `account?.localProposals` or similar, the class and DB both have a type-safety to them which now guarantee the availability of the `type` for every key of the Account.

When there's MPW updates, the DB will automatically add new keys added to the `Account` class, with zero need for manual migration.

---

## Testing

To test this PR, it's suggested to attempt these user flows, or variations of these:
- Create or Import your wallet, as you normally would.
- **Heavily** test that the database is working as expected, examples of testing this are: *Setting, Renaming, Deleting Contacts, by creating Proposals, by testing that wallets are saving and being remembered correctly, with zero data loss.*


> **Note:** the new Testnet integration is known to have certain quirks: you may experience network errors when switching between Mainnet and Testnet, this is from switching halfway through Explorer Syncing, but this is relatively harmless and out-of-scope of this PR to fix.

> **Note:** it's known that when switching between networks, if the NEW wallet does not have any UTXOs, the Activity will not update; this will be resolved with the merging of #186 since we'll have the ability to re-render the Activity list at-will then.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---