### PR TITLE
Improve Governance consensus rules

### DIFF
--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -278,6 +278,7 @@ export const de_translation = {
     proposalFinalisationReady: 'Bereit zum Einreichen', //Ready to submit
     proposalPassing: 'Bestehend', //PASSING
     proposalFailing: 'Scheiternd', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'Finanziert', //FUNDED
     proposalNotFunded: 'nicht Finanziert', //NOT FUNDED
     proposalPaymentsRemaining: 'Ausstehende Transaktionen<br>', //installment(s) remaining<br>of

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -275,6 +275,7 @@ export const en_translation = {
     proposalFinalisationReady: 'Ready to submit',
     proposalPassing: 'PASSING',
     proposalFailing: 'FAILING',
+    proposalTooYoung: 'TOO YOUNG',
     proposalFunded: 'FUNDED',
     proposalNotFunded: 'NOT FUNDED',
     proposalPaymentsRemaining: 'installment(s) remaining<br>of',

--- a/locale/es-mx/translation.js
+++ b/locale/es-mx/translation.js
@@ -283,6 +283,7 @@ export const es_mx_translation = {
     proposalFinalisationReady: 'Listo para enviarla', //Ready to submit
     proposalPassing: 'PASANDO', //PASSING
     proposalFailing: 'FRACASANDO', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'FINANCIADA', //FUNDED
     proposalNotFunded: 'NO FINANCIADA', //NOT FUNDED
     proposalPaymentsRemaining: 'plazo(s) restante(s)<br>de', //installment(s) remaining<br>of

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -285,6 +285,7 @@ export const fr_translation = {
     proposalFinalisationReady: 'Prêt à soumettre', //Ready to submit
     proposalPassing: 'PASSANT', //PASSING
     proposalFailing: 'ÉCHOUANT', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'FINANCÉE', //FUNDED
     proposalNotFunded: 'NON FINANCÉE', //NOT FUNDED
     proposalPaymentsRemaining: "l'installation(s) restants<br>de", //installment(s) remaining<br>of

--- a/locale/it/translation.js
+++ b/locale/it/translation.js
@@ -265,6 +265,7 @@ export const it_translation = {
     proposalFinalisationReady: "Pronto per l'invio", //Ready to submit
     proposalPassing: 'Passata', //PASSING
     proposalFailing: 'Fallita', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'Finanziata', //FUNDED
     proposalNotFunded: 'Non finanziata', //NOT FUNDED
     proposalPaymentsRemaining: 'rata/i rimanente<br>di', //installment(s) remaining<br>of

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -287,6 +287,7 @@ export const ph_translation = {
     proposalFinalisationReady: 'Handa ng ipasa', //Ready to submit
     proposalPassing: 'PASSING', //PASSING
     proposalFailing: 'FAILING', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'FUNDED', //FUNDED
     proposalNotFunded: 'NOT FUNDED', //NOT FUNDED
     proposalPaymentsRemaining: 'installment(s) remaining<br>of', //installment(s) remaining<br>of

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -281,6 +281,7 @@ export const pt_br_translation = {
     proposalFinalisationReady: 'Pronto para enviar', //Ready to submit
     proposalPassing: 'PASSAGEM', //PASSING
     proposalFailing: 'FALHA', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'FINANCIADO/A', //FUNDED
     proposalNotFunded: 'NÃO FINANCIADO/A', //NOT FUNDED
     proposalPaymentsRemaining: 'parcela(s) restante(s)<br>de', //installment(s) remaining<br>of

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -281,6 +281,7 @@ export const pt_pt_translation = {
     proposalFinalisationReady: 'Pronto para enviar', //Ready to submit
     proposalPassing: 'PASSAGEM', //PASSING
     proposalFailing: 'FALHA', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: 'FINANCIADO/A', //FUNDED
     proposalNotFunded: 'NÃO FINANCIADO/A', //NOT FUNDED
     proposalPaymentsRemaining: 'parcela(s) restante(s)<br>de', //installment(s) remaining<br>of

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -269,6 +269,7 @@ export const translation_template = {
     proposalFinalisationReady: '', //Ready to submit
     proposalPassing: '', //PASSING
     proposalFailing: '', //FAILING
+    proposalTooYoung: '', //TOO YOUNG
     proposalFunded: '', //FUNDED
     proposalNotFunded: '', //NOT FUNDED
     proposalPaymentsRemaining: '', //installment(s) remaining<br>of

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -278,6 +278,7 @@ export const uwu_translation = {
     proposalFinalisationReady: 'Ready tew submit', //Ready to submit
     proposalPassing: 'PASSING, YAY!', //PASSING
     proposalFailing: 'FAILING, NAY!', //FAILING
+    proposalTooYoung: 'TOO YOUNG, BAKA!', //TOO YOUNG
     proposalFunded: 'FUNDED!', //FUNDED
     proposalNotFunded: 'NO MONIES', //NOT FUNDED
     proposalPaymentsRemaining: 'payment(s) remainingz<br>of', //installment(s) remaining<br>of

--- a/scripts/chain_params.js
+++ b/scripts/chain_params.js
@@ -46,6 +46,7 @@ export const cChainParams = {
         },
         budgetCycleBlocks: 43200,
         proposalFee: 50 * COIN,
+        proposalFeeConfirmRequirement: 6,
         maxPaymentCycles: 6,
         maxPayment: 10 * 43200 * COIN, // 43200 blocks of 10 PIV
     },
@@ -74,6 +75,7 @@ export const cChainParams = {
         },
         budgetCycleBlocks: 144,
         proposalFee: 50 * COIN,
+        proposalFeeConfirmRequirement: 3,
         maxPaymentCycles: 20,
         maxPayment: 10 * 144 * COIN, // 144 blocks of 10 tPIV
     },

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2234,19 +2234,18 @@ async function renderProposals(arrProposals, fContested) {
         let strFundingStatus = '';
 
         // Proposal Status calculations
-        if (cProposal.IsEstablished) {
-            // Scenario 1: Proposal is established and is or is not funded
-            if (nNetYes >= nRequiredVotes) {
-                strStatus = translation.proposalPassing;
-                strFundingStatus = translation.proposalFunded;
-            } else {
-                strStatus = translation.proposalFailing;
-                strFundingStatus = translation.proposalNotFunded;
-            }
-        } else {
-            // Scenario 2: Proposal is not established (nor funded)
+        if (nNetYes < nRequiredVotes) {
+            // Scenario 1: Not enough votes
+            strStatus = translation.proposalFailing;
+            strFundingStatus = translation.proposalNotFunded;
+        } else if (!cProposal.IsEstablished) {
+            // Scenario 2: Enough votes, but not established
             strStatus = translation.proposalFailing;
             strFundingStatus = translation.proposalTooYoung;
+        } else {
+            // Scenario 3: Enough votes, and established
+            strStatus = translation.proposalPassing;
+            strFundingStatus = translation.proposalFunded;
         }
 
         // Funding Status and allocation calculations

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2083,7 +2083,11 @@ async function waitForSubmissionBlockHeight(cProposalCache) {
  */
 function getProposalFinalisationStatus(cPropCache) {
     const cNet = getNetwork();
-    const nConfsLeft = cPropCache.nSubmissionHeight + 6 - cNet.cachedBlockCount;
+    // Confirmations left until finalisation, by network consensus
+    const nConfsLeft =
+        cPropCache.nSubmissionHeight +
+        cChainParams.current.proposalFeeConfirmRequirement -
+        cNet.cachedBlockCount;
 
     if (cPropCache.nSubmissionHeight === 0 || cNet.cachedBlockCount === 0) {
         return translation.proposalFinalisationConfirming;
@@ -2171,6 +2175,7 @@ async function renderProposals(arrProposals, fContested) {
                     Nays: 0,
                     local: true,
                     Ratio: 0,
+                    IsEstablished: false,
                     mpw: p,
                 };
             }) || [];
@@ -2224,12 +2229,25 @@ async function renderProposals(arrProposals, fContested) {
         const nNetYesPercent = (nNetYes / cMasternodes.enabled) * 100;
 
         // Proposal Status calculation
-        const nRequiredVotes = Math.round(cMasternodes.enabled * 0.1);
-        const strStatus =
-            nNetYes >= nRequiredVotes
-                ? translation.proposalPassing
-                : translation.proposalFailing;
-        let strFundingStatus = translation.proposalNotFunded;
+        const nRequiredVotes = cMasternodes.enabled / 10;
+        let strStatus = '';
+        let strFundingStatus = '';
+
+        // Proposal Status calculations
+        if (cProposal.IsEstablished) {
+            // Scenario 1: Proposal is established and is or is not funded
+            if (nNetYes >= nRequiredVotes) {
+                strStatus = translation.proposalPassing;
+                strFundingStatus = translation.proposalFunded;
+            } else {
+                strStatus = translation.proposalFailing;
+                strFundingStatus = translation.proposalNotFunded;
+            }
+        } else {
+            // Scenario 2: Proposal is not established (nor funded)
+            strStatus = translation.proposalFailing;
+            strFundingStatus = translation.proposalTooYoung;
+        }
 
         // Funding Status and allocation calculations
         if (cProposal.local) {
@@ -2240,14 +2258,14 @@ async function renderProposals(arrProposals, fContested) {
                     updateGovernanceTab
                 );
             }
-            const strStatus = getProposalFinalisationStatus(cPropCache);
+            const strLocalStatus = getProposalFinalisationStatus(cPropCache);
             const finalizeButton = document.createElement('button');
             finalizeButton.className = 'pivx-button-small';
             finalizeButton.innerHTML = '<i class="fas fa-check"></i>';
 
             if (
-                strStatus === translation.proposalFinalisationReady ||
-                strStatus === translation.proposalFinalisationExpired
+                strLocalStatus === translation.proposalFinalisationReady ||
+                strLocalStatus === translation.proposalFinalisationExpired
             ) {
                 finalizeButton.addEventListener('click', async () => {
                     const result = await Masternode.finalizeProposal(
@@ -2320,7 +2338,7 @@ async function renderProposals(arrProposals, fContested) {
 
             domStatus.innerHTML = `
             <span style="font-size:12px; line-height: 15px; display: block; margin-bottom:15px;">
-                <span style="color:#fff; font-weight:700;">${strStatus}</span><br>
+                <span style="color:#fff; font-weight:700;">${strLocalStatus}</span><br>
             </span>
             <span class="governArrow for-mobile ptr">
                 <i class="fa-solid fa-angle-down"></i>
@@ -2329,6 +2347,7 @@ async function renderProposals(arrProposals, fContested) {
         } else {
             if (domTable.id == 'proposalsTableBody') {
                 if (
+                    cProposal.IsEstablished &&
                     nNetYes >= nRequiredVotes &&
                     totalAllocatedAmount + cProposal.MonthlyPayment <=
                         cChainParams.current.maxPayment / COIN


### PR DESCRIPTION
## Abstract

This proposal fixes a handful of small areas where MPW deviated from PIVX Core's Governance consensus rules, those being:
- The 'Budget Fee' finalisation confirms: MPW now uses [PIVX Core's rules](https://github.com/PIVX-Project/PIVX/blob/7b7803c57b6b59995c54ff8ad40080c5b45009da/src/budget/budgetmanager.cpp#L1578) for Mainnet and Testnet.
- The 'Budget Fee' confirmation time (24h rule), for this, we use [IsEstablished](https://github.com/PIVX-Project/PIVX/blob/7b7803c57b6b59995c54ff8ad40080c5b45009da/src/budget/budgetproposal.cpp#L197) from the `getbudgetinfo` results.
- - *I would have preferred computing confirm time in-MPW to reduce RPC reliance, but it felt overkill for a single bool.*
- Fixed how MN votes are computed, now MPW uses the [exact same calculation](https://github.com/PIVX-Project/PIVX/blob/7b7803c57b6b59995c54ff8ad40080c5b45009da/src/budget/budgetproposal.cpp#L211C36-L211C36) without rounding, which stops Testnet `0 vote` proposals from "Passing" due to Testnet's low MN count.

When a proposal falls under the '24h rule' (on Mainnet, it's 5m on Testnet) then the Governance Dashboard will signal this with a "Too Young" message, and will not allow it to pass or be funded.
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/29296b05-1950-454e-95ef-4cb44946f41f)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Compare PIVX.org with MyPIVXWallet (this PR), ensure the Passing and Funding states 100% match.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---