### PR TITLE
Fix incorrect `getXPub` in `openExplorer()`

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -801,7 +801,7 @@ export async function openSendQRScanner() {
  */
 export async function openExplorer(strAddress = '') {
     if (wallet.isLoaded() && wallet.isHD() && !strAddress) {
-        const xpub = await wallet.getxpub();
+        const xpub = await wallet.getXPub();
         window.open(cExplorer.url + '/xpub/' + xpub, '_blank');
     } else {
         const address = strAddress || (await wallet.getAddress());


### PR DESCRIPTION
## Abstract

This PR fixes another bug from #200 / #197 which uses the wrong `getXPub` call in the "View on Explorer" button,

I suggest we quickly scan MPW for other bugs related to those PRs also; i.e: typos, wrong function capitalisation, etc as there might be more of these we haven't caught yet, so we can include those fixes in this PR.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Open your wallet and click "View on Explorer" in the Dashboard Menu.

---