### PR TITLE
Improve Mnemonic handling + UX, Add Advanced Mode

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -780,7 +780,7 @@
                         <!-- IMPORT WALLET -->
                         <input class="hide-element" type="text" id="clipboard" />
                         <div id="importWallet" style="display: none;">
-                          <input type="password" class="textbox-opacity-trans" id="privateKey" placeholder="Seed Phrase, XPriv or WIF Private Key" oninput="MPW.onPrivateKeyChanged()" />
+                          <input type="password" class="textbox-opacity-trans" id="privateKey" placeholder="Seed Phrase, XPriv or WIF Private Key" oninput="MPW.guiUpdateImportInput()" />
                           <input hidden type="password" id="privateKeyPassword" placeholder="Password" />
                           <button class="pivx-button-big" onclick="MPW.guiImportWallet()">
                             <span class="buttoni-icon"><i class="fas fa-file-upload fa-tiny-margin"></i></span>
@@ -1184,14 +1184,24 @@
                       </div>
 
                       <!-- Default switch -->
-                      <div class="custom-control custom-switch" style="margin-bottom:15px;">
+                      <div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" id="debugToggler" onclick="MPW.toggleDebug()">
                         <label data-i18n="settingsToggleDebug" class="custom-control-label" for="debugToggler">Debug Mode</label>
                       </div>
 
+                      <br>
+
                       <div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" id="testnetToggler" onclick="MPW.toggleTestnet()">
                         <label data-i18n="settingsToggleTestnet" class="custom-control-label" for="testnetToggler">Testnet Mode</label>
+                      </div>
+
+                      <br>
+
+                      <div class="custom-control custom-switch">
+                        <input type="checkbox" class="custom-control-input" id="advancedModeToggler" onclick="MPW.toggleAdvancedMode()">
+                        <label data-i18n="settingsToggleAdvancedMode" class="custom-control-label" for="advancedModeToggler">Advanced Mode</label>
+                        <p style="opacity: 0.6; margin-top: 5px;"><i class="fa-solid fa-triangle-exclamation" style="margin-right: 5px;"></i><span data-i18n="settingsToggleAdvancedModeSubtext">This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!</p>
                       </div>
 
                     </div>

--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -62,8 +62,15 @@ export const de_translation = {
         'Jeder mit einer Kopie der Phrase hat Zugriff auf <b>deine Brieftasche</b>.', //Anyone with a copy of it can access <b>all</b> of your funds.
     doNotShare: 'Teile Sie unter keinen Umständen mit dritten.', //Do NOT share it with anybody.
     digitalStoreNotAdvised: 'Es wird empfohlen diese nicht digital zu sichern', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: 'Optionale Pass Phrase', //Optional Passphrase
+    optionalPassphrase: 'Optionale Pass Phrase (BIP39)', //Optional Passphrase (BIP39)
     writtenDown: 'Ich bestätige, dass ich die Seed Phrase notiert habe', //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: '', //Seed Phrase is valid!
+    importSeedError: '', //Seed Phrase is invalid!
+    importSeedErrorSize: '', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo: '', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip: '', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: 'Erste Schritte', //Getting Started
@@ -178,6 +185,8 @@ export const de_translation = {
     settingsAnalytics: 'Wähle die verwendeten Analysedaten dieser Sitzung', //Choose your analytics contribution level:
     settingsToggleDebug: 'Debug Modus', //Debug Mode
     settingsToggleTestnet: 'Testnet Modus', //Testnet Mode
+    settingsToggleAdvancedMode: '', //Advanced Mode
+    settingsToggleAdvancedModeSubtext: '', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Transparency Report
     transparencyReport: 'Transparenz-Bericht', //Transparency Report

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -59,8 +59,17 @@ export const en_translation = {
         'Anyone with a copy of it can access <b>all</b> of your funds.', //
     doNotShare: 'Do NOT share it with anyone.', //
     digitalStoreNotAdvised: 'It is <b>NOT</b> advised to store this digitally.', //
-    optionalPassphrase: 'Optional Passphrase', //
+    optionalPassphrase: 'Optional Passphrase (BIP39)', //
     writtenDown: 'I have written down my seed phrase', //
+
+    // Seed Phrase Import
+    importSeedValid: 'Seed Phrase is valid!', //
+    importSeedError: 'Seed Phrase is invalid!', //
+    importSeedErrorSize: 'A Seed Phrase should be 12 or 24 words long!', //
+    importSeedErrorTypo:
+        'Seed Phrase contains typing errors! Check your input carefully', //
+    importSeedErrorSkip:
+        'Seed Phrase appears invalid, but the warning was skipped by the user', //
 
     // Wallet Dashboard
     gettingStarted: 'Getting Started', //
@@ -179,6 +188,9 @@ export const en_translation = {
     settingsAnalytics: 'Choose your analytics contribution level:', //
     settingsToggleDebug: 'Debug Mode', //
     settingsToggleTestnet: 'Testnet Mode', //
+    settingsToggleAdvancedMode: 'Advanced Mode', //
+    settingsToggleAdvancedModeSubtext:
+        'This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!', //
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: "Your {network} wallet isn't saved!", //

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -62,8 +62,15 @@ export const fr_translation = {
     doNotShare: 'Ne le partagez avec personne.', //Do NOT share it with anybody.
     digitalStoreNotAdvised:
         '<b>NON</b> il est conseillé de les stocker sous forme numérique.', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: 'Phrase mot de passe Facultatif', //Optional Passphrase
+    optionalPassphrase: 'Phrase mot de passe Facultatif (BIP39)', //Optional Passphrase
     writtenDown: "J'ai écrit ma phrase d'introduction", //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: '', //Seed Phrase is valid!
+    importSeedError: '', //Seed Phrase is invalid!
+    importSeedErrorSize: '', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo: '', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip: '', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: 'Démarrer', //Getting Started
@@ -178,6 +185,8 @@ export const fr_translation = {
     settingsAnalytics: "Choisissez votre niveau d'analyse :", //Choose your analytics contribution level:
     settingsToggleDebug: 'Mode de débogage', //Debug Mode
     settingsToggleTestnet: 'Mode testnet', //Testnet Mode
+    settingsToggleAdvancedMode: '', //Advanced Mode
+    settingsToggleAdvancedModeSubtext: '', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: '', //Your {network} wallet isn\'t saved!

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -63,8 +63,15 @@ export const ph_translation = {
     doNotShare: 'WAG mo itong ibibigay kahit kanino', //Do NOT share it with anybody.
     digitalStoreNotAdvised:
         'Ito ay <b>HINDI</b> payo upang itago ito digitally', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: 'Optional Passphrase', //Optional Passphrase
+    optionalPassphrase: 'Optional Passphrase (BIP39)', //Optional Passphrase
     writtenDown: 'Isinulat ko na ang aking seed phrase', //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: '', //Seed Phrase is valid!
+    importSeedError: '', //Seed Phrase is invalid!
+    importSeedErrorSize: '', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo: '', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip: '', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: 'Magsimula', //Getting Started
@@ -179,6 +186,8 @@ export const ph_translation = {
     settingsAnalytics: 'Pumili ng iyong analytics contribution level:', //Choose your analytics contribution level:
     settingsToggleDebug: 'Debug Mode', //Debug Mode
     settingsToggleTestnet: 'Testnet Mode', //Testnet Mode
+    settingsToggleAdvancedMode: '', //Advanced Mode
+    settingsToggleAdvancedModeSubtext: '', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: '', //Your {network} wallet isn\'t saved!

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -62,8 +62,15 @@ export const pt_br_translation = {
     doNotShare: 'NÃO a compartilhe com ninguém.', //Do NOT share it with anybody.
     digitalStoreNotAdvised:
         '<b>NÃO</b> é aconselhável armazená-la digitalmente.', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: 'Frasse-Passe Opcional', //Optional Passphrase
+    optionalPassphrase: 'Frasse-Passe Opcional (BIP39)', //Optional Passphrase
     writtenDown: 'Eu escrevi a minha Seed Phrase', //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: '', //Seed Phrase is valid!
+    importSeedError: '', //Seed Phrase is invalid!
+    importSeedErrorSize: '', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo: '', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip: '', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: 'Começar', //Getting Started
@@ -179,6 +186,8 @@ export const pt_br_translation = {
     settingsAnalytics: 'Escolha o seu nível de contribuição analítica:', //Choose your analytics contribution level:
     settingsToggleDebug: 'Modo de depuração', //Debug Mode
     settingsToggleTestnet: 'Modo Testnet', //Testnet Mode
+    settingsToggleAdvancedMode: '', //Advanced Mode
+    settingsToggleAdvancedModeSubtext: '', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: '', //Your {network} wallet isn\'t saved!

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -61,8 +61,15 @@ export const pt_pt_translation = {
     doNotShare: 'NÃO a compartilhe com ninguém.', //Do NOT share it with anybody.
     digitalStoreNotAdvised:
         '<b>NÃO</b> é aconselhável armazená-lo digitalmente.', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: 'Frase Senha Opcional', //Optional Passphrase
+    optionalPassphrase: 'Frase Senha Opcional (BIP39)', //Optional Passphrase
     writtenDown: 'Eu escrevi a minha frase-inicial', //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: '', //Seed Phrase is valid!
+    importSeedError: '', //Seed Phrase is invalid!
+    importSeedErrorSize: '', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo: '', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip: '', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: 'A Começar', //Getting Started
@@ -178,6 +185,8 @@ export const pt_pt_translation = {
     settingsAnalytics: 'Escolha o seu nível de contribuição analítica:', //Choose your analytics contribution level:
     settingsToggleDebug: 'Modo de depuração', //Debug Mode
     settingsToggleTestnet: 'Modo Testnet', //Testnet Mode
+    settingsToggleAdvancedMode: '', //Advanced Mode
+    settingsToggleAdvancedModeSubtext: '', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: '', //Your {network} wallet isn\'t saved!

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -74,8 +74,15 @@ var translation = {
     doNotShareWarning: '', //Anyone with a copy of it can access <b>all</b> of your funds.
     doNotShare: '', //Do NOT share it with anybody.
     digitalStoreNotAdvised: '', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: '', //Optional Passphrase
+    optionalPassphrase: '', //Optional Passphrase (BIP39)
     writtenDown: '', //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: '', //Seed Phrase is valid!
+    importSeedError: '', //Seed Phrase is invalid!
+    importSeedErrorSize: '', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo: '', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip: '', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: '', //Getting Started
@@ -185,6 +192,8 @@ var translation = {
     settingsAnalytics: '', //Choose your analytics contribution level:
     settingsToggleDebug: '', //Debug Mode
     settingsToggleTestnet: '', //Testnet Mode
+    settingsToggleAdvancedMode: '', //Advanced Mode
+    settingsToggleAdvancedModeSubtext: '', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: '', //Your {network} wallet isn\'t saved!

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -61,8 +61,17 @@ export const uwu_translation = {
     doNotShare: 'Do NOT share it with anyuwu.', //Do NOT share it with anybody.
     digitalStoreNotAdvised:
         'It is <b>NAWT</b> advised to store this digitally.', //It is <b>NOT</b> advised to store this digitally.
-    optionalPassphrase: 'Optional Passphwase', //Optional Passphrase
+    optionalPassphrase: 'Optional Passphwase (BIP39)', //Optional Passphrase
     writtenDown: 'I haz written down my seed phrase', //I have written down my seed phrase
+
+    // Seed Phrase Import
+    importSeedValid: 'Seed Phwase iz valid!', //Seed Phrase is valid!
+    importSeedError: 'Seed Phwase iz invalid!', //Seed Phrase is invalid!
+    importSeedErrorSize: 'A Seed Phwase shwould be 12 or 24 words long!', //A Seed Phrase should be 12 or 24 words long!
+    importSeedErrorTypo:
+        'Seed Phwase contains typing ewrrors! Check ur input carefully', //Seed Phrase contains typing errors! Check your input carefully
+    importSeedErrorSkip:
+        'Seed Phwase appears invalid, but da warning was skipped by da user', //Seed Phrase appears invalid, but the warning was skipped by the user
 
     // Wallet Dashboard
     gettingStarted: 'Getting Stwarted', //Getting Started
@@ -182,6 +191,9 @@ export const uwu_translation = {
     settingsAutoSelectNet: 'Auto-select Expwowers and Nowodes', // Auto-select Explorers and Nodes
     settingsToggleDebug: 'Debug Mowode', //Debug Mode
     settingsToggleTestnet: 'Testnet Mowode', //Testnet Mode
+    settingsToggleAdvancedMode: 'Advwanced Mowode', //Advanced Mode
+    settingsToggleAdvancedModeSubtext:
+        'Dis unlocks deeper fwunctionality and cuwustomisatwion, but may be oveuhwhelming and potentially dangerwus for unexperienced bakas!', //This unlocks deeper functionality and customisation, but may be overwhelming and potentially dangerous for unexperienced users!
 
     // Network switching (mainnet <---> testnet)
     netSwitchUnsavedWarningTitle: "Ur {network} wawwet isn't saved!", //Your {network} wallet isn\'t saved!

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -22,6 +22,7 @@ import {
     setColdStakingAddress,
     strColdStakingAddress,
     nDisplayDecimals,
+    fAdvancedMode,
 } from './settings.js';
 import { createAndSendTransaction, signTransaction } from './transactions.js';
 import {
@@ -319,6 +320,7 @@ export async function start() {
         domVersion: document.getElementById('version'),
         domFlipdown: document.getElementById('flipdown'),
         domTestnetToggler: document.getElementById('testnetToggler'),
+        domAdvancedModeToggler: document.getElementById('advancedModeToggler'),
     };
     await i18nStart();
     await loadImages();
@@ -1529,15 +1531,19 @@ export async function accessOrImportWallet() {
  *
  * Useful for adjusting the input types or displaying password prompts depending on the import scheme
  */
-export async function onPrivateKeyChanged() {
+export async function guiUpdateImportInput() {
     if (await hasEncryptedWallet()) return;
     // Check whether the string is Base64 (would likely be an MPW-encrypted import)
     // and it doesn't have any spaces (would be a mnemonic seed)
-    const fContainsSpaces = doms.domPrivKey.value.includes(' ');
+    const fContainsSpaces = doms.domPrivKey.value.trim().includes(' ');
+
+    // If this could require a Seed Passphrase (BIP39 Passphrase) and Advanced Mode is enabled
+    // ...or if this is an Encrypted Import (Encrypted Base64 MPW key)
+    const fBIP39Passphrase = fContainsSpaces && fAdvancedMode;
     doms.domPrivKeyPassword.hidden =
         (doms.domPrivKey.value.length < 128 ||
             !isBase64(doms.domPrivKey.value)) &&
-        !fContainsSpaces;
+        !fBIP39Passphrase;
 
     doms.domPrivKeyPassword.placeholder = fContainsSpaces
         ? translation.optionalPassphrase

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1548,6 +1548,11 @@ export async function guiUpdateImportInput() {
     doms.domPrivKeyPassword.placeholder = fContainsSpaces
         ? translation.optionalPassphrase
         : translation.password;
+
+    // If the "Import Password/Passphrase" is hidden, we'll also wipe it's input, in the
+    // ... edge-case that a passphrase was entered, then the import key had changed.
+    if (doms.domPrivKeyPassword.hidden) doms.domPrivKeyPassword.value = '';
+
     // Uncloak the private input IF spaces are detected, to make Seed Phrases easier to input and verify
     doms.domPrivKey.setAttribute('type', fContainsSpaces ? 'text' : 'password');
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -19,7 +19,7 @@ export {
     accessOrImportWallet,
     guiImportWallet,
     guiSetColdStakingAddress,
-    onPrivateKeyChanged,
+    guiUpdateImportInput,
     toClipboard,
     toggleExportUI,
     wipePrivateData,
@@ -46,7 +46,12 @@ export {
     govVote,
 } from './global.js';
 export { generateWallet, getNewAddress, importWallet } from './wallet.js';
-export { toggleTestnet, toggleDebug, toggleAutoSwitch } from './settings.js';
+export {
+    toggleTestnet,
+    toggleDebug,
+    toggleAutoSwitch,
+    toggleAdvancedMode,
+} from './settings.js';
 export {
     createTxGUI,
     undelegateGUI,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -2,6 +2,7 @@ import {
     doms,
     getBalance,
     getStakingBalance,
+    guiUpdateImportInput,
     mempool,
     refreshChainData,
     renderActivityGUI,
@@ -52,6 +53,8 @@ export let fAutoSwitch = true;
 export let strColdStakingAddress = 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy';
 /** The decimals to display for the wallet balance */
 export let nDisplayDecimals = 2;
+/** A mode which configures MPW towards Advanced users, with low-level feature access and less restrictions (Potentially dangerous) */
+export let fAdvancedMode = false;
 
 let transparencyReport;
 
@@ -88,6 +91,10 @@ export class Settings {
      * @type {number} The decimals to display for the wallet balance
      */
     displayDecimals;
+    /**
+     * @type {Boolean} Whether Advanced Mode is enabled or disabled
+     */
+    advancedMode;
     constructor({
         analytics,
         explorer,
@@ -97,6 +104,7 @@ export class Settings {
         translation = '',
         displayCurrency = 'usd',
         displayDecimals = nDisplayDecimals,
+        advancedMode = false,
     } = {}) {
         this.analytics = analytics;
         this.explorer = explorer;
@@ -106,6 +114,7 @@ export class Settings {
         this.translation = translation;
         this.displayCurrency = displayCurrency;
         this.displayDecimals = displayDecimals;
+        this.advancedMode = advancedMode;
     }
 }
 
@@ -196,14 +205,21 @@ export async function start() {
         coldAddress,
         displayCurrency,
         displayDecimals,
+        advancedMode,
     } = await database.getSettings();
 
     // Set the Cold Staking address
     strColdStakingAddress = coldAddress;
 
     // Set any Toggles to their default or DB state
+    // Network Auto-Switch
     fAutoSwitch = autoswitch;
     doms.domAutoSwitchToggle.checked = fAutoSwitch;
+
+    // Advanced Mode
+    fAdvancedMode = advancedMode;
+    doms.domAdvancedModeToggler.checked = fAdvancedMode;
+    await configureAdvancedMode();
 
     // Set the display currency
     strCurrency = doms.domCurrencySelect.value = displayCurrency;
@@ -619,4 +635,29 @@ async function fillNodeSelect() {
 
     // And update the UI to reflect them
     doms.domNodeSelect.value = cNode.url;
+}
+
+/**
+ * Toggle Advanced Mode at runtime and in DB
+ */
+export async function toggleAdvancedMode() {
+    fAdvancedMode = !fAdvancedMode;
+
+    // Configure the app accordingly
+    await configureAdvancedMode();
+
+    // Update the setting in the DB
+    const database = await Database.getInstance();
+    await database.setSettings({ advancedMode: fAdvancedMode });
+}
+
+/**
+ * Configure the app functionality and UI for the current mode
+ */
+async function configureAdvancedMode() {
+    // Re-render the Import Input UI
+    await guiUpdateImportInput();
+
+    // Hide or Show the "Mnemonic Passphrase" in the Seed Creation modal
+    doms.domMnemonicModalPassphrase.hidden = !fAdvancedMode;
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -92,7 +92,7 @@ export class Settings {
      */
     displayDecimals;
     /**
-     * @type {Boolean} Whether Advanced Mode is enabled or disabled
+     * @type {boolean} Whether Advanced Mode is enabled or disabled
      */
     advancedMode;
     constructor({

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -658,6 +658,7 @@ async function configureAdvancedMode() {
     // Re-render the Import Input UI
     await guiUpdateImportInput();
 
-    // Hide or Show the "Mnemonic Passphrase" in the Seed Creation modal
+    // Hide or Show the "Mnemonic Passphrase" in the Seed Creation modal, and reset it's input
+    doms.domMnemonicModalPassphrase.value = '';
     doms.domMnemonicModalPassphrase.hidden = !fAdvancedMode;
 }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -38,6 +38,7 @@ import * as jdenticon from 'jdenticon';
 import { Database } from './database.js';
 import { guiRenderCurrentReceiveModal } from './contacts-book.js';
 import { Account } from './accounts.js';
+import { debug, fAdvancedMode } from './settings.js';
 
 export let fWalletLoaded = false;
 
@@ -657,39 +658,57 @@ export async function importWallet({
             doms.domPrivKey.value = '';
             doms.domPrivKeyPassword.value = '';
 
-            if (await verifyMnemonic(privateImportValue)) {
-                // Generate our masterkey via Mnemonic Phrase
+            // Clean and verify the Seed Phrase (if one exists)
+            const cPhraseValidator = await cleanAndVerifySeedPhrase(
+                privateImportValue,
+                true
+            );
+
+            // If Debugging is enabled, show what the validator returned
+            if (debug) {
+                const fnLog = cPhraseValidator.ok ? console.log : console.warn;
+                fnLog('Seed Import Validator: ' + cPhraseValidator.msg);
+            }
+
+            // If the Seed is OK, proceed
+            if (cPhraseValidator.ok) {
+                // Generate our HD MasterKey with the cleaned (Mnemonic) Seed Phrase
                 const seed = await mnemonicToSeed(
-                    privateImportValue,
+                    cPhraseValidator.phrase,
                     passphrase
                 );
                 await setMasterKey(new HdMasterKey({ seed }));
+            } else if (cPhraseValidator.phrase.includes(' ')) {
+                // The Phrase Validator failed, but the input contains at least one space; possibly a Seed Typo?
+                return createAlert('warning', cPhraseValidator.msg, 5000);
             } else {
-                // Public Key Derivation
+                // The input definitely isn't a seed, so we'll try every other import method
                 try {
+                    // XPub import (HD view only)
                     if (isXPub(privateImportValue)) {
                         await setMasterKey(
                             new HdMasterKey({
                                 xpub: privateImportValue,
                             })
                         );
+                        // XPrv import (HD full access)
                     } else if (privateImportValue.startsWith('xprv')) {
                         await setMasterKey(
                             new HdMasterKey({
                                 xpriv: privateImportValue,
                             })
                         );
+                        // Pubkey import (non-HD view only)
                     } else if (isStandardAddress(privateImportValue)) {
                         await setMasterKey(
                             new LegacyMasterKey({
                                 address: privateImportValue,
                             })
                         );
+                        // WIF import (non-HD full access)
                     } else {
-                        // Lastly, attempt to parse as a WIF private key
+                        // Attempt to import a raw WIF private key
                         const pkBytes = parseWIF(privateImportValue);
-
-                        // Import the raw private key
                         await setMasterKey(new LegacyMasterKey({ pkBytes }));
                     }
                 } catch (e) {
@@ -813,37 +832,79 @@ export async function generateWallet(noUI = false) {
     return masterKey;
 }
 
-export async function verifyMnemonic(strMnemonic = '', fPopupConfirm = true) {
-    const nWordCount = strMnemonic.trim().split(/\s+/g).length;
+export async function cleanAndVerifySeedPhrase(
+    strPhraseInput = '',
+    fPopupConfirm = true
+) {
+    // Clean the phrase (removing unnecessary spaces) and force to lowercase
+    const strPhrase = strPhraseInput.trim().replace(/\s+/g, ' ').toLowerCase();
 
-    // Sanity check: Convert to lowercase
-    strMnemonic = strMnemonic.toLowerCase();
+    // Count the Words
+    const nWordCount = strPhrase.trim().split(' ').length;
 
     // Ensure it's a word count that makes sense
-    if (nWordCount >= 12 && nWordCount <= 24) {
-        if (!validateMnemonic(strMnemonic)) {
+    if (nWordCount === 12 || nWordCount === 24) {
+        if (!validateMnemonic(strPhrase)) {
+            // If a popup is allowed and Advanced Mode is enabled, warn the user that the
+            // ... seed phrase is potentially bad, and ask for confirmation to proceed
+            if (!fPopupConfirm || !fAdvancedMode)
+                return {
+                    ok: false,
+                    msg: translation.importSeedErrorTypo,
+                    phrase: strPhrase,
+                };
+
             // The reason we want to ask the user for confirmation is that the mnemonic
-            // Could have been generated with another app that has a different dictionary
-            return (
-                fPopupConfirm &&
-                (await confirmPopup({
-                    title: translation.popupSeedPhraseBad,
-                    html: translation.popupSeedPhraseBadNote,
-                }))
-            );
+            // could have been generated with another app that has a different dictionary
+            const fSkipWarning = await confirmPopup({
+                title: translation.popupSeedPhraseBad,
+                html: translation.popupSeedPhraseBadNote,
+            });
+
+            if (fSkipWarning) {
+                // User is probably an Arch Linux user and used `-f`
+                return {
+                    ok: true,
+                    msg: translation.importSeedErrorSkip,
+                    phrase: strPhrase,
+                };
+            } else {
+                // User heeded the warning and rejected the phrase
+                return {
+                    ok: false,
+                    msg: translation.importSeedError,
+                    phrase: strPhrase,
+                };
+            }
         } else {
             // Valid count and mnemonic
-            return true;
+            return {
+                ok: true,
+                msg: translation.importSeedValid,
+                phrase: strPhrase,
+            };
         }
     } else {
         // Invalid count
-        return false;
+        return {
+            ok: false,
+            msg: translation.importSeedErrorSize,
+            phrase: strPhrase,
+        };
     }
 }
 
+/**
+ * Display a Seed Phrase popup to the user and optionally wait for a Seed Passphrase
+ * @param {String} mnemonic - The Seed Phrase to display to the user
+ * @returns {Promise<String>} - The Mnemonic Passphrase (empty string if omitted by user)
+ */
 function informUserOfMnemonic(mnemonic) {
     return new Promise((res, _) => {
+        // Configure the modal
         $('#mnemonicModal').modal({ keyboard: false });
+
+        // Render the Seed Phrase and configure the button
         doms.domMnemonicModalContent.innerText = mnemonic;
         doms.domMnemonicModalButton.onclick = () => {
             res(doms.domMnemonicModalPassphrase.value);
@@ -853,6 +914,8 @@ function informUserOfMnemonic(mnemonic) {
             doms.domMnemonicModalContent.innerText = '';
             doms.domMnemonicModalPassphrase.value = '';
         };
+
+        // Display the modal
         $('#mnemonicModal').modal('show');
     });
 }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -903,7 +903,7 @@ export async function cleanAndVerifySeedPhrase(
 
 /**
  * Display a Seed Phrase popup to the user and optionally wait for a Seed Passphrase
- * @param {String} mnemonic - The Seed Phrase to display to the user
+ * @param {string} mnemonic - The Seed Phrase to display to the user
  * @returns {Promise<String>} - The Mnemonic Passphrase (empty string if omitted by user)
  */
 function informUserOfMnemonic(mnemonic) {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -904,7 +904,7 @@ export async function cleanAndVerifySeedPhrase(
 /**
  * Display a Seed Phrase popup to the user and optionally wait for a Seed Passphrase
  * @param {string} mnemonic - The Seed Phrase to display to the user
- * @returns {Promise<String>} - The Mnemonic Passphrase (empty string if omitted by user)
+ * @returns {Promise<string>} - The Mnemonic Passphrase (empty string if omitted by user)
  */
 function informUserOfMnemonic(mnemonic) {
     return new Promise((res, _) => {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -832,6 +832,13 @@ export async function generateWallet(noUI = false) {
     return masterKey;
 }
 
+/**
+ * Clean a Seed Phrase string and verify it's integrity
+ *
+ * This returns an object of the validation status and the cleaned Seed Phrase for safe low-level usage.
+ * @param {String} strPhraseInput - The Seed Phrase string
+ * @param {Boolean} fPopupConfirm - Allow a warning bypass popup if the Seed Phrase is unusual
+ */
 export async function cleanAndVerifySeedPhrase(
     strPhraseInput = '',
     fPopupConfirm = true


### PR DESCRIPTION
## Abstract

This PR largely improves Seed Phrase UX, by:
- Simplifying the Creation and Import flows (Resolves #117).
- Improving validation robustness (whitespace handling, less generic errors).

The UX is simplified by removing the below functionality, outside of "Advanced Mode":
- Hiding the "Optional Passphrase (BIP39)" from the New Wallet 'wizard'.
- Hiding the "Optional Passphrase (BIP39)" from the "Import Wallet" flow.
- Removing the "Are you sure?" popup on typo'd seeds, strictly denying their import.

"Advanced Mode" is an off-by-default, session persisted mode in which MPW's functionality is simplified, to improve the experience for less knowledgeable users that are prone to losing funds from accidental mistakes, such as mixing up BIP39 Passphrases with their MPW Password, hitting "Confirm" when MPW warns of Seed Phrase typos, etc.

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/f84d451f-ea95-4526-a138-a954cd149dc8)

In future PRs, Advanced Mode will be leveraged to also hide features such as "VanityGen", and any other non-primary features of MPW, to simplify the app as much as possible for the average user.

This feature allows for both New and Advanced users to benefit from MPW, without any drawbacks, both communities can eat their cake, rather than removing "complex" features in the name of simplicity, but denying advanced users their tools.

---

## Testing
This PR can be tested in various ways, I'll outline a bunch of them below, each with their own "testing flow", feel free to try variations of these to maximise our testing reach!

**1: Test Creating a new wallet in Normal and Advanced mode**
- (Optional) visit **Settings** and enable "Advanced Mode" in the Wallet options.
- Visit **Dashboard** and Create a New Wallet.
- - If "Advanced Mode" is enabled, you'll see "Optional Passphrase" reveal itself.
- - If "Advanced Mode" is disabled, you should **not** see the "Optional Passphrase".

**2: Test importing a Seed Phrase in various ways, in Normal or Advanced Mode**
- (Optional) visit **Settings** and enable "Advanced Mode" in the Wallet options.
- Visit **Dashboard** and then "Access Wallet".
- - If "Advanced Mode" is enabled, when typing your Seed Phrase, you'll see the "Optional Passphrase" reveal itself.
- - If "Advanced Mode" is disabled, when typing your Seed Phrase, you should **not** see the "Optional Passphrase".

Now, try importing it in various ways, such as:
- - Import it as normal (all should go well).
- - Import it with a typo (with Advanced Mode, it will show a "confirm" popup, in Normal Mode, it will reject the typo entirely).
- - Import it with excess spaces at the start, end, or between existing words. (It should ignore the spaces, and if they break the words, it will reject the import).

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---