### PR TITLE
Add change address

### DIFF
--- a/scripts/Activity.vue
+++ b/scripts/Activity.vue
@@ -270,7 +270,9 @@ defineExpose({ update, reset, getTxCount });
 <template>
     <center>
         <span class="dcWallet-activityLbl"
-            ><span :data-i18n="rewards ? 'rewardHistory' : 'activity'">{{ title }}</span>
+            ><span :data-i18n="rewards ? 'rewardHistory' : 'activity'">{{
+                title
+            }}</span>
             <span v-if="rewards"> ({{ rewardsText }} {{ ticker }}) </span>
         </span>
     </center>

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1529,7 +1529,9 @@ export async function sweepAddress(arrUTXOs, sweepingMasterKey, nFixedFee = 0) {
     const nFee = nFixedFee || getNetwork().getFee(cTx.serialize().length);
 
     // Use a new address from our wallet to sweep the UTXOs in to
-    const strAddress = (await getNewAddress(true, false))[0];
+    const strAddress = (
+        await getNewAddress({ nReceiving: 1, updateGUI: true, verify: false })
+    )[0];
 
     // Sweep the full funds amount, minus the fee, leaving no change from any sweeped UTXOs
     cTx.addoutput(strAddress, (nTotal - nFee) / COIN);
@@ -2529,7 +2531,7 @@ export async function createProposal() {
     // If Advanced Mode is enabled and an address is given, use the provided address, otherwise, generate a new one
     const strAddress =
         document.getElementById('proposalAddress').value.trim() ||
-        (await wallet.getNewAddress())[0];
+        (await wallet.getNewAddress(1))[0];
     const nextSuperblock = await Masternode.getNextSuperblock();
     const proposal = {
         name: strTitle,

--- a/scripts/masterkey.js
+++ b/scripts/masterkey.js
@@ -73,7 +73,7 @@ export class MasterKey {
     }
 
     /**
-     * @return {Promise<String>} public key to export. Only suitable for monitoring balance.
+     * @return {string} public key to export. Only suitable for monitoring balance.
      * @abstract
      */
     getKeyToExport(_nAccount) {

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -306,7 +306,7 @@ export class ExplorerNetwork extends Network {
 
             const nReceiving = parseInt(path[4]);
             const nAccount = parseInt(path[5]);
-            const lastWallet = this._lastWallets.get(nReceiving);
+            const lastWallet = this.getLastWallet(nReceiving);
 
             this._lastWallets.set(nReceiving, Math.max(nAccount, lastWallet));
             path = path.join('/');

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -95,6 +95,12 @@ export class HistoricalTx {
 export class Network {
     wallet;
     /**
+     * Map last wallet by receiving index
+     * @protected
+     * @type {Map<number, number>}
+     */
+    _lastWallets = new Map();
+    /**
      * @param {import('./wallet.js').Wallet} wallet
      */
     constructor(wallet) {
@@ -104,7 +110,6 @@ export class Network {
         this._enabled = true;
         this.wallet = wallet;
 
-        this.lastWallet = 0;
         this.isHistorySynced = false;
     }
 
@@ -165,6 +170,10 @@ export class Network {
 
     async getTxInfo(_txHash) {
         throw new Error('getTxInfo must be implemented');
+    }
+
+    getLastWallet(nReceiving = 0) {
+        return this._lastWallets.get(nReceiving) ?? 0;
     }
 }
 
@@ -294,7 +303,12 @@ export class ExplorerNetwork extends Network {
                 (this.wallet.isHardwareWallet()
                     ? cChainParams.current.BIP44_TYPE_LEDGER
                     : cChainParams.current.BIP44_TYPE) + "'";
-            this.lastWallet = Math.max(parseInt(path[5]), this.lastWallet);
+
+            const nReceiving = parseInt(path[4]);
+            const nAccount = parseInt(path[5]);
+            const lastWallet = this._lastWallets.get(nReceiving);
+
+            this._lastWallets.set(nReceiving, Math.max(nAccount, lastWallet));
             path = path.join('/');
         }
 

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -11,7 +11,7 @@ import {
     guiSetColdStakingAddress,
 } from './global.js';
 import { cHardwareWallet, strHardwareName } from './ledger.js';
-import { wallet } from './wallet.js';
+import { wallet, getNewAddress } from './wallet.js';
 import { HdMasterKey } from './masterkey.js';
 import { Mempool, UTXO } from './mempool.js';
 import { getNetwork } from './network.js';
@@ -231,7 +231,7 @@ export async function undelegateGUI() {
     if (!validateAmount(nAmount)) return;
 
     // Generate a new address to undelegate towards
-    const [address] = await wallet.getNewAddress();
+    const [address] = await wallet.getNewAddress(1);
 
     // Perform the TX
     const cTxRes = await createAndSendTransaction({
@@ -299,7 +299,8 @@ export async function createAndSendTransaction({
 
     // Compute change (or lack thereof)
     const nChange = cCoinControl.nValue - (nFee + amount);
-    const [changeAddress, changeAddressPath] = await wallet.getNewAddress({
+    const [changeAddress, changeAddressPath] = await getNewAddress({
+        nReceiving: 1,
         verify: wallet.isHardwareWallet(),
     });
 
@@ -349,8 +350,9 @@ export async function createAndSendTransaction({
 
     // Primary output (receiver)
     if (isDelegation) {
-        const [primaryAddress, primaryAddressPath] =
-            await wallet.getNewAddress();
+        const [primaryAddress, primaryAddressPath] = await wallet.getNewAddress(
+            1
+        );
         cTx.addcoldstakingoutput(primaryAddress, address, amount / COIN);
         outputs.push([primaryAddress, address, amount / COIN]);
 
@@ -443,7 +445,7 @@ export async function createMasternode() {
         return;
 
     // Generate the Masternode collateral
-    const [address] = await wallet.getNewAddress();
+    const [address] = await wallet.getNewAddress(1);
     const result = await createAndSendTransaction({
         amount: cChainParams.current.collateralInSats,
         address,

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -229,9 +229,11 @@ export class Wallet {
                 getNetwork().getLastWallet(nReceiving),
                 this.#addressIndeces.get(nReceiving) ?? 0
             );
+
             if (this.isHD()) {
                 for (let i = 0; i <= maxIndex + MAX_ACCOUNT_GAP; i++) {
                     const path = this.getDerivationPath(nReceiving, i);
+                    console.log(nReceiving, path);
                     const testAddress = await this.#masterKey.getAddress(path);
                     if (address === testAddress) {
                         this.#ownAddresses.set(address, path);
@@ -244,10 +246,9 @@ export class Wallet {
                 this.#ownAddresses.set(address, value);
                 return value;
             }
-
-            this.#ownAddresses.set(address, null);
-            return null;
         }
+        this.#ownAddresses.set(address, null);
+        return null;
     }
 
     /**

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -316,8 +316,7 @@ export class Wallet {
                     }
                 }
             } else {
-                const value =
-                    address === (await this.getKeyToExport()) ? ':)' : null;
+                const value = address === this.getKeyToExport() ? ':)' : null;
                 this.#ownAddresses.set(address, value);
                 return value;
             }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -51,7 +51,7 @@ export class Wallet {
      * nReceiving = 1 are change addresses
      * @type {Map<number, number>}
      */
-    #addressIndeces = new Map();
+    #addressIndices = new Map();
 
     /**
      * Map our own address -> Path
@@ -125,7 +125,7 @@ export class Wallet {
     async getCurrentAddress(nReceiving = 0) {
         return await this.getAddress(
             nReceiving,
-            this.#addressIndeces.get(nReceiving) ?? 0
+            this.#addressIndices.get(nReceiving) ?? 0
         );
     }
 
@@ -198,12 +198,12 @@ export class Wallet {
     async getNewAddress(nReceiving = 0) {
         const last = getNetwork().getLastWallet(nReceiving);
         let newIndex =
-            Math.max(last, this.#addressIndeces.get(nReceiving) ?? 0) + 1;
+            Math.max(last, this.#addressIndices.get(nReceiving) ?? 0) + 1;
         if (newIndex - last > MAX_ACCOUNT_GAP) {
             // If the user creates more than ${MAX_ACCOUNT_GAP} empty wallets we will not be able to sync them!
             newIndex = last;
         }
-        this.#addressIndeces.set(nReceiving, newIndex);
+        this.#addressIndices.set(nReceiving, newIndex);
         const path = this.getDerivationPath(nReceiving, newIndex);
         const address = await this.getAddress(nReceiving, newIndex);
         return [address, path];
@@ -227,13 +227,12 @@ export class Wallet {
         for (const nReceiving of [0, 1]) {
             const maxIndex = Math.max(
                 getNetwork().getLastWallet(nReceiving),
-                this.#addressIndeces.get(nReceiving) ?? 0
+                this.#addressIndices.get(nReceiving) ?? 0
             );
 
             if (this.isHD()) {
                 for (let i = 0; i <= maxIndex + MAX_ACCOUNT_GAP; i++) {
                     const path = this.getDerivationPath(nReceiving, i);
-                    console.log(nReceiving, path);
                     const testAddress = await this.#masterKey.getAddress(path);
                     if (address === testAddress) {
                         this.#ownAddresses.set(address, path);


### PR DESCRIPTION
## Abstract

Add proper change address, deriving them using `m/44'/119'/0'/1/${nAccount}` (or equivalent for testnet/hardware wallets).
All "internal" addresses, i.e. addresses that are not presented to the user, should derive this way.

## Testing
- Test send and receiving and that balance is correct
- (Advanced) Check that the explorer return the correct bip32 path

