### PR TITLE
Include also the last index in isOwnAddress

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -219,7 +219,7 @@ export class Wallet {
         this.#addressIndex =
             this.#addressIndex > last ? this.#addressIndex : last;
         if (this.isHD()) {
-            for (let i = 0; i < this.#addressIndex; i++) {
+            for (let i = 0; i <= this.#addressIndex; i++) {
                 const path = this.getDerivationPath(0, i);
                 const testAddress = await this.#masterKey.getAddress(path);
                 if (address === testAddress) {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -219,7 +219,7 @@ export class Wallet {
         this.#addressIndex =
             this.#addressIndex > last ? this.#addressIndex : last;
         if (this.isHD()) {
-            for (let i = 0; i <= this.#addressIndex; i++) {
+            for (let i = 0; i <= this.#addressIndex + MAX_ACCOUNT_GAP; i++) {
                 const path = this.getDerivationPath(0, i);
                 const testAddress = await this.#masterKey.getAddress(path);
                 if (address === testAddress) {


### PR DESCRIPTION
## Abstract
I spotted this bug in #201, but it will take a while to be merged so (as suggested by a review) I'm opening a PR just for this:
`isOwnAddress` is currently marking the last used address as null. As you can see the fix is trivial. 

## Testing
verify that the last used address has a valid path
---
