### PR TITLE
Ignore immature txs

### DIFF
--- a/scripts/Activity.vue
+++ b/scripts/Activity.vue
@@ -161,9 +161,11 @@ async function parseTXs(arrTXs) {
         // Update the time cache
         prevTimestamp = cTx.time * 1000;
 
-        // Coinbase Transactions (rewards) require 100 confs
+        // Coinbase Transactions (rewards) require coinbaseMaturity confs
         const fConfirmed =
-            cNet.cachedBlockCount - cTx.blockHeight >= props.rewards ? 100 : 6;
+            cNet.cachedBlockCount - cTx.blockHeight >= props.rewards
+                ? cChainParams.coinbaseMaturity
+                : 6;
 
         // Choose the content type, for the Dashboard; use a generative description, otherwise, a TX-ID
         // let txContent = props.rewards ? cTx.id : 'Block Reward';

--- a/scripts/Activity.vue
+++ b/scripts/Activity.vue
@@ -164,7 +164,7 @@ async function parseTXs(arrTXs) {
         // Coinbase Transactions (rewards) require coinbaseMaturity confs
         const fConfirmed =
             cNet.cachedBlockCount - cTx.blockHeight >= props.rewards
-                ? cChainParams.coinbaseMaturity
+                ? cChainParams.current.coinbaseMaturity
                 : 6;
 
         // Choose the content type, for the Dashboard; use a generative description, otherwise, a TX-ID

--- a/scripts/Activity.vue
+++ b/scripts/Activity.vue
@@ -163,9 +163,8 @@ async function parseTXs(arrTXs) {
 
         // Coinbase Transactions (rewards) require coinbaseMaturity confs
         const fConfirmed =
-            cNet.cachedBlockCount - cTx.blockHeight >= props.rewards
-                ? cChainParams.current.coinbaseMaturity
-                : 6;
+            cNet.cachedBlockCount - cTx.blockHeight >=
+            (props.rewards ? cChainParams.current.coinbaseMaturity : 6);
 
         // Choose the content type, for the Dashboard; use a generative description, otherwise, a TX-ID
         // let txContent = props.rewards ? cTx.id : 'Block Reward';

--- a/scripts/chain_params.js
+++ b/scripts/chain_params.js
@@ -46,6 +46,7 @@ export const cChainParams = reactive({
             // Network upgrades
             UPGRADE_V6_0: undefined,
         },
+        coinbaseMaturity: 100,
         budgetCycleBlocks: 43200,
         proposalFee: 50 * COIN,
         proposalFeeConfirmRequirement: 6,
@@ -77,6 +78,7 @@ export const cChainParams = reactive({
             // Network upgrades
             UPGRADE_V6_0: undefined,
         },
+        coinbaseMaturity: 15,
         budgetCycleBlocks: 144,
         proposalFee: 50 * COIN,
         proposalFeeConfirmRequirement: 3,

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -77,7 +77,7 @@ export class Transaction {
     }
     isCoinBase() {
         // txid undefined happens only for coinbase inputs
-        return this.vin.length == 1 && this.vin[0].outpoint.txid === undefined;
+        return this.vin.length == 1 && !this.vin[0].outpoint.txid;
     }
     isMature() {
         if (!(this.isCoinBase() || this.isCoinStake())) {

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -27,6 +27,9 @@ export class CTxOut {
          *  @type {Number} */
         this.value = value;
     }
+    isEmpty() {
+        return this.value == 0 && this.script == 'f8';
+    }
 }
 export class CTxIn {
     /**
@@ -68,6 +71,13 @@ export class Transaction {
     }
     isConfirmed() {
         return this.blockHeight != -1;
+    }
+    isCoinStake() {
+        return this.vout.length >= 2 && this.vout[0].isEmpty();
+    }
+    isCoinBase() {
+        // txid undefined happens only for coinbase inputs
+        return this.vin.length == 1 && this.vin[0].outpoint.txid === undefined;
     }
 }
 /** An Unspent Transaction Output, used as Inputs of future transactions */


### PR DESCRIPTION
## Abstract

Wallet can now recognize if a tx is Coinbase/Coinstake/mature or immature. Wallet will ignore immature txs since they cannot be spent yet

---

## Testing
For devs: should be enough verifying that your coinbase/coinstake txs are recognized as such (use a console.log for example)

