### PR TITLE
Fix ledger udev error

### DIFF
--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -92,7 +92,7 @@ export async function getHardwareWalletKeys(path, xpub = false, verify = true) {
         // This is when the OS denies access to the WebUSB
         // It's likely caused by faulty udev rules on linux
         console.log(e.message);
-        if (e instanceof DOMException && e.message.match(/Access Denied/i)) {
+        if (e instanceof DOMException && e.message.match(/access denied/i)) {
             if (navigator.userAgent.toLowerCase().includes('linux')) {
                 createAlert('warning', ALERTS.WALLET_HARDWARE_UDEV, 5500);
             } else {

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -91,7 +91,6 @@ export async function getHardwareWalletKeys(path, xpub = false, verify = true) {
 
         // This is when the OS denies access to the WebUSB
         // It's likely caused by faulty udev rules on linux
-        console.log(e.message);
         if (e instanceof DOMException && e.message.match(/access denied/i)) {
             if (navigator.userAgent.toLowerCase().includes('linux')) {
                 createAlert('warning', ALERTS.WALLET_HARDWARE_UDEV, 5500);

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -91,7 +91,8 @@ export async function getHardwareWalletKeys(path, xpub = false, verify = true) {
 
         // This is when the OS denies access to the WebUSB
         // It's likely caused by faulty udev rules on linux
-        if (e instanceof DOMException && e.message.includes('Access Denied')) {
+        console.log(e.message);
+        if (e instanceof DOMException && e.message.match(/Access Denied/i)) {
             if (navigator.userAgent.toLowerCase().includes('linux')) {
                 createAlert('warning', ALERTS.WALLET_HARDWARE_UDEV, 5500);
             } else {


### PR DESCRIPTION
## Abstract

This PR just makes the check case insensitive.
The error was much more descriptive than the former `undefined`, but the intended message wasn't being displayed

## Testing
- Try to access the ledger without proper udev rules