### PR TITLE
Fix UI error upon receiving MN Collateral

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2312,7 +2312,7 @@ export async function updateMasternodeTab() {
                 doms.domMnDashboard.style.display = '';
             } else {
                 doms.domMnTxId.style.display = 'none';
-                doms.domccessMasternode.style.display = 'block';
+                doms.domAccessMasternode.style.display = 'block';
             }
         } else if (balance < cChainParams.current.collateralInSats) {
             // The user needs more funds


### PR DESCRIPTION
## Abstract

A simple one-liner fix to a typo which caused the MN UI to error upon receiving a collateral (when no prior MN was setup).
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/76a2fed9-c149-40c8-a093-828cc49f4a98)

It now displays as intended:
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/89e5d51b-a5a3-4cae-af0b-af0c0737d1f1)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Import or Create a wallet - mainnet or testnet.
- Receive 10,000 PIV exactly.
- Try to open the Masternode Dashboard.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---