### PR TITLE
Cold Staking improvements: owner addresses, defaults and fixes

### DIFF
--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -249,7 +249,8 @@ export const de_translation = {
     popupSetColdAddr: 'Gib eine kalte Staking Adresse an', //Set your Cold Staking address
     popupCurrentAddress: 'Aktuelle Adresse', //Current address:
     popupColdStakeNote:
-        'Eine kalte Staking Adresse delegiert Münzen für dich. Sie kann nicht für Transaktionen verwendet werden, so kannst du auch fremde kalte Adressen verwenden!', //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+        'Eine kalte Staking Adresse delegiert Münzen für dich. Sie kann nicht für Transaktionen verwendet werden, so kannst du auch fremde kalte Adressen verwenden!', //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger\'s Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger\'s Owner Address!</b>
     popupExample: 'Beispiel', //Example:
     popupWalletLock: 'Möchtest du deine Geldbörse sperren?', //Do you want to lock your wallet?
     popupWalletWipe:

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -246,6 +246,8 @@ export const en_translation = {
     popupCurrentAddress: 'Current address:',
     popupColdStakeNote:
         "A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!",
+    popupColdStakeOwnerNote:
+        "You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>",
     popupExample: 'Example:',
     popupWalletLock: 'Do you want to lock your wallet?',
     popupWalletWipe: 'Do you want to wipe your wallet private data?',

--- a/locale/es-mx/translation.js
+++ b/locale/es-mx/translation.js
@@ -254,6 +254,7 @@ export const es_mx_translation = {
     popupCurrentAddress: 'Dirección actual', //Current address:
     popupColdStakeNote:
         '¡Una dirección de Cold Staking hace stake de monedas en tu nombre, pero no puede gastar las monedas, por lo que es seguro utilizar la Dirección Cold Staking de un desconocido!', //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: 'Ejemplo:', //Example:
     popupWalletLock: '¿Quieres bloquear tu wallet?', //Do you want to lock your wallet?
     popupWalletWipe: '¿Quieres eliminar los datos privados de tu wallet?', //Do you want to wipe your wallet private data?

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -255,6 +255,7 @@ export const fr_translation = {
     popupCurrentAddress: 'Adresse actuelle :', //Current address:
     popupColdStakeNote:
         "Une Cold Address mise des pièces en votre nom, mais ne peut pas en dépenser. Il est donc possible d'utiliser Cold Address d'un inconnu en toute sécurité !", //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: 'Exemple :', //Example:
     popupWalletLock: 'Voulez-vous verrouiller votre portefeuille ?', //Do you want to lock your wallet?
     popupWalletWipe:

--- a/locale/it/translation.js
+++ b/locale/it/translation.js
@@ -236,6 +236,7 @@ export const it_translation = {
     popupCurrentAddress: 'Indirizzo attuale:', //Current address:
     popupColdStakeNote:
         "Con un Cold Address puoi mettere in stake i tuoi PIVs anche usando l'address di uno sconosciuto, che non potrà spenderli!", //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: 'Esempio:', //Example:
     popupWalletLock: 'Vuoi bloccare il tuo wallet?', //Do you want to lock your wallet?
     popupWalletWipe: 'Vuoi cancellare i dati privati ​​del tuo wallet?', //Do you want to wipe your wallet private data?

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -257,6 +257,7 @@ export const ph_translation = {
     popupCurrentAddress: 'Kasalukuyang Address:', //Current address:
     popupColdStakeNote:
         "Ang Cold Address stakes coins sa iyong ngalan, ay hindi makakagastos ng coins, kaya mas ligtas itong gumamit ng stranger's cold address!", //A Cold Address stakes coins on your behalf, it cannot spend coins, so it\'s even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: 'Halimbawa', //Example:
     popupWalletLock: 'Gusto mo bang i-lock ang iyong wallet?', //Do you want to lock your wallet?
     popupWalletWipe:

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -254,6 +254,7 @@ export const pt_br_translation = {
     popupCurrentAddress: 'Endereço atual', //Current address:
     popupColdStakeNote:
         'Um Endereço de Cold Staking faz staking de moedas em seu nome, não pode gastar moedas, então é seguro até usar o Cold Address de um estranho!', //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: 'Exemplo:', //Example:
     popupWalletLock: 'Você quer bloquear a sua carteira', //Do you want to lock your wallet?
     popupWalletWipe: 'Deseja limpar os dados privados da sua carteira', //Do you want to wipe your wallet private data?

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -254,6 +254,7 @@ export const pt_pt_translation = {
     popupCurrentAddress: 'Endereço atual', //Current address:
     popupColdStakeNote:
         'Um Endereço de aposta moedas em seu nome, não pode gastar moedas, então é até seguro usar o Cold Address de um estranho!', //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: 'Exemplo:', //Example:
     popupWalletLock: 'Você quer bloquear a sua carteira', //Do you want to lock your wallet?
     popupWalletWipe: 'Deseja limpar os dados privados da sua carteira', //Do you want to wipe your wallet private data?

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -246,6 +246,7 @@ export const translation_template = {
     popupSetColdAddr: '', //Set your Cold Staking address
     popupCurrentAddress: '', //Current address:
     popupColdStakeNote: '', //A Cold Address stakes coins on your behalf, it cannot spend coins, so it's even safe to use a stranger's Cold Address!
+    popupColdStakeOwnerNote: '', //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger's Owner Address!</b>
     popupExample: '', //Example:
     popupWalletLock: '', //Do you want to lock your wallet?
     popupWalletWipe: '', //Do you want to wipe your wallet private data?

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -250,6 +250,8 @@ export const uwu_translation = {
     popupCurrentAddress: 'Current addwess:', //Current address:
     popupColdStakeNote:
         "A Cold Addwess stakes coins on ur behalf, it cannot spend coins, so it's even safe to uwuse a stwanger's Cold Addwess!", //A Cold Address stakes coins on your behalf, it cannot spend coins, so it\'s even safe to use a stranger\'s Cold Address!
+    popupColdStakeOwnerNote:
+        "Yew can set a static Owner Addwess, or weave it empty to let MPW handlwe it, <b>do NAWT use a stranger's Owner Addwess!</b>", //You can set a static Owner Address, or leave it empty to let MPW handle it, <b>do not use a stranger\'s Owner Address!</b>
     popupExample: 'Examplez:', //Example:
     popupWalletLock: 'Do yew want to lock ur wawwet?', //Do you want to lock your wallet?
     popupWalletWipe: 'Do yew want to wipe ur wawwet pwivate data?', //Do you want to wipe your wallet private data?

--- a/scripts/chain_params.js
+++ b/scripts/chain_params.js
@@ -49,6 +49,7 @@ export const cChainParams = {
         proposalFeeConfirmRequirement: 6,
         maxPaymentCycles: 6,
         maxPayment: 10 * 43200 * COIN, // 43200 blocks of 10 PIV
+        defaultColdStakingAddress: 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy', // Labs Cold Pool
     },
     testnet: {
         name: 'testnet',
@@ -78,6 +79,7 @@ export const cChainParams = {
         proposalFeeConfirmRequirement: 3,
         maxPaymentCycles: 20,
         maxPayment: 10 * 144 * COIN, // 144 blocks of 10 tPIV
+        defaultColdStakingAddress: 'WmNziUEPyhnUkiVdfsiNX93H6rSJnios44', // Sparrow's Testnet Cold Pool
     },
 };
 // Set default chain

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -290,6 +290,18 @@ export function isStandardAddress(strAddress) {
 }
 
 /**
+ * A quick check to see if an address is a Cold (P2CS) address
+ * @param {string} strAddress - The address to check
+ * @returns {boolean} - `true` if a Cold address, `false` if not
+ */
+export function isColdAddress(strAddress) {
+    return (
+        strAddress.length === 34 &&
+        cChainParams.current.STAKING_PREFIX === strAddress[0]
+    );
+}
+
+/**
  * A quick check to see if a string is an XPub key
  * @param {string} strXPub - The XPub to check
  * @returns {boolean} - `true` if a valid formatted XPub, `false` if not

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -1,5 +1,5 @@
 import { cChainParams, COIN } from './chain_params.js';
-import { createAlert } from './misc.js';
+import { createAlert, isColdAddress } from './misc.js';
 import { Mempool, UTXO } from './mempool.js';
 import { getEventEmitter } from './event_bus.js';
 import {
@@ -526,7 +526,7 @@ export class ExplorerNetwork extends Network {
                     // Check vins for undelegations
                     for (const vin of tx.vin) {
                         const fDelegation = vin.addresses?.some((addr) =>
-                            addr.startsWith(cChainParams.current.STAKING_PREFIX)
+                            isColdAddress(addr)
                         );
                         if (fDelegation) {
                             nDelegated -= parseInt(vin.value);
@@ -537,9 +537,7 @@ export class ExplorerNetwork extends Network {
                     for (const out of tx.vout) {
                         strDelegatedAddr =
                             out.addresses?.find((addr) =>
-                                addr.startsWith(
-                                    cChainParams.current.STAKING_PREFIX
-                                )
+                                isColdAddress(addr)
                             ) || strDelegatedAddr;
 
                         const fDelegation = !!strDelegatedAddr;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -44,8 +44,11 @@ export let cExplorer = cChainParams.current.Explorers[0];
 export let cNode = cChainParams.current.Nodes[0];
 /** A mode which allows MPW to automatically select it's data sources */
 export let fAutoSwitch = true;
-/** The active Cold Staking address: default is the PIVX Labs address */
-export let strColdStakingAddress = 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy';
+/** The active Cold Staking address: default is set via chainparams */
+export let strColdStakingAddress =
+    cChainParams.current.defaultColdStakingAddress;
+/** The primary Owner Address for Cold Staking: default is a new address each delegation */
+export let strColdStakeOwnerAddress = '';
 /** The decimals to display for the wallet balance */
 export let nDisplayDecimals = 2;
 /** A mode which configures MPW towards Advanced users, with low-level feature access and less restrictions (Potentially dangerous) */
@@ -75,6 +78,10 @@ export class Settings {
      */
     coldAddress;
     /**
+     * @type {string} The user's primary Owner Address for Cold Delegations
+     */
+    coldOwnerAddress;
+    /**
      * @type {String} translation to use
      */
     translation;
@@ -96,6 +103,7 @@ export class Settings {
         node,
         autoswitch = true,
         coldAddress = strColdStakingAddress,
+        coldOwnerAddress = strColdStakeOwnerAddress,
         translation = '',
         displayCurrency = 'usd',
         displayDecimals = nDisplayDecimals,
@@ -106,6 +114,7 @@ export class Settings {
         this.node = node;
         this.autoswitch = autoswitch;
         this.coldAddress = coldAddress;
+        this.coldOwnerAddress = coldOwnerAddress;
         this.translation = translation;
         this.displayCurrency = displayCurrency;
         this.displayDecimals = displayDecimals;
@@ -198,13 +207,15 @@ export async function start() {
         analytics: strSettingAnalytics,
         autoswitch,
         coldAddress,
+        coldOwnerAddress,
         displayCurrency,
         displayDecimals,
         advancedMode,
     } = await database.getSettings();
 
-    // Set the Cold Staking address
+    // Set the Cold Staking and Owner addresses
     strColdStakingAddress = coldAddress;
+    strColdStakeOwnerAddress = coldOwnerAddress;
 
     // Set any Toggles to their default or DB state
     // Network Auto-Switch
@@ -351,6 +362,16 @@ export async function setColdStakingAddress(strColdAddress) {
     strColdStakingAddress = strColdAddress;
     const database = await Database.getInstance();
     database.setSettings({ coldAddress: strColdAddress });
+}
+
+/**
+ * Sets and saves the primary Owner address for Delegations
+ * @param {string} strOwnerAddress - The Owner address
+ */
+export async function setColdStakingOwnerAddress(strOwnerAddress) {
+    strColdStakeOwnerAddress = strOwnerAddress;
+    const database = await Database.getInstance();
+    database.setSettings({ coldOwnerAddress: strOwnerAddress });
 }
 
 /**


### PR DESCRIPTION
## Abstract

This PR fulfills a user feature request which asked for the ability to customise the Owner Address for Cold Staking: this PR adds such a feature, allowing you to set an Owner Address when using Advanced Mode.

Both Internal and External addresses are supported, the 'mempool' will account for Internal/External to prevent the Cold Balance increasing on an 'external' delegation (which is basically a Send transaction).

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/d62fd91f-544b-4c10-94d4-7f8db90173df)

Additionally, this PR adds a bunch of other changes to improve Cold Staking overall, such as:
- Moved 'default' Cold Addresses to the chainparams.
- Added a default Testnet Cold Pool, hosted by @DeanSparrow.
- Added a simple misc `isColdAddress()` sanity utility function and added this across the codebase.
- Allowed the 'Set Cold Address' popup to be given empty input, which effectively resets to MPW defaults.

And while not being Cold Staking related, this PR also improves `wallet.isOwnAddress()` by better caching derived addresses, deriving ahead of time by `MAX_ACCOUNT_GAP`, this was done because while I was writing the new Owner Address mempool logic (to not add external delegations to the 'mempool'), `isOwnAddress` was incorrectly describing a fresh address from `getNewAddress()` as non-owned and external, because it was only scanning for older BIP39 indexes.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Import your wallet
- Try Staking and Unstaking (Delegating and Undelegating).
- Enable Advanced Mode
- - Try Staking and Unstaking again, without changing anything but `Advanced Mode = On`
- - Hit the `Stake` Settings (⚙️) icon, set a custom **Cold Staking** address and try to Stake.
- - Hit the `Stake` Settings (⚙️) icon, set a custom **internal Owner Address** and try to Stake.
- - Hit the `Stake` Settings (⚙️) icon, set a custom **external Owner Address** and try to Stake.
- - Hit the `Stake` Settings (⚙️) icon, set **bad/invalid Cold or Owner address**, it should reject them.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---

<!---
Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
--->