### PR TITLE
Track Stake inputs for post-stake invalidation

### DIFF
--- a/scripts/network.js
+++ b/scripts/network.js
@@ -322,6 +322,7 @@ export class ExplorerNetwork extends Network {
             path,
             sats: Math.round(cVout.value * COIN),
             script: cVout.scriptPubKey.hex,
+            vin: cTx?.vin || [],
             vout: cVout.n,
             height: this.cachedBlockCount - (cTx.confirmations - 1),
             status: cTx.confirmations < 1 ? Mempool.PENDING : Mempool.CONFIRMED,


### PR DESCRIPTION
## Abstract

This PR fixes a bug in which Stakes earned, while MPW was open, would cause the user's balance (or more accurately, the specific Staked UTXO) to "duplicate", for ex: a 1,000 PIV `vin` hitting a Stake would result in a new balance of 2,000 PIV.

This bug primarily affects folks that:
- Keep their wallet open for long periods of time.
- Earn Stakes at high frequency.

The PR resolves this by back-tracing the Stake Input, and if it's still within the wallet's 'mempool' tracker, and remove the Input UTXO immediately, effectively replacing the `Stake Input` with the `Stake Output`.

This bug (and subsequently, the fix) should affect both Hot and Cold stakes, in the case that the user has a local PIVX Core hot-staking their MPW funds, then this fix applies there too, but obviously, most MPW users will be Cold Staking.

**Note:** I think our Mempool handling in general needs a decent rewrite, as the current logic is over-complex and written badly, it is prone to these duplication errors because it has no context of vins/vouts, but refactoring all of that is out-of-scope for this quick Stake Rewards patch which users have complained about, I will handle a bigger Mempool rework in a future PR.

---

## Testing
This PR fixes a bug where users earning Stakes while MPW open, would see their balance "duplicate", as such, this fix is harder to test, since you'll need to wait for a stake, and keep MPW (and your device) fully online and undisturbed to ensure new stakes didn't break your balance.

To test this PR, it's suggested to attempt this user flow:
- Stake some PIV (Testnet is more likely to receive frequent stakes).
- Keep MPW open until you hit a stake (or a few).
- Ensure your balance looks correct and has not "duplicated" erroneously.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---