### PR TITLE
Add duddino testnet explorer

### DIFF
--- a/scripts/chain_params.js
+++ b/scripts/chain_params.js
@@ -67,6 +67,7 @@ export const cChainParams = {
         Explorers: [
             // Display name      Blockbook-compatible API base
             { name: 'rockdev', url: 'https://testnet.rockdev.org' },
+            { name: 'duddino', url: 'https://testnet.duddino.com' },
         ],
         Nodes: [{ name: 'Duddino', url: 'https://rpc.duddino.com/testnet' }],
         Consensus: {


### PR DESCRIPTION
## Abstract

Add duddino testnet explorer

Due to the addition, both `explorer.duddino.com` and `testnet.duddino.com` are currently syncing, however they should be available to use soon.

## Testing

- Switch to testnet and testnet.duddino.com
- Check that all network requests work and don't switch back to rockdev due to errors
