### PR TITLE
Coin Lock system

### DIFF
--- a/scripts/charting.js
+++ b/scripts/charting.js
@@ -70,7 +70,7 @@ async function getWalletDataset() {
     if (masternode) {
         if (
             wallet.isCoinLocked(
-                COutpoint({
+                new COutpoint({
                     txid: masternode.collateralTxId,
                     n: masternode.outidx,
                 })

--- a/scripts/charting.js
+++ b/scripts/charting.js
@@ -11,7 +11,7 @@ import { cChainParams, COIN } from './chain_params.js';
 import { doms, mempool } from './global.js';
 import { Database } from './database.js';
 import { translation } from './i18n.js';
-import { UTXO_WALLET_STATE } from './mempool.js';
+import { wallet } from './wallet.js';
 import { COutpoint } from './mempool.js';
 
 Chart.register(
@@ -68,11 +68,14 @@ async function getWalletDataset() {
 
     // Masternode (Locked)
     if (masternode) {
-        const mnOp = new COutpoint({
-            txid: masternode.collateralTxId,
-            n: masternode.outidx,
-        });
-        if (mempool.hasUTXO(mnOp, UTXO_WALLET_STATE.SPENDABLE, true)) {
+        if (
+            wallet.isCoinLocked(
+                COutpoint({
+                    txid: masternode.collateralTxId,
+                    n: masternode.outidx,
+                })
+            )
+        ) {
             arrBreakdown.push({
                 type: 'Masternode',
                 balance: cChainParams.current.collateralInSats / COIN,

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -278,7 +278,7 @@ export class Database {
             .transaction('masternodes', 'readonly')
             .objectStore('masternodes');
         const mnData = await store.get('masternode');
-        return mnData === undefined ? null : new Masternode(mnData);
+        return !mnData ? null : new Masternode(mnData);
     }
 
     /**

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -277,7 +277,8 @@ export class Database {
         const store = this.#db
             .transaction('masternodes', 'readonly')
             .objectStore('masternodes');
-        return new Masternode(await store.get('masternode'));
+        const mnData = await store.get('masternode');
+        return mnData === undefined ? null : new Masternode(mnData);
     }
 
     /**

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2360,37 +2360,38 @@ export async function updateMasternodeTab() {
         doms.domMnAccessMasternodeText.innerHTML = doms.masternodeHDAccessText;
 
         // First UTXO for each address in HD
-        const mapCollateralAddresses = new Map();
+        const mapCollateralPath = new Map();
 
-        // Aggregate all valid Masternode collaterals into a map of Address <--> Collateral
+        // Aggregate all valid Masternode collaterals into a map of Path <--> Collateral
         for (const cUTXO of mempool.getUTXOs({
             filter: UTXO_WALLET_STATE.SPENDABLE,
             onlyConfirmed: true,
             includeLocked: false,
         })) {
             if (cUTXO.value !== cChainParams.current.collateralInSats) continue;
-            mapCollateralAddresses.set(wallet.getPath(cUTXO.script), cUTXO);
+            mapCollateralPath.set(wallet.getPath(cUTXO.script), cUTXO);
         }
-        const fHasCollateral = mapCollateralAddresses.size > 0;
+        const fHasCollateral = mapCollateralPath.size > 0;
 
         // If there's no loaded MN, but valid collaterals, display the configuration screen
         if (!cMasternode && fHasCollateral) {
             doms.domMnTxId.style.display = 'block';
             doms.domAccessMasternode.style.display = 'block';
 
-            for (const [key] of mapCollateralAddresses) {
+            for (const [key] of mapCollateralPath) {
                 const option = document.createElement('option');
                 option.value = key;
-                option.innerText = await wallet.getAddress(key);
+                option.innerText = wallet.getAddressFromPath(key);
                 doms.domMnTxId.appendChild(option);
             }
         }
 
         // If there's no collateral found, display the creation UI
-        if (!fHasCollateral) doms.domCreateMasternode.style.display = 'block';
+        if (!fHasCollateral && !cMasternode)
+            doms.domCreateMasternode.style.display = 'block';
 
-        // If we have a collateral and a loaded Masternode, display the Dashboard
-        if (fHasCollateral && cMasternode) {
+        // If we a loaded Masternode, display the Dashboard
+        if (cMasternode) {
             // Refresh the display
             refreshMasternodeData(cMasternode);
             doms.domMnDashboard.style.display = '';

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1043,8 +1043,17 @@ export async function startMasternode(fRestart = false) {
 
 export async function destroyMasternode() {
     const database = await Database.getInstance();
+    const cMasternode = await database.getMasternode(wallet.getMasterKey());
+    if (cMasternode) {
+        // Unlock the coin and update the balance
+        wallet.unlockCoin(
+            new COutpoint({
+                txid: cMasternode.collateralTxId,
+                n: cMasternode.outidx,
+            })
+        );
+        mempool.setBalance();
 
-    if (await database.getMasternode(wallet.getMasterKey())) {
         database.removeMasternode(wallet.getMasterKey());
         createAlert('success', ALERTS.MN_DESTROYED, 5000);
         updateMasternodeTab();

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2302,7 +2302,7 @@ export async function updateMasternodeTab() {
     if (cMasternode) {
         if (
             !wallet.isCoinLocked(
-                COutpoint({
+                new COutpoint({
                     txid: cMasternode.collateralTxId,
                     n: cMasternode.outidx,
                 })
@@ -2435,7 +2435,7 @@ async function refreshMasternodeData(cMasternode, fAlert = false) {
                 const database = await Database.getInstance();
                 await database.addMasternode(cMasternode);
                 wallet.lockCoin(
-                    COutpoint({
+                    new COutpoint({
                         txid: cMasternode.collateralTxId,
                         n: cMasternode.outidx,
                     })
@@ -2460,7 +2460,7 @@ async function refreshMasternodeData(cMasternode, fAlert = false) {
         const database = await Database.getInstance();
         await database.addMasternode(cMasternode);
         wallet.lockCoin(
-            COutpoint({
+            new COutpoint({
                 txid: cMasternode.collateralTxId,
                 n: cMasternode.outidx,
             })

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2434,6 +2434,12 @@ async function refreshMasternodeData(cMasternode, fAlert = false) {
                 createAlert('success', ALERTS.MN_STARTED_ONLINE_SOON, 6000);
                 const database = await Database.getInstance();
                 await database.addMasternode(cMasternode);
+                wallet.lockCoin(
+                    COutpoint({
+                        txid: cMasternode.collateralTxId,
+                        n: cMasternode.outidx,
+                    })
+                );
             } else {
                 doms.domMnTextErrors.innerHTML = ALERTS.MN_START_FAILED;
                 createAlert('warning', ALERTS.MN_START_FAILED, 6000);
@@ -2453,6 +2459,12 @@ async function refreshMasternodeData(cMasternode, fAlert = false) {
             );
         const database = await Database.getInstance();
         await database.addMasternode(cMasternode);
+        wallet.lockCoin(
+            COutpoint({
+                txid: cMasternode.collateralTxId,
+                n: cMasternode.outidx,
+            })
+        );
     } else if (cMasternodeData.status === 'REMOVED') {
         const state = cMasternodeData.status;
         doms.domMnTextErrors.innerHTML = tr(ALERTS.MN_STATE, [

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2341,14 +2341,12 @@ export async function updateMasternodeTab() {
             );
 
         const balance = getBalance(false);
-        if (cCollaUTXO) {
-            if (cMasternode) {
-                await refreshMasternodeData(cMasternode);
-                doms.domMnDashboard.style.display = '';
-            } else {
-                doms.domMnTxId.style.display = 'none';
-                doms.domAccessMasternode.style.display = 'block';
-            }
+        if (cMasternode) {
+            await refreshMasternodeData(cMasternode);
+            doms.domMnDashboard.style.display = '';
+        } else if (cCollaUTXO) {
+            doms.domMnTxId.style.display = 'none';
+            doms.domAccessMasternode.style.display = 'block';
         } else if (balance < cChainParams.current.collateralInSats) {
             // The user needs more funds
             doms.domMnTextErrors.innerHTML =
@@ -2381,7 +2379,6 @@ export async function updateMasternodeTab() {
             mapCollateralPath.set(wallet.getPath(cUTXO.script), cUTXO);
         }
         const fHasCollateral = mapCollateralPath.size > 0;
-
         // If there's no loaded MN, but valid collaterals, display the configuration screen
         if (!cMasternode && fHasCollateral) {
             doms.domMnTxId.style.display = 'block';

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -235,7 +235,7 @@ export class Mempool {
         });
     }
     /**
-     * Add op to the spent map and eventually remove it from the lock set
+     * Add op to the spent map and optionally remove it from the lock set
      * @param {String} txid - transaction id
      * @param {COutpoint} op
      */

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -181,18 +181,12 @@ export class Mempool {
                         (x) => x.txid == op.txid && x.vout == op.n
                     );
                     if (!isMyUTXO && !this.isSpent(op)) {
-                        this.spent.set(tx.txid, op);
-                        if (wallet.isCoinLocked(op)) wallet.unlockCoin(op);
+                        this.setSpent(tx.txid, op);
                     }
                 }
             }
             this.#isLoaded = true;
-            this.#balance = this.getBalance(UTXO_WALLET_STATE.SPENDABLE);
-            this.#coldBalance = this.getBalance(
-                UTXO_WALLET_STATE.SPENDABLE_COLD
-            );
-            getEventEmitter().emit('balance-update');
-            getStakingBalance(true);
+            this.setBalance();
             activityDashboard.update();
             stakingDashboard.update();
             getEventEmitter().emit('sync-status', 'stop');
@@ -220,6 +214,15 @@ export class Mempool {
             }
             getEventEmitter().emit('sync-status', 'stop');
         });
+    }
+    /**
+     * Add op to the spent map and eventually remove it from the lock set
+     * @param {String} txid - transaction id
+     * @param {COutpoint} op
+     */
+    setSpent(txid, op) {
+        this.spent.set(txid, op);
+        if (wallet.isCoinLocked(op)) wallet.unlockCoin(op);
     }
     /**
      * An Outpoint to check

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -334,7 +334,7 @@ export class Mempool {
                 if (wallet.isCoinLocked(op)) wallet.unlockCoin(op);
             }
         }
-        setBalance();
+        this.setBalance();
     }
     setBalance() {
         this.#balance = this.getBalance(UTXO_WALLET_STATE.SPENDABLE);

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -334,6 +334,9 @@ export class Mempool {
                 if (wallet.isCoinLocked(op)) wallet.unlockCoin(op);
             }
         }
+        setBalance();
+    }
+    setBalance() {
         this.#balance = this.getBalance(UTXO_WALLET_STATE.SPENDABLE);
         this.#coldBalance = this.getBalance(UTXO_WALLET_STATE.SPENDABLE_COLD);
         getEventEmitter().emit('balance-update');

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -422,7 +422,9 @@ export async function createMasternode() {
         return;
 
     // Generate the Masternode collateral
-    const [address] = getNewAddress({ verify: wallet.isHardwareWallet() });
+    const [address] = await getNewAddress({
+        verify: wallet.isHardwareWallet(),
+    });
     const result = await createAndSendTransaction({
         amount: cChainParams.current.collateralInSats,
         address,

--- a/scripts/transactions.js
+++ b/scripts/transactions.js
@@ -514,16 +514,14 @@ async function chooseUTXOs(
     const arrUTXOs = mempool.getUTXOs({
         filter: filter,
         target: nTotalSatsRequired,
+        includeLocked: false,
     });
 
     // Select and return UTXO pointers (filters applied)
     const cCoinControl = { nValue: 0, nChange: 0, arrSelectedUTXOs: [] };
-    const masternode = await (await Database.getInstance()).getMasternode();
 
     for (let i = 0; i < arrUTXOs.length; i++) {
         const cUTXO = arrUTXOs[i];
-        // Don't spend locked Masternode collaterals
-        if (isMasternodeUTXO(cUTXO, masternode)) continue; //CHANGE THIS
 
         // Have we met the required sats threshold?
         if (

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -19,6 +19,7 @@ import {
     refreshChainData,
     setDisplayForAllWalletOptions,
     getStakingBalance,
+    mempool,
 } from './global.js';
 import { ALERTS, tr, translation } from './i18n.js';
 import { encrypt, decrypt } from './aes-gcm.js';
@@ -100,6 +101,7 @@ export class Wallet {
      */
     lockCoin(opt) {
         this.#lockedCoins.add(opt.toUnique());
+        mempool.setBalance();
     }
 
     /**
@@ -199,6 +201,14 @@ export class Wallet {
      */
     getAddress(nReceiving = 0, nIndex = 0) {
         const path = this.getDerivationPath(nReceiving, nIndex);
+        return this.#masterKey.getAddress(path);
+    }
+
+    /**
+     * Derive a generic address (given the full path)
+     * @return {string} Address
+     */
+    getAddressFromPath(path) {
         return this.#masterKey.getAddress(path);
     }
 

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -514,7 +514,7 @@ export async function importWallet({
         const masternode = await (await Database.getInstance()).getMasternode();
         if (masternode) {
             wallet.lockCoin(
-                COutpoint({
+                new COutpoint({
                     txid: masternode.collateralTxId,
                     n: masternode.outidx,
                 })


### PR DESCRIPTION
## Abstract

This PR makes the "Don't spend my MN" system more abstract and general.
A Locked Coin is an UTXO that we don't want to spend, at the moment it is only used to avoid spending the masternode collateral (but it will have future application, for example when we will have a better coin control), the flow is the following:
1) While importing the wallet lock the masternode collateral
2) Each time a UTXO is put in the spent multimap, unlock it
So to check if the masternode is still unspent we can simply check if the collateral is in the lock set.

Overall the code is simplified because we can avoid outputting locked coins directly in the `getBalance` and `getUTXOs` functions.

---

## Testing
Verify that your masternode is locked. Checking that the balance does not consider it is enough.

