### PR TITLE
Ledger refactor

### DIFF
--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -301,6 +301,7 @@ export default {
 
     INTERNAL_ERROR: 'Interner Fehler, bitte versuche es später erneut', //Internal error, please try again later
     FAILED_TO_IMPORT: '<b>Import fehlgeschlagen!</b> Falsches Passwort', //<b>Failed to import!</b> Invalid password
+    FAILED_TO_IMPORT_HARDWARE: '', // <b> Failed to import Hardware Wallet</b>.
     UNSUPPORTED_CHARACTER:
         'Das Zeichen {char} ist nicht erlaubt in der Adresse! (Nicht Base58 kompatibel)', //The character '{char}' is unsupported in addresses! (Not Base58 compatible)
     UNSUPPORTED_WEBWORKERS:

--- a/locale/de/translation.js
+++ b/locale/de/translation.js
@@ -436,6 +436,9 @@ export default {
     WALLET_CONFIRM_L: 'Bestätige den Import auf deinem Ledger', //Confirm the import on your Ledger
     WALLET_NO_HARDWARE:
         '<b>Kein Gerät verfügbar</b><br>Es wurde keine Hardware-Geldbörse gefunden, bitte stecke es ein und entsperre es!', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
+
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Verbindung zum {hardwareWallet} verloren</b><br>So wie es scheint, wurde das {hardwareWalletProductionName} im Prozess abgezogen, oops!', //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -298,6 +298,7 @@ export default {
 
     INTERNAL_ERROR: 'Internal error, please try again later',
     FAILED_TO_IMPORT: '<b>Failed to import!</b> Invalid password',
+    FAILED_TO_IMPORT_HARDWARE: '<b> Failed to import Hardware Wallet</b>.',
     TESTNET_ENCRYPTION_DISABLED:
         '<b>Testnet Mode is ON!</b><br>Wallet encryption disabled',
     PASSWORD_TOO_SMALL:

--- a/locale/en/translation.js
+++ b/locale/en/translation.js
@@ -425,6 +425,10 @@ export default {
     WALLET_CONFIRM_L: 'Confirm the import on your Ledger',
     WALLET_NO_HARDWARE:
         "<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!",
+    WALLET_HARDWARE_UDEV:
+        '<b>The OS denied access</b> Did you add the udev rules?',
+    WALLET_HARDWARE_NO_ACCESS:
+        '<b>The OS denied access</b> Please check your Operating System settings.',
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWallet} was unplugged mid-operation, oops!',
     WALLET_HARDWARE_BUSY:

--- a/locale/es-mx/translation.js
+++ b/locale/es-mx/translation.js
@@ -423,6 +423,8 @@ export default {
     WALLET_CONFIRM_L: 'Confirma la importación en tu Ledger', //Confirm the import on your Ledger
     WALLET_NO_HARDWARE:
         '<b>No hay ningún dispositivo disponible</b><br>No se pudo encontrar una wallet de hardware; ¡Conéctala y desbloquéala!', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Se perdió la conexión con {hardwareWallet} </b><br>Parece que {hardwareWalletProductionName} se desconectó en mitad de la operación, ¡ups!', //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/es-mx/translation.js
+++ b/locale/es-mx/translation.js
@@ -305,6 +305,7 @@ export default {
 
     INTERNAL_ERROR: 'Error interno, vuelve a intentarlo más tarde', //Internal error, please try again later
     FAILED_TO_IMPORT: '<b>¡No se ha podido importar!</b> Contraseña inválida', //<b>Failed to import!</b> Invalid password
+    FAILED_TO_IMPORT_HARDWARE: '', // <b> Failed to import Hardware Wallet</b>.
     UNSUPPORTED_CHARACTER:
         '¡El carácter {char} no está soportado en las direcciones! (No compatible con Base58)', //The character '{char}' is unsupported in addresses! (Not Base58 compatible)
     UNSUPPORTED_WEBWORKERS:

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -307,6 +307,7 @@ export default {
 
     INTERNAL_ERROR: 'Erreur interne, veuillez réessayer plus tard', //Internal error, please try again later
     FAILED_TO_IMPORT: "<b>Échec de l'importation !</b> Mot de passe invalide", //<b>Failed to import!</b> Invalid password
+    FAILED_TO_IMPORT_HARDWARE: '', // <b> Failed to import Hardware Wallet</b>.
     UNSUPPORTED_CHARACTER:
         "Le caractère {char} n'est pas pris en charge dans les adresses ! (Non compatible avec Base58)", //The character '{char}' is unsupported in addresses! (Not Base58 compatible)
     UNSUPPORTED_WEBWORKERS:

--- a/locale/fr/translation.js
+++ b/locale/fr/translation.js
@@ -427,6 +427,8 @@ export default {
     WALLET_CONFIRM_L: "Confirmez l'importation dans votre Ledger", //Confirm the import on your Ledger
     WALLET_NO_HARDWARE:
         "<b>Aucun dispositif disponible</b><br>Il n'a pas été possible de trouver un portefeuille de hardware; brancher et déverrouiller!", //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_CONNECTION_LOST:
         "<b>Perte de connexion avec le {hardwareWallet} </b><br>Oops! Il semble que {hardwareWalletProductionName} a été déconnecté au milieu de l'opération.", //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/it/translation.js
+++ b/locale/it/translation.js
@@ -402,6 +402,11 @@ export default {
     WALLET_CONFIRM_L: "Conferma l'importo sulla tua Ledger", //Confirm the import on your Ledger
     WALLET_NO_HARDWARE:
         '<b>Nessun dispositivo disponibile</b><br>Impossibile trovare un wallet hardware; per favore collegalo e sbloccalo!', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV:
+        "<b> Il Sistema operativo ha negato l'accesso </b> Hai aggiunto le regole udev?", // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS:
+        "<b> Il Sistema Operativo ha negato l'accesso </b> Perfavore, controlla le impostazioni del tuo sistema operativo.", // <b>The OS denied access</b> Please check your Operating System settings.
+
     WALLET_HARDWARE_CONNECTION_LOST:
         "<b>Connessione a {hardwareWallet} persa </b><br>Sembra che {hardwareWalletProductionName} sia stato scollegato durante l'operazione, ops!", //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/it/translation.js
+++ b/locale/it/translation.js
@@ -287,6 +287,8 @@ export default {
 
     INTERNAL_ERROR: 'Errore interno, rirova più tardi', //Internal error, please try again later
     FAILED_TO_IMPORT: '<b>Impossibile importare!</b> Password non valida', //<b>Failed to import!</b> Invalid password
+    FAILED_TO_IMPORT_HARDWARE:
+        '<b>Impossibile importare il wallet Hardware!</b>', // <b> Failed to import Hardware Wallet</b>.
     UNSUPPORTED_CHARACTER:
         "Il carattere '{char}' non è supportato negli indirizzi! (Non compatibile con Base58)", //The character '{char}' is unsupported in addresses! (Not Base58 compatible)
     UNSUPPORTED_WEBWORKERS:

--- a/locale/ph/translation.js
+++ b/locale/ph/translation.js
@@ -431,6 +431,8 @@ export default {
     WALLET_CONFIRM_L: 'Kumpirmahin ang import sa iyong Ledger', //Confirm the import on your Ledger
     WALLET_NO_HARDWARE:
         '<b>Walang pwedeng magamit na device</b><br>Hindi makahanap ng hardware wallet; pakiusap i-plug in ito at buksan!', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Nawala ang koneksyon sa {hardwareWallet} </b><br>Parang ang {hardwareWalletProductionName} ay na-unplug sa kalagitnaan ng operasyon, oops!', //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/pt-br/translation.js
+++ b/locale/pt-br/translation.js
@@ -434,6 +434,8 @@ export default {
     WALLET_CONFIRM_L: 'Confirme a importação na sua Ledger', //Confirm the import on your Ledger",
     WALLET_NO_HARDWARE:
         '<b>Nenhum dispositivo disponível</b><br>Não foi possível encontrar uma carteira de hardware; conecte-a e desbloqueie-a!', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Conexão perdida com a {hardwareWallet} </b><br>Oops! Parece que a {hardwareWalletProductionName} foi desconectada no meio da operação.', //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/pt-pt/translation.js
+++ b/locale/pt-pt/translation.js
@@ -434,6 +434,8 @@ export default {
     WALLET_CONFIRM_L: 'Confirme a importação na sua Ledger', //Confirm the import on your Ledger",
     WALLET_NO_HARDWARE:
         '<b>Nenhum dispositivo disponível</b><br>Não foi possível encontrar uma carteira de hardware; conecte-a e desbloqueie-a!', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Conexão perdida com a {hardwareWallet} </b><br>Oops! Parece que a {hardwareWalletProductionName} foi desconectado no meio da operação.', //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
     WALLET_HARDWARE_BUSY:

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -370,6 +370,8 @@ export default {
     WALLET_CONFIRM_L: '', //Confirm the import on your Ledger
     WALLET_NO_HARDWARE: '', //<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!
     WALLET_HARDWARE_CONNECTION_LOST: '', //<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!
+    WALLET_HARDWARE_UDEV: '', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS: '', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_BUSY: '', //<b>{hardwareWallet} is waiting</b><br>Please unlock your {hardwareWalletProductionName} or finish it's current prompt
     WALLET_HARDWARE_ERROR: '', //<b> {hardwareWallet} </b><br> {error}
 

--- a/locale/template/translation.js
+++ b/locale/template/translation.js
@@ -291,6 +291,7 @@ export default {
 
     INTERNAL_ERROR: '', //Internal error, please try again later
     FAILED_TO_IMPORT: '', //<b>Failed to import!</b> Invalid password
+    FAILED_TO_IMPORT_HARDWARE: '', // <b> Failed to import Hardware Wallet</b>.
     UNSUPPORTED_CHARACTER: '', //The character '{char}' is unsupported in addresses! (Not Base58 compatible)
     UNSUPPORTED_WEBWORKERS: '', //This browser doesn\'t support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!
     INVALID_ADDRESS: '', //<b>Invalid PIVX address!</b><br> {address}

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -433,7 +433,7 @@ export default {
     WALLET_HARDWARE_UDEV:
         '<b>Onii-chan noticed the OS denied access~ OwO Did you add the udev rules? UwU</b>', // <b>The OS denied access</b> Did you add the udev rules?
     WALLET_HARDWARE_NO_ACCESS:
-        '<b>Nyaa~ The OS denied access, nya~ Please purr-retty please check your Operating System settings, nya~ UwU</b>', // <b>The OS denied access</b> Please check your Operating System settings.
+        '<b>Nyaa~ The OS denied access, nya~</b> Please purr-retty please check your Operating System settings, nya~ UwU', // <b>The OS denied access</b> Please check your Operating Sybstem settings.
     WALLET_HARDWARE_BUSY:
         "<b>{hardwareWallet} is waiting!</b><br>Pwease unwock yowour {hardwareWalletProductionName} or finish it's cuwwent pwompt", //"<b>{hardwareWallet} is waiting</b><br>Please unlock your {hardwareWalletProductionName} or finish it's current prompt",
     WALLET_HARDWARE_ERROR: '<b> {hardwareWallet} </b><br> {error}', //"<b> {hardwareWallet} </b><br> {error}"

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -433,7 +433,7 @@ export default {
     WALLET_HARDWARE_UDEV:
         '<b>Onii-chan noticed the OS denied access~ OwO Did you add the udev rules? UwU</b>', // <b>The OS denied access</b> Did you add the udev rules?
     WALLET_HARDWARE_NO_ACCESS:
-        '<b>Nyaa~ The OS denied access, nya~</b> Please purr-retty please check your Operating System settings, nya~ UwU', // <b>The OS denied access</b> Please check your Operating Sybstem settings.
+        '<b>Nyaa~ The OS denied access, nya~</b> Please purr-retty please check your Operating System settings, nya~ UwU', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_BUSY:
         "<b>{hardwareWallet} is waiting!</b><br>Pwease unwock yowour {hardwareWalletProductionName} or finish it's cuwwent pwompt", //"<b>{hardwareWallet} is waiting</b><br>Please unlock your {hardwareWalletProductionName} or finish it's current prompt",
     WALLET_HARDWARE_ERROR: '<b> {hardwareWallet} </b><br> {error}', //"<b> {hardwareWallet} </b><br> {error}"

--- a/locale/uwu/translation.js
+++ b/locale/uwu/translation.js
@@ -430,6 +430,10 @@ export default {
         "<b>No device avaiwable ☹</b><br>Couldn't find a hawdware wawwet; pwease pwug it in and unwock!", //"<b>No device available</b><br>Couldn't find a hardware wallet; please plug it in and unlock!",
     WALLET_HARDWARE_CONNECTION_LOST:
         '<b>Wost connection to da {hardwareWallet} </b><br>It seems da {hardwareWalletProductionName} was unpwugged mid-opewation, oops!!', // "<b>Lost connection to {hardwareWallet} </b><br>It seems the {hardwareWalletProductionName} was unplugged mid-operation, oops!",
+    WALLET_HARDWARE_UDEV:
+        '<b>Onii-chan noticed the OS denied access~ OwO Did you add the udev rules? UwU</b>', // <b>The OS denied access</b> Did you add the udev rules?
+    WALLET_HARDWARE_NO_ACCESS:
+        '<b>Nyaa~ The OS denied access, nya~ Please purr-retty please check your Operating System settings, nya~ UwU</b>', // <b>The OS denied access</b> Please check your Operating System settings.
     WALLET_HARDWARE_BUSY:
         "<b>{hardwareWallet} is waiting!</b><br>Pwease unwock yowour {hardwareWalletProductionName} or finish it's cuwwent pwompt", //"<b>{hardwareWallet} is waiting</b><br>Please unlock your {hardwareWalletProductionName} or finish it's current prompt",
     WALLET_HARDWARE_ERROR: '<b> {hardwareWallet} </b><br> {error}', //"<b> {hardwareWallet} </b><br> {error}"

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1623,6 +1623,7 @@ export async function wipePrivateData() {
  * @returns {Promise<boolean>} - If the unlock was successful or rejected
  */
 export async function restoreWallet(strReason = '') {
+    if (wallet.isHardwareWallet()) return true;
     // Build up the UI elements based upon conditions for the unlock prompt
     let strHTML = '';
 

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -12,12 +12,7 @@ export let strHardwareName = '';
  * @param {string} path - bip32 path to the key
  * @returns {Promise<string?>}
  */
-export async function getHardwareWalletKeys(
-    path,
-    xpub = false,
-    verify = true,
-    _attempts = 0
-) {
+export async function getHardwareWalletKeys(path, xpub = false, verify = true) {
     try {
         // Check if we haven't setup a connection yet OR the previous connection disconnected
         if (!cHardwareWallet || transport._disconnectEmitted) {
@@ -72,18 +67,6 @@ export async function getHardwareWalletKeys(
                 10000
             );
             return null;
-        }
-        if (false && _attempts < 10) {
-            // This is an ugly hack :(
-            // in the event where multiple parts of the code decide to ask for an address, just
-            // Retry at most 10 times waiting 200ms each time
-            await sleep(200);
-            return await getHardwareWalletKeys(
-                path,
-                xpub,
-                verify,
-                _attempts + 1
-            );
         }
 
         // If the ledger is busy, just nudge the user.

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -7,10 +7,15 @@ import { createAlert, sleep } from './misc.js';
 let transport;
 export let cHardwareWallet = null;
 export let strHardwareName = '';
+/**
+ * Get hardware wallet keys.
+ * @param {string} path - bip32 path to the key
+ * @returns {Promise<string?>}
+ */
 export async function getHardwareWalletKeys(
     path,
     xpub = false,
-    verify = false,
+    verify = true,
     _attempts = 0
 ) {
     try {
@@ -46,13 +51,13 @@ export async function getHardwareWalletKeys(
     } catch (e) {
         if (e.message.includes('denied by the user')) {
             // User denied an operation
-            return false;
+            return null;
         }
 
         // If there's no device, nudge the user to plug it in.
         if (e.message.toLowerCase().includes('no device selected')) {
             createAlert('info', ALERTS.WALLET_NO_HARDWARE, 10000);
-            return false;
+            return null;
         }
 
         // If the device is unplugged, or connection lost through other means (such as spontanious device explosion)
@@ -66,9 +71,9 @@ export async function getHardwareWalletKeys(
                 ]),
                 10000
             );
-            return false;
+            return null;
         }
-        if (_attempts < 10) {
+        if (false && _attempts < 10) {
             // This is an ugly hack :(
             // in the event where multiple parts of the code decide to ask for an address, just
             // Retry at most 10 times waiting 200ms each time
@@ -92,7 +97,7 @@ export async function getHardwareWalletKeys(
                 ]),
                 7500
             );
-            return false;
+            return null;
         }
 
         // Check if this is an expected error
@@ -117,7 +122,7 @@ export async function getHardwareWalletKeys(
             5500
         );
 
-        return false;
+        return null;
     }
 }
 

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -4,6 +4,9 @@ import AppBtc from '@ledgerhq/hw-app-btc';
 import TransportWebUSB from '@ledgerhq/hw-transport-webusb';
 import { createAlert } from './misc.js';
 
+/**
+ * @type{TransportWebUSB}
+ */
 let transport;
 /**
  * @type {AppBtc?}

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -89,12 +89,25 @@ export async function getHardwareWalletKeys(path, xpub = false, verify = true) {
             return null;
         }
 
+        // This is when the OS denies access to the WebUSB
+        // It's likely caused by faulty udev rules on linux
+        if (e instanceof DOMException && e.message.includes('Access Denied')) {
+            if (navigator.userAgent.toLowerCase().includes('linux')) {
+                createAlert('warning', ALERTS.WALLET_HARDWARE_UDEV, 5500);
+            } else {
+                createAlert('warning', ALERTS.WALLET_HARDWARE_NO_ACCESS, 5500);
+            }
+
+            console.error(e);
+            return;
+        }
+
         // Check if this is an expected error
         if (!e.statusCode || !LEDGER_ERRS.has(e.statusCode)) {
             console.error(
                 'MISSING LEDGER ERROR-CODE TRANSLATION! - Please report this below error on our GitHub so we can handle it more nicely!'
             );
-            console.error(e);
+            throw e;
         }
 
         // Translate the error to a user-friendly string (if possible)

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -2,9 +2,12 @@ import createXpub from 'create-xpub';
 import { ALERTS, tr } from './i18n.js';
 import AppBtc from '@ledgerhq/hw-app-btc';
 import TransportWebUSB from '@ledgerhq/hw-transport-webusb';
-import { createAlert, sleep } from './misc.js';
+import { createAlert } from './misc.js';
 
 let transport;
+/**
+ * @type {AppBtc?}
+ */
 export let cHardwareWallet = null;
 export let strHardwareName = '';
 /**

--- a/scripts/masterkey.js
+++ b/scripts/masterkey.js
@@ -210,7 +210,7 @@ export class HardwareWalletMasterKey extends HdMasterKey {
             .slice(0, 4)
             .join('/');
         const xpub = await getHardwareWalletKeys(path, true);
-        if (!xpub) return new Error('Failed to get hardware wallet keys.');
+        if (!xpub) throw new Error('Failed to get hardware wallet keys.');
         HardwareWalletMasterKey.#initializing = true;
         return new HardwareWalletMasterKey(xpub);
     }

--- a/scripts/masterkey.js
+++ b/scripts/masterkey.js
@@ -209,7 +209,7 @@ export class HardwareWalletMasterKey extends HdMasterKey {
             .split('/')
             .slice(0, 4)
             .join('/');
-        const xpub = await getHardwareWalletKeys(path, true);
+        const xpub = await getHardwareWalletKeys(path, true, false);
         if (!xpub) throw new Error('Failed to get hardware wallet keys.');
         HardwareWalletMasterKey.#initializing = true;
         return new HardwareWalletMasterKey(xpub);

--- a/scripts/masterkey.js
+++ b/scripts/masterkey.js
@@ -209,7 +209,6 @@ export class HardwareWalletMasterKey extends HdMasterKey {
             .split('/')
             .slice(0, 4)
             .join('/');
-        console.log(path);
         const xpub = await getHardwareWalletKeys(path, true);
         if (!xpub) return new Error('Failed to get hardware wallet keys.');
         HardwareWalletMasterKey.#initializing = true;

--- a/scripts/masterkey.js
+++ b/scripts/masterkey.js
@@ -231,7 +231,11 @@ export class HardwareWalletMasterKey extends HdMasterKey {
     }
 
     getDerivationPath(nAccount, nReceiving, nIndex) {
-        return `m/44'/${cChainParams.current.BIP44_TYPE_LEDGER}'/${nAccount}'/${nReceiving}/${nIndex}`;
+        return HardwareWalletMasterKey.getDerivationPath(
+            nAccount,
+            nReceiving,
+            nIndex
+        );
     }
 
     static getDerivationPath(nAccount, nReceiving, nIndex) {

--- a/scripts/masterkey.js
+++ b/scripts/masterkey.js
@@ -21,38 +21,37 @@ export class MasterKey {
 
     /**
      * @param {String} [path] - BIP32 path pointing to the private key.
-     * @return {Promise<Array<Number>>} Array of bytes containing private key
+     * @return {number[]} array of bytes containing private key
      * @abstract
      */
-    async getPrivateKeyBytes(_path) {
+    getPrivateKeyBytes(_path) {
         throw new Error('Not implemented');
     }
 
     /**
      * @param {String} [path] - BIP32 path pointing to the private key.
-     * @return {Promise<String>} encoded private key
+     * @return {string} encoded private key
      * @abstract
      */
-    async getPrivateKey(path) {
-        return generateOrEncodePrivkey(await this.getPrivateKeyBytes(path))
-            .strWIF;
+    getPrivateKey(path) {
+        return generateOrEncodePrivkey(this.getPrivateKeyBytes(path)).strWIF;
     }
 
     /**
      * @param {String} [path] - BIP32 path pointing to the address
-     * @return {Promise<String>} Address
+     * @return {string} Address
      * @abstract
      */
-    async getAddress(path) {
-        return deriveAddress({ pkBytes: await this.getPrivateKeyBytes(path) });
+    getAddress(path) {
+        return deriveAddress({ pkBytes: this.getPrivateKeyBytes(path) });
     }
 
     /**
      * @param {String} path - BIP32 path pointing to the xpub
-     * @return {Promise<String>} xpub
+     * @return {string} xpub
      * @abstract
      */
-    async getxpub(_path) {
+    getxpub(_path) {
         throw new Error('Not implemented');
     }
 
@@ -103,15 +102,8 @@ export class MasterKey {
     }
 
     // Construct a full BIP44 pubkey derivation path from it's parts
-    getDerivationPath(nAccount, nReceiving, nIndex) {
-        // Coin-Type is different on Ledger, as such, for local wallets; we modify it if we're using a Ledger to derive a key
-        const strCoinType = this.isHardwareWallet
-            ? cChainParams.current.BIP44_TYPE_LEDGER
-            : cChainParams.current.BIP44_TYPE;
-        if (!this.isHD && !this.isHardwareWallet) {
-            return `:)//${strCoinType}'`;
-        }
-        return `m/44'/${strCoinType}'/${nAccount}'/${nReceiving}/${nIndex}`;
+    getDerivationPath(_nAccount, _nReceiving, _nIndex) {
+        throw new Error('Not implemented');
     }
 }
 
@@ -129,7 +121,7 @@ export class HdMasterKey extends MasterKey {
         this._isHardwareWallet = false;
     }
 
-    async getPrivateKeyBytes(path) {
+    getPrivateKeyBytes(path) {
         if (this.isViewOnly) {
             throw new Error(
                 'Trying to get private key bytes from a view only key'
@@ -145,7 +137,7 @@ export class HdMasterKey extends MasterKey {
         return this._hdKey.privateExtendedKey;
     }
 
-    async getxpub(path) {
+    getxpub(path) {
         if (this.isViewOnly) return this._hdKey.publicExtendedKey;
         return this._hdKey.derive(path).publicExtendedKey;
     }
@@ -183,54 +175,68 @@ export class HdMasterKey extends MasterKey {
                 .join('/')
         ).publicExtendedKey;
     }
+
+    getDerivationPath(nAccount, nReceiving, nIndex) {
+        return `m/44'/${cChainParams.current.BIP44_TYPE}'/${nAccount}'/${nReceiving}/${nIndex}`;
+    }
 }
 
-export class HardwareWalletMasterKey extends MasterKey {
-    constructor() {
-        super();
-        this._isHD = true;
-        this._isHardwareWallet = true;
-    }
-    async getPrivateKeyBytes(_path) {
-        throw new Error('Hardware wallets cannot export private keys');
-    }
-
-    async getAddress(path, { verify } = {}) {
-        return deriveAddress({
-            publicKey: await this.getPublicKey(path, { verify }),
-        });
-    }
-
-    async getPublicKey(path, { verify } = {}) {
-        return deriveAddress({
-            publicKey: await getHardwareWalletKeys(path, false, verify),
-            output: 'COMPRESSED_HEX',
-        });
-    }
-
-    get keyToBackup() {
-        throw new Error("Hardware wallets don't have keys to backup");
-    }
-
-    async getxpub(path) {
-        if (!this.xpub) {
-            this.xpub = await getHardwareWalletKeys(path, true);
+export class HardwareWalletMasterKey extends HdMasterKey {
+    /**
+     * Trick to get private constructors
+     */
+    static #initializing = false;
+    constructor(xpub) {
+        if (!HardwareWalletMasterKey.#initializing) {
+            throw new Error(
+                'Hardware wallet master keys must be created with create'
+            );
         }
-        return this.xpub;
+        HardwareWalletMasterKey.#initializing = false;
+        super({
+            xpub,
+        });
+        this._isHardwareWallet = true;
+        this._isViewOnly = true;
     }
 
-    // Hardware Wallets don't have exposed private data
-    wipePrivateData(_nAccount) {}
-
-    get isViewOnly() {
-        return false;
-    }
-    getKeyToExport(nAccount) {
-        const derivationPath = this.getDerivationPath(nAccount, 0, 0)
+    /**
+     * @param {number} nAccount
+     * @returns {Promise<HardwareWalletMasterKey>}
+     */
+    static async create(nAccount = 0) {
+        const path = this.getDerivationPath(nAccount, 0, 0)
             .split('/')
             .slice(0, 4)
             .join('/');
-        return this.getxpub(derivationPath);
+        console.log(path);
+        const xpub = await getHardwareWalletKeys(path, true);
+        if (!xpub) return new Error('Failed to get hardware wallet keys.');
+        HardwareWalletMasterKey.#initializing = true;
+        return new HardwareWalletMasterKey(xpub);
+    }
+
+    /**
+     * Verifies that the address is correct by asking the ledger
+     * directly and then the user.
+     * This is considerably slower than deriving the key ourselves
+     * with `getAddress`, but should be used every time we want to be sure
+     * the address cannot be tampered with
+     * @param {string} path - bip32 path
+     * @returns {Promise<string?>} address or null if the user rejected the verification
+     */
+    async verifyAddress(path) {
+        const publicKey = await getHardwareWalletKeys(path);
+
+        return deriveAddress({ publicKey });
+    }
+
+    getDerivationPath(nAccount, nReceiving, nIndex) {
+        return `m/44'/${cChainParams.current.BIP44_TYPE_LEDGER}'/${nAccount}'/${nReceiving}/${nIndex}`;
+    }
+
+    static getDerivationPath(nAccount, nReceiving, nIndex) {
+        return `m/44'/${cChainParams.current.BIP44_TYPE_LEDGER}'/${nAccount}'/${nReceiving}/${nIndex}`;
     }
 }
 
@@ -252,7 +258,7 @@ export class LegacyMasterKey extends MasterKey {
         return this._address;
     }
 
-    async getPrivateKeyBytes(_path) {
+    getPrivateKeyBytes(_path) {
         if (this.isViewOnly) {
             throw new Error(
                 'Trying to get private key bytes from a view only key'
@@ -265,7 +271,7 @@ export class LegacyMasterKey extends MasterKey {
         return generateOrEncodePrivkey(this._pkBytes).strWIF;
     }
 
-    async getxpub(_path) {
+    getxpub(_path) {
         throw new Error(
             'Trying to get an extended public key from a legacy address'
         );
@@ -274,5 +280,14 @@ export class LegacyMasterKey extends MasterKey {
     wipePrivateData(_nAccount) {
         this._pkBytes = null;
         this._isViewOnly = true;
+    }
+
+    /**
+     * This is a bit of a hack:
+     * Legacy master keys don't need derivation paths.
+     * We're going to make one nonetheless, to generalize things a bit
+     */
+    getDerivationPath(_nAccount, _nReceiving, _nIndex) {
+        return `:)//${cChainParams.current.BIP44_TYPE}'`;
     }
 }

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -11,7 +11,7 @@ import {
     guiSetColdStakingAddress,
 } from './global.js';
 import { cHardwareWallet, strHardwareName } from './ledger.js';
-import { wallet } from './wallet.js';
+import { wallet, getNewAddress } from './wallet.js';
 import { HdMasterKey } from './masterkey.js';
 import { Mempool, UTXO } from './mempool.js';
 import { getNetwork } from './network.js';
@@ -231,7 +231,7 @@ export async function undelegateGUI() {
     if (!validateAmount(nAmount)) return;
 
     // Generate a new address to undelegate towards
-    const [address] = await wallet.getNewAddress();
+    const [address] = wallet.getNewAddress();
 
     // Perform the TX
     const cTxRes = await createAndSendTransaction({
@@ -299,7 +299,7 @@ export async function createAndSendTransaction({
 
     // Compute change (or lack thereof)
     const nChange = cCoinControl.nValue - (nFee + amount);
-    const [changeAddress, changeAddressPath] = await wallet.getNewAddress({
+    const [changeAddress, changeAddressPath] = await getNewAddress({
         verify: wallet.isHardwareWallet(),
     });
 
@@ -349,8 +349,7 @@ export async function createAndSendTransaction({
 
     // Primary output (receiver)
     if (isDelegation) {
-        const [primaryAddress, primaryAddressPath] =
-            await wallet.getNewAddress();
+        const [primaryAddress, primaryAddressPath] = await getNewAddress();
         cTx.addcoldstakingoutput(primaryAddress, address, amount / COIN);
         outputs.push([primaryAddress, address, amount / COIN]);
 
@@ -410,7 +409,7 @@ export async function createAndSendTransaction({
         }
 
         if (!isDelegation && !isProposal) {
-            const path = await wallet.isOwnAddress(address);
+            const path = wallet.isOwnAddress(address);
 
             // If the tx was sent to yourself, add it to the mempool
             if (path) {
@@ -443,7 +442,7 @@ export async function createMasternode() {
         return;
 
     // Generate the Masternode collateral
-    const [address] = await wallet.getNewAddress();
+    const [address] = getNewAddress({ verify: wallet.isHardwareWallet() });
     const result = await createAndSendTransaction({
         amount: cChainParams.current.collateralInSats,
         address,

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -28,7 +28,7 @@ import { Database } from './database.js';
 import { guiRenderCurrentReceiveModal } from './contacts-book.js';
 import { Account } from './accounts.js';
 import { debug, fAdvancedMode } from './settings.js';
-import { strHardwareName, getHardwareWalletKeys } from './ledger.js';
+import { strHardwareName } from './ledger.js';
 export let fWalletLoaded = false;
 
 /**
@@ -106,7 +106,7 @@ export class Wallet {
 
     /**
      * Set or replace the active Master Key with a new Master Key
-     * @param {Promise<MasterKey>} mk - The new Master Key to set active
+     * @param {import('./masterkey.js').MasterKey} mk - The new Master Key to set active
      */
     async setMasterKey(mk) {
         this.#masterKey = mk;
@@ -116,36 +116,33 @@ export class Wallet {
 
     /**
      * Derive the current address (by internal index)
-     * @return {Promise<String>} Address
+     * @return {string} Address
      *
      */
-    async getCurrentAddress() {
-        return await this.getAddress(0, this.#addressIndex);
+    getCurrentAddress() {
+        return this.getAddress(0, this.#addressIndex);
     }
 
     /**
      * Derive a generic address (given nReceiving and nIndex)
-     * @return {Promise<String>} Address
+     * @return {string} Address
      */
-    async getAddress(nReceiving = 0, nIndex = 0) {
+    getAddress(nReceiving = 0, nIndex = 0) {
         const path = this.getDerivationPath(nReceiving, nIndex);
-        return await this.#masterKey.getAddress(path);
+        return this.#masterKey.getAddress(path);
     }
 
     /**
      * Derive xpub (given nReceiving and nIndex)
-     * @return {Promise<String>} Address
+     * @return {string} Address
      */
-    async getXPub(nReceiving = 0, nIndex = 0) {
-        if (this.isHD()) {
-            // Get our current wallet XPub
-            const derivationPath = this.getDerivationPath(nReceiving, nIndex)
-                .split('/')
-                .slice(0, 4)
-                .join('/');
-            return await this.#masterKey.getxpub(derivationPath);
-        }
-        throw new Error('Legacy wallet does not have a xpub');
+    getXPub(nReceiving = 0, nIndex = 0) {
+        // Get our current wallet XPub
+        const derivationPath = this.getDerivationPath(nReceiving, nIndex)
+            .split('/')
+            .slice(0, 4)
+            .join('/');
+        return this.#masterKey.getxpub(derivationPath);
     }
 
     /**
@@ -166,7 +163,7 @@ export class Wallet {
 
         // Prepare to Add/Update an account in the DB
         const cAccount = new Account({
-            publicKey: await this.getKeyToExport(),
+            publicKey: this.getKeyToExport(),
             encWif: strEncWIF,
         });
 
@@ -187,9 +184,9 @@ export class Wallet {
     }
 
     /**
-     * @return Promise<[string, string]> Address and its BIP32 derivation path
+     * @return [string, string] Address and its BIP32 derivation path
      */
-    async getNewAddress() {
+    getNewAddress() {
         const last = getNetwork().lastWallet;
         this.#addressIndex =
             (this.#addressIndex > last ? this.#addressIndex : last) + 1;
@@ -198,20 +195,19 @@ export class Wallet {
             this.#addressIndex = last;
         }
         const path = this.getDerivationPath(0, this.#addressIndex);
-        const address = await this.getAddress(0, this.#addressIndex);
+        const address = this.getAddress(0, this.#addressIndex);
         return [address, path];
     }
-    // If the privateKey is null then the user connected a hardware wallet
+
     isHardwareWallet() {
-        if (!this.#masterKey) return false;
-        return this.#masterKey.isHardwareWallet == true;
+        return this.#masterKey?.isHardwareWallet === true;
     }
 
     /**
      * @param {string} address - address to check
-     * @return {Promise<String?>} BIP32 path or null if it's not your address
+     * @return {string?} BIP32 path or null if it's not your address
      */
-    async isOwnAddress(address) {
+    isOwnAddress(address) {
         if (this.#ownAddresses.has(address)) {
             return this.#ownAddresses.get(address);
         }
@@ -221,15 +217,14 @@ export class Wallet {
         if (this.isHD()) {
             for (let i = 0; i <= this.#addressIndex + MAX_ACCOUNT_GAP; i++) {
                 const path = this.getDerivationPath(0, i);
-                const testAddress = await this.#masterKey.getAddress(path);
+                const testAddress = this.#masterKey.getAddress(path);
                 if (address === testAddress) {
                     this.#ownAddresses.set(address, path);
                     return path;
                 }
             }
         } else {
-            const value =
-                address === (await this.getKeyToExport()) ? ':)' : null;
+            const value = address === this.getKeyToExport() ? ':)' : null;
             this.#ownAddresses.set(address, value);
             return value;
         }
@@ -249,8 +244,8 @@ export class Wallet {
         );
     }
 
-    async getKeyToExport() {
-        return await this.#masterKey?.getKeyToExport(this.#nAccount);
+    getKeyToExport() {
+        return this.#masterKey?.getKeyToExport(this.#nAccount);
     }
 }
 
@@ -290,15 +285,8 @@ export async function importWallet({
                 );
             }
             // Derive our hardware address and import!
-            await wallet.setMasterKey(new HardwareWalletMasterKey());
-            const publicKey = await getHardwareWalletKeys(
-                wallet.getDerivationPath()
-            );
-            // Errors are handled within the above function, so there's no need for an 'else' here, just silent ignore.
-            if (!publicKey) {
-                await wallet.setMasterKey(null);
-                return;
-            }
+            const key = await HardwareWalletMasterKey.create(0);
+            await wallet.setMasterKey(key);
 
             // Hide the 'export wallet' button, it's not relevant to hardware wallets
             doms.domExportWallet.hidden = true;
@@ -414,7 +402,7 @@ export async function importWallet({
         doms.domDashboard.click();
 
         // Update identicon
-        doms.domIdenticon.dataset.jdenticonValue = await wallet.getAddress();
+        doms.domIdenticon.dataset.jdenticonValue = wallet.getAddress();
         jdenticon.update('#identicon');
 
         // Hide the encryption prompt if the user is using
@@ -476,7 +464,7 @@ export async function generateWallet(noUI = false) {
         setDisplayForAllWalletOptions('none');
 
         // Update identicon
-        doms.domIdenticon.dataset.jdenticonValue = await wallet.getAddress();
+        doms.domIdenticon.dataset.jdenticonValue = wallet.getAddress();
         jdenticon.update('#identicon');
 
         await getNewAddress({ updateGUI: true });
@@ -618,14 +606,15 @@ export async function getNewAddress({
     updateGUI = false,
     verify = false,
 } = {}) {
-    const [address, path] = await wallet.getNewAddress();
+    const [address, path] = wallet.getNewAddress();
     if (verify && wallet.isHardwareWallet()) {
         // Generate address to present to the user without asking to verify
         const confAddress = await confirmPopup({
             title: ALERTS.CONFIRM_POPUP_VERIFY_ADDR,
             html: createAddressConfirmation(address),
-            resolvePromise: wallet.getMasterKey().getAddress(path, { verify }),
+            resolvePromise: wallet.getMasterKey().verifyAddress(path),
         });
+        console.log(address, confAddress);
         if (address !== confAddress) {
             throw new Error('User did not verify address');
         }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -285,8 +285,26 @@ export async function importWallet({
                 );
             }
             // Derive our hardware address and import!
-            const key = await HardwareWalletMasterKey.create(0);
-            await wallet.setMasterKey(key);
+            try {
+                const key = await HardwareWalletMasterKey.create(0);
+                await wallet.setMasterKey(key);
+            } catch (e) {
+                // Display a properly translated error if it's a ledger error
+                if (
+                    e instanceof Error &&
+                    e.message === 'Failed to get hardware wallet keys.'
+                ) {
+                    // console.error so we get a backtrace if needed
+                    console.error(e);
+                    return createAlert(
+                        'warning',
+                        translation.FAILED_TO_IMPORT_HARDWARE,
+                        5000
+                    );
+                } else {
+                    throw e;
+                }
+            }
 
             // Hide the 'export wallet' button, it's not relevant to hardware wallets
             doms.domExportWallet.hidden = true;


### PR DESCRIPTION
## Abstract
This PR aims to refactor ledger to prevent most of the common errors that commonly pop up.
All MasterKey functions are now non-async.
HardwareMasterKey is now simply a view-only HdMasterKey with one addtional function that verifies the address. All non-important addresses must be derived using `getAddress` as normal.
When an address needs to be used to transfer funds (for instance to generate change addresses), verifyAddress must also be called, which will derive the address using the ledger and will ask the user to validate it.


## Testing
- Test all ledger functions
