### PR TITLE
Clarify Dashboard Send/Receive flows

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -2471,19 +2471,7 @@ input {
   outline-color: rgb(180, 180, 180);
 }
 
-.dcWallet-sWithdraw {
-    background-color: #ffffff29;
-    width: 50px;
-    height: 50px;
-    padding-top: 13px;
-    border-radius: 50%;
-    border-top-left-radius: 7px;
-    border-bottom-right-radius: 7px;
-    background-image: linear-gradient(183deg, #9621ff, #7d21ff);
-    cursor:pointer;
-}
-
-.dcWallet-stake {
+.dcWallet-btn-left {
     background-color: #ffffff29;
     width: 100px;
     height: 43px;
@@ -2496,7 +2484,7 @@ input {
     cursor: pointer;
 }
 
-.dcWallet-unstake {
+.dcWallet-btn-right {
     background-color: #ffffff29;
     width: 100px;
     height: 43px;
@@ -2508,19 +2496,6 @@ input {
     background-image: linear-gradient(183deg, #9621ff, #7d21ff);
     cursor:pointer;
 }
-
-.dcWallet-sDeposit {
-    background-color: #ffffff29;
-    width: 50px;
-    height: 50px;
-    padding-top: 13px;
-    border-radius: 50%;
-    border-top-right-radius: 7px;
-    border-bottom-left-radius: 7px;
-    background-image: linear-gradient(183deg, #9621ff, #7d21ff);
-    cursor:pointer;
-}
-
 
 
 .blackBack {
@@ -2560,8 +2535,9 @@ input {
     }
 }
 
-.transferMenu .transferHeader .transferExit {
-    cursor:pointer;
+.transferExit {
+    position: absolute;
+    right: 15px;
 }
 
 .transferAnimation {

--- a/index.template.html
+++ b/index.template.html
@@ -502,14 +502,14 @@
 
                             <div class="row lessTop p-0">
                               <div class="col-6 d-flex" style="justify-content: flex-start;">
-                                <div class="dcWallet-sWithdraw" onclick="MPW.toggleBottomMenu('transferMenu', 'transferAnimation')">
-                                  <i class="fas fa-arrow-up"></i>  
+                                <div class="dcWallet-btn-left" data-i18n="send" onclick="MPW.toggleBottomMenu('transferMenu', 'transferAnimation')">
+                                  Send
                                 </div>
                               </div>
 
                               <div class="col-6 d-flex" style="justify-content: flex-end;">
-                                <div class="dcWallet-sDeposit" onclick="MPW.guiRenderCurrentReceiveModal()" data-toggle="modal" data-target="#qrModal">
-                                  <i class="fas fa-arrow-down"></i>  
+                                <div class="dcWallet-btn-right" data-i18n="receive" onclick="MPW.guiRenderCurrentReceiveModal()" data-toggle="modal" data-target="#qrModal">
+                                  Receive
                                 </div>
                               </div>
                             </div>
@@ -565,9 +565,8 @@
                     <!-- // Export Private Keys Modal -->
 
                     <div id="transferMenu" class="exportKeysModalColor transferMenu transferAnimation">
-                      <div class="transferHeader">
-                        <div data-i18n="transfer" class="transferHeaderText">Transfer</div>
-                        <div class="transferExit" onclick="MPW.toggleBottomMenu('transferMenu', 'transferAnimation')"><i class="fa-solid fa-xmark"></i></div>
+                      <div style="padding-top: 5px;">
+                        <div class="transferExit ptr" onclick="MPW.toggleBottomMenu('transferMenu', 'transferAnimation')"><i class="fa-solid fa-xmark"></i></div>
                       </div>
     
                       <div class="transferBody">
@@ -846,13 +845,13 @@
 
                         <div class="row lessTop p-0">
                           <div class="col-6 d-flex" style="justify-content: flex-start;">
-                            <div data-i18n="stake" class="dcWallet-stake" onclick="MPW.toggleBottomMenu('stakingDelegate', 'transferAnimation')">
+                            <div data-i18n="stake" class="dcWallet-btn-left" onclick="MPW.toggleBottomMenu('stakingDelegate', 'transferAnimation')">
                               Stake
                             </div>
                           </div>
 
                           <div class="col-6 d-flex" style="justify-content: flex-end;">
-                            <div data-i18n="stakeUnstake" class="dcWallet-unstake" onclick="MPW.toggleBottomMenu('stakingUndelegate', 'transferAnimation')">
+                            <div data-i18n="stakeUnstake" class="dcWallet-btn-right" onclick="MPW.toggleBottomMenu('stakingUndelegate', 'transferAnimation')">
                               Unstake  
                             </div>
                           </div>
@@ -879,8 +878,8 @@
 
                 <div id="stakingUndelegate" class="exportKeysModalColor transferMenu transferAnimation">
                   <div class="transferHeader">
-                    <div data-i18n="stakeUnstake" class="transferHeaderText">Unstake</div>
-                    <div class="transferExit" onclick="MPW.toggleBottomMenu('stakingUndelegate', 'transferAnimation')"><i class="fa-solid fa-xmark"></i></div>
+                    <div data-i18n="stakeUnstake" class="sendHeaderText">Unstake</div>
+                    <div class="transferExit ptr" onclick="MPW.toggleBottomMenu('stakingUndelegate', 'transferAnimation')"><i class="fa-solid fa-xmark"></i></div>
                   </div>
 
                   <div class="transferBody">
@@ -923,8 +922,8 @@
 
                 <div id="stakingDelegate" class="exportKeysModalColor transferMenu transferAnimation">
                   <div class="transferHeader">
-                    <div data-i18n="stake" class="transferHeaderText">Stake</div>
-                    <div class="transferExit" onclick="MPW.toggleBottomMenu('stakingDelegate', 'transferAnimation')"><i class="fa-solid fa-xmark"></i></div>
+                    <div data-i18n="stake" class="sendHeaderText">Stake</div>
+                    <div class="transferExit ptr" onclick="MPW.toggleBottomMenu('stakingDelegate', 'transferAnimation')"><i class="fa-solid fa-xmark"></i></div>
                   </div>
 
                   <div class="transferBody">

--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -87,7 +87,6 @@ export const de_translation = {
     redeemOrCreateCode: 'Erstelle Codes, oder löse Codes ein', //Redeem or Create Code
 
     // Send
-    transfer: 'Verschicken', //Transfer
     address: 'Adresse', //Address
     receivingAddress: 'Empfänger Adresse', //Receiving address
     sendAmountCoinsMax: 'Maximal', //MAX

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -84,7 +84,6 @@ export const en_translation = {
     redeemOrCreateCode: 'Redeem or Create Code', //
 
     // Send
-    transfer: 'Transfer', //
     address: 'Address', //
     receivingAddress: 'Receiving address', //
     sendAmountCoinsMax: 'MAX', //

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -87,7 +87,6 @@ export const fr_translation = {
     redeemOrCreateCode: 'Remplacer ou créer un code', //Redeem or Create Code
 
     // Send
-    transfer: 'Télécharger', //Transfer
     address: 'Adresse', //Address
     receivingAddress: 'Adresse de réception', //Receiving address
     sendAmountCoinsMax: 'Maximum', //MAX

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -88,7 +88,6 @@ export const ph_translation = {
     redeemOrCreateCode: 'I-redeem o Gumawa ng Code', //Redeem or Create Code
 
     // Send
-    transfer: 'Ilipat', //Transfer
     address: 'Address', //Address
     receivingAddress: 'Address ng tatangap', //Receiving address
     sendAmountCoinsMax: 'MAX', //MAX

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -87,7 +87,6 @@ export const pt_br_translation = {
     redeemOrCreateCode: 'Resgatar ou Criar Código', //Redeem or Create Code
 
     // Send
-    transfer: 'Transferir', //Transfer
     address: 'Endereço', //Address
     receivingAddress: 'Endereço de recepção', //Receiving address
     sendAmountCoinsMax: 'Máximo', //MAX

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -86,7 +86,6 @@ export const pt_pt_translation = {
     redeemOrCreateCode: 'Resgatar ou Criar Código', //Redeem or Create Code
 
     // Send
-    transfer: 'Transferir', //Transfer
     address: 'Endereço', //Address
     receivingAddress: 'Endereço de recepção', //Receiving address
     sendAmountCoinsMax: 'Máximo', //MAX

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -99,7 +99,6 @@ var translation = {
     redeemOrCreateCode: '', //Redeem or Create Code
 
     // Send
-    transfer: '', //Transfer
     address: '', //Address
     receivingAddress: '', //Receiving address
     sendAmountCoinsMax: '', //MAX

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -86,7 +86,6 @@ export const uwu_translation = {
     redeemOrCreateCode: 'Redeem or Cweate Cowode', //Redeem or Create Code
 
     // Send
-    transfer: 'Twansfer', //Transfer
     address: 'Addwess', //Address
     receivingAddress: 'Receivwing addwess', //Receiving address
     sendAmountCoinsMax: 'MAX♡', //MAX


### PR DESCRIPTION
## Abstract

This PR simply clarifies the "Send" and "Receive" flows by swapping out the icon buttons for i18n-supported text buttons.

Additionally, the "Transfer" title was removed from the Send dialog, since it used unnecessary space and was written ambiguously, this also drops a key from the i18n system, so slightly less work for the translation teams!

### New Buttons
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/18ada439-756d-4e89-a213-454e7ccfc6f7)

### New Send Menu
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/752f40f0-ed77-46f0-b1e0-975d46422650)

This PR closes #165

---

## Testing
This PR is nice and simple:
- Login.
- Ensure the "Send" and "Receive" buttons are text-based and adjust to each language.
- Check the "Send", "Stake" and "Unstake" menus on many devices and browsers, ensuring the new design tweaks look good universally.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---