### PR TITLE
Solve activity spam

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -519,6 +519,19 @@ function subscribeToNetworkEvents() {
         }
     });
 
+    getEventEmitter().on('new-block', (block, oldBlock) => {
+        console.log(`New block detected! ${oldBlock} --> ${block}`);
+        // Fetch latest Activity
+        activityDashboard.update(true);
+        stakingDashboard.update(true);
+
+        // If it's open: update the Governance Dashboard
+        if (doms.domGovTab.classList.contains('active')) {
+            updateGovernanceTab();
+        }
+        getBalance(true);
+    });
+
     getEventEmitter().on('transaction-sent', (success, result) => {
         if (success) {
             doms.domAddress1s.value = '';
@@ -2567,17 +2580,8 @@ export function refreshChainData() {
         );
     if (!wallet.isLoaded()) return;
 
-    // Fetch block count + UTXOs, update the UI for new transactions
-    cNet.getBlockCount().then((_) => {
-        // Fetch latest Activity
-        activityDashboard.update(true);
-
-        // If it's open: update the Governance Dashboard
-        if (doms.domGovTab.classList.contains('active')) {
-            updateGovernanceTab();
-        }
-    });
-    getBalance(true);
+    // Fetch block count
+    cNet.getBlockCount().then(() => {});
 }
 
 // A safety mechanism enabled if the user attempts to leave without encrypting/saving their keys

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -215,11 +215,10 @@ export class ExplorerNetwork extends Network {
                 await retryWrapper(fetchBlockbook, `/api/v2/api`)
             ).json();
             if (backend.blocks > this.blocks) {
-                console.log(
-                    'New block detected! ' +
-                        this.blocks +
-                        ' --> ' +
-                        backend.blocks
+                getEventEmitter().emit(
+                    'new-block',
+                    backend.blocks,
+                    this.blocks
                 );
                 this.blocks = backend.blocks;
 

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -230,6 +230,7 @@ export class ExplorerNetwork extends Network {
         } finally {
             getEventEmitter().emit('sync-status', 'stop');
         }
+	return this.blocks;
     }
 
     /**

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -230,7 +230,7 @@ export class ExplorerNetwork extends Network {
         } finally {
             getEventEmitter().emit('sync-status', 'stop');
         }
-	return this.blocks;
+        return this.blocks;
     }
 
     /**


### PR DESCRIPTION
## Abstract

Activity was being synced multiple times per block. This is because `Network::getBlockCount` resolves the promise immediately (This may have changed, i'm not sure).
Added a new event, 'new-block', and moved the console.log and the activityUpdate there
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/47313600/3f7b742e-cd15-472c-bf9c-60c5d68d1143)
Example of the amount of times Activity::update was called on master, using the latest state of the art profiling tools 

## Testing
- Test that the network syncs correctly
- Test that the switch to testnet works correctly 