### PR TITLE
Skip empty DB keys to prevent console spam

### DIFF
--- a/scripts/database.js
+++ b/scripts/database.js
@@ -248,6 +248,10 @@ export class Database {
         // We'll generate an Account Class for up-to-date keys, then layer the 'new' type-checked properties on it one-by-one
         const cAccount = new Account();
         for (const strKey of Object.keys(cAccount)) {
+            // If the key is missing: this is fine, `cAccount` will auto-fill it with the default blank Account Class type and value
+            if (!Object.prototype.hasOwnProperty.call(cDBAccount, strKey))
+                continue;
+
             // Ensure the Type is correct for the Key against the Account class (with instanceof to also check Class validity)
             if (!isSameType(cDBAccount[strKey], cAccount[strKey])) {
                 console.error(


### PR DESCRIPTION
## Abstract

This PR simply skips missing DB keys in `getAccount`, to prevent console spam about the key being an invalid type (of course, because it's undefined), this is safe because `getAccount` auto-fills missing keys in the returned `Account` class with the default values of the `Account` class, the error log is still annoying, though, even if harmless.

This will only effect users upgrading their 'accounts' from older MPW versions to v1.2.0, since those will not have the `name` or `contacts` keys, the new DB complains that they're missing.

Without this PR, you can expect the below Testing process to spam these errors (albeit, completely harmless) in the console:
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/107d8fd2-44a0-4d1e-9622-51ba6d6e9ad6)

---

## Testing (Developers Only)
To test this PR, you'll need to have a clean account from v1.1.1 saved in your browser already, preferrably on localhost with `npm run dev` on the v1.1.1 tag by running `git checkout d16cdfb19b2134bec2d976894dfa15c1769c2bed`, once you have an account encrypted and saved on v1.1.1, proceed to:
- Switch to this PR.
- Login to your Account.
- Check the console for errors of missing keys, there should not be any.
- Try to 'use' those missing keys, by adding a Contact, or an incoming Contact Name, for example.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---