### PR TITLE
Improve CoinGecko stability, add attribution

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -1207,6 +1207,8 @@
                         <!-- Populated via JS at Price Source data load (prices.js) -->
                       </select>
 
+                      <p style="opacity: 0.6; margin-top: 5px;"><span data-i18n="priceProvidedBy">Price data provided by</span> <a class="active" href="https://www.coingecko.com/" target="_blank" rel="noopener noreferrer">CoinGecko</a></p>
+
                       <br />
 
                       <label for="displayDecimals" data-i18n="settingsDecimals">Balance Decimals:</label> <span class="sliderDisplay" id="sliderDisplay">(-)</span>

--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -169,6 +169,7 @@ export const de_translation = {
 
     // Settings
     settingsCurrency: 'Wähle die angezeigte Währung', //Choose a display currency:
+    priceProvidedBy: '', //Price data provided by
     settingsDecimals: '', //Balance Decimals:
     settingsExplorer: 'Wähle einen Explorer', //Choose an explorer:
     settingsLanguage: 'Wähle eine Sprache', //Choose a Language:

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -170,6 +170,7 @@ export const en_translation = {
 
     // Settings
     settingsCurrency: 'Choose a display currency:', //
+    priceProvidedBy: 'Price data provided by', //
     settingsDecimals: 'Balance Decimals:', //
     settingsExplorer: 'Choose an explorer:', //
     settingsLanguage: 'Choose a Language:', //

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -168,6 +168,7 @@ export const fr_translation = {
 
     // Settings
     settingsCurrency: "Choisissez une devise d'affichage :", //Choose a display currency:
+    priceProvidedBy: '', //Price data provided by
     settingsDecimals: 'Solde Décimales :', //Balance Decimals:
     settingsExplorer: 'Choisissez un explorateur :', //Choose an explorer:
     settingsLanguage: 'Choisissez une langue :', //Choose a Language:

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -170,6 +170,7 @@ export const ph_translation = {
 
     // Settings
     settingsCurrency: 'Pumili ng display currency:', //Choose a display currency:
+    priceProvidedBy: '', //Price data provided by
     settingsDecimals: '', //Balance Decimals:
     settingsExplorer: 'Pumili ng explorer:', //Choose an explorer:
     settingsLanguage: 'Pumili ng Wika:', //Choose a Language:

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -170,6 +170,7 @@ export const pt_br_translation = {
 
     // Settings
     settingsCurrency: 'Escolha uma moeda de exibição:', //Choose a display currency:
+    priceProvidedBy: '', //Price data provided by
     settingsDecimals: '', //Balance Decimals:
     settingsExplorer: 'Escolha um explorador:', //Choose an explorer:
     settingsLanguage: 'Escolha um Idioma:', //Choose a Language:

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -169,6 +169,7 @@ export const pt_pt_translation = {
 
     // Settings
     settingsCurrency: 'Escolha uma moeda de exibição:', //Choose a display currency:
+    priceProvidedBy: '', //Price data provided by
     settingsDecimals: '', //Balance Decimals:
     settingsExplorer: 'Escolha um explorador:', //Choose an explorer:
     settingsLanguage: 'Escolha um Idioma:', //Choose a Language:

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -176,6 +176,7 @@ var translation = {
 
     // Settings
     settingsCurrency: '', //Choose a display currency:
+    priceProvidedBy: '', //Price data provided by
     settingsDecimals: '', //Balance Decimals:
     settingsExplorer: '', //Choose an explorer:
     settingsLanguage: '', //Choose a Language:

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -173,6 +173,7 @@ export const uwu_translation = {
 
     // Settings
     settingsCurrency: 'Chowose a dispway cuwwency:', //Choose a display currency:
+    priceProvidedBy: 'Pwice data pwovided by', //Price data provided by
     settingsDecimals: 'Balance Decimawls:', //Balance Decimals:
     settingsExplorer: 'Chowose an expwower:', //Choose an explorer:
     settingsLanguage: 'Chowose a Languwuage:', //Choose a Language:

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -653,9 +653,11 @@ export function optimiseCurrencyLocale(nAmount) {
  * @param {HTMLElement} domValue
  * @param {boolean} fCold
  */
-export function updatePriceDisplay(domValue, fCold = false) {
+export async function updatePriceDisplay(domValue, fCold = false) {
     // Update currency values
-    cMarket.getPrice(strCurrency).then((nPrice) => {
+    const nPrice = await cMarket.getPrice(strCurrency);
+
+    if (nPrice) {
         // Calculate the value
         const nCurrencyValue =
             ((fCold ? getStakingBalance() : getBalance()) / COIN) * nPrice;
@@ -664,7 +666,7 @@ export function updatePriceDisplay(domValue, fCold = false) {
 
         // Update the DOM
         domValue.innerText = nValue.toLocaleString('en-gb', cLocale);
-    });
+    }
 }
 
 export function getBalance(updateGUI = false) {
@@ -1203,6 +1205,10 @@ export function toggleBottomMenu(dom, ani) {
 export async function updateAmountInputPair(domCoin, domValue, fCoinEdited) {
     // Fetch the price in the user's preferred currency
     const nPrice = await cMarket.getPrice(strCurrency);
+
+    // If there is no price loaded, then we just won't do anything
+    if (!nPrice) return;
+
     if (fCoinEdited) {
         // If the 'Coin' input is edited, then update the 'Value' input with it's converted currency
         const nValue = Number(domCoin.value) * nPrice;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -18,7 +18,7 @@ import {
 } from './wallet.js';
 import { cChainParams } from './chain_params.js';
 import { setNetwork, ExplorerNetwork, getNetwork } from './network.js';
-import { confirmPopup, createAlert } from './misc.js';
+import { confirmPopup, createAlert, isEmpty } from './misc.js';
 import {
     switchTranslation,
     ALERTS,
@@ -194,6 +194,7 @@ export async function start() {
         analytics: strSettingAnalytics,
         autoswitch,
         coldAddress,
+        displayCurrency,
         displayDecimals,
     } = await database.getSettings();
 
@@ -203,6 +204,9 @@ export async function start() {
     // Set any Toggles to their default or DB state
     fAutoSwitch = autoswitch;
     doms.domAutoSwitchToggle.checked = fAutoSwitch;
+
+    // Set the display currency
+    strCurrency = doms.domCurrencySelect.value = displayCurrency;
 
     // Set the display decimals
     nDisplayDecimals = displayDecimals;
@@ -361,16 +365,21 @@ async function fillTranslationSelect() {
  * Fills the display currency dropbox on the settings page
  */
 export async function fillCurrencySelect() {
-    while (doms.domCurrencySelect.options.length > 0) {
-        doms.domCurrencySelect.remove(0);
-    }
+    const arrCurrencies = await cMarket.getCurrencies();
 
-    // Add each data source currency into the UI selector
-    for (const currency of await cMarket.getCurrencies()) {
-        const opt = document.createElement('option');
-        opt.innerHTML = currency.toUpperCase();
-        opt.value = currency;
-        doms.domCurrencySelect.appendChild(opt);
+    // Only update if we have a currency list
+    if (!isEmpty(arrCurrencies)) {
+        while (doms.domCurrencySelect.options.length > 0) {
+            doms.domCurrencySelect.remove(0);
+        }
+
+        // Add each data source currency into the UI selector
+        for (const currency of arrCurrencies) {
+            const opt = document.createElement('option');
+            opt.innerHTML = currency.toUpperCase();
+            opt.value = currency;
+            doms.domCurrencySelect.appendChild(opt);
+        }
     }
 
     const database = await Database.getInstance();


### PR DESCRIPTION
## Abstract

This simple PR improves the stability of our CoinGecko integration:
- MPW now quietly catches any errors on data refreshes.
- MPW can still display the correct `Currency` even if CoinGecko is unavailable.
- MPW can fallback to in-memory cache, if CoinGecko suddenly goes unresponsive.

Previously, even a single CoinGecko call failing would still display a generic "Uncaught Network Error" for the user, CoinGecko calls sometimes randomly fail, so this was causing users that kept MPW open for long periods of time, to randomly return to errors on their app, this should be less now that CoinGecko errors are handled perfectly.

Additionally, the PR adds i18n'd CoinGecko attribution, which is required by their [documentation terms](https://www.coingecko.com/en/api/documentation).

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/b81e8c64-5b28-412f-a870-64df77ba90aa)

---

## Testing
This PR is fairly behind-the-scenes, so the best tests a user can do, is to simply check that their currency (USD, GBP, etc) is loading correctly, displaying correctly in all areas, and that the Settings show the currency options and CoinGecko attribution.

For folks that are confident in messing with the Browser Developer Console, however, you can follow this to thoroughly test the PR:
- Load up MPW as normal, login.
- Open the console, hit "Network".
- Find a "CoinGecko" request, and hit "Block URL" or similar depending on your browser.
- Once you've blocked CoinGecko's requests from MPW, watch for any errors, the GUI should **NOT** show any errors, and prices should continue displaying nicely from local cache, any CoinGecko errors will be silently placed in the Console Logs.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---