### PR TITLE
Add full JSDoc context and types to translation global

### DIFF
--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -1,4 +1,4 @@
-var translation = {
+export const translation_template = {
     // This document is to be used as a template as all the base code is in English
     // Basic HTML tags are allowed such as <b><i> etc. All data is sanitized https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML
 

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,3 +1,4 @@
+import { translation_template } from '../locale/template/translation.js';
 import { en_translation } from '../locale/en/translation.js';
 import { pt_br_translation } from '../locale/pt-br/translation.js';
 import { pt_pt_translation } from '../locale/pt-pt/translation.js';
@@ -15,11 +16,12 @@ import { getNetwork } from './network.js';
 import { cReceiveType, guiToggleReceiveType } from './contacts-book.js';
 
 /**
- * @type{Record<string, string>}
+ * @type {translation_template}
  */
 export const ALERTS = {};
+
 /**
- * @type{Record<string, string>}
+ * @type {translation_template}
  */
 export let translation = {};
 

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -14,7 +14,13 @@ import { masterKey } from './wallet.js';
 import { getNetwork } from './network.js';
 import { cReceiveType, guiToggleReceiveType } from './contacts-book.js';
 
+/**
+ * @type{Record<string, string>}
+ */
 export const ALERTS = {};
+/**
+ * @type{Record<string, string>}
+ */
 export let translation = {};
 
 // TRANSLATION
@@ -99,7 +105,6 @@ export function tr(message, variables) {
 /**
  * Translates all static HTML based on the `data-i18n` tag
  * @param {Array} i18nLangs
- *
  */
 export function translateStaticHTML(i18nLangs) {
     if (!i18nLangs) return;


### PR DESCRIPTION
## Abstract

Adds jsdoc typings so the ALERTS and translation objects correctly have the string typing.

## Testing
- Create a variable `let test = translation.test`
- Check that your lsp gives the `string` type to the test variable


