### PR TITLE
Transaction Database

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -463,6 +463,10 @@ export async function start() {
             await accessOrImportWallet();
         }
     } else {
+        // Clear the transaction DB
+        const database = await Database.getInstance();
+        await database.removeAllTxs();
+
         // Just load the block count, for use in non-wallet areas
         getNetwork().getBlockCount();
     }

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -1,9 +1,6 @@
 import { getNetwork } from './network.js';
-import {
-    activityDashboard,
-    getStakingBalance,
-    stakingDashboard,
-} from './global.js';
+import { getStakingBalance } from './global.js';
+import { Database } from './database.js';
 import { getEventEmitter } from './event_bus.js';
 import Multimap from 'multimap';
 import { wallet } from './wallet.js';
@@ -180,6 +177,11 @@ export class Mempool {
      * @type {number} - Our Cold Staking balance in Satoshis
      */
     #coldBalance = 0;
+    /**
+     * @type {number} - Highest block height saved on disk
+     */
+    #highestSavedHeight = 0;
+
     constructor() {
         /**
          * Multimap txid -> spent Coutpoint
@@ -202,6 +204,8 @@ export class Mempool {
         this.txmap = new Map();
         this.spent = new Multimap();
         this.orderedTxmap = new Multimap();
+        this.#balance = 0;
+        this.#coldBalance = 0;
     }
     get balance() {
         return this.#balance;
@@ -364,5 +368,54 @@ export class Mempool {
         this.#coldBalance = this.getBalance(UTXO_WALLET_STATE.SPENDABLE_COLD);
         getEventEmitter().emit('balance-update');
         getStakingBalance(true);
+    }
+
+    /**
+     * Save txs on database
+     */
+    async saveOnDisk() {
+        const nBlockHeights = Array.from(this.orderedTxmap.keys())
+            .sort((a, b) => a - b)
+            .reverse();
+        if (nBlockHeights.length == 0) {
+            return;
+        }
+        const database = await Database.getInstance();
+        for (const nHeight of nBlockHeights) {
+            if (this.#highestSavedHeight > nHeight) {
+                break;
+            }
+            this.orderedTxmap.get(nHeight).forEach(async function (tx) {
+                await database.storeTx(tx);
+            });
+        }
+        this.#highestSavedHeight = nBlockHeights[0];
+    }
+    /**
+     * Load txs from database
+     * @returns {Promise<Boolean>} true if database was non-empty and transaction are loaded successfully
+     */
+    async loadFromDisk() {
+        const database = await Database.getInstance();
+        const txs = await database.getTxs();
+        if (txs.length == 0) {
+            return false;
+        }
+        for (const tx of txs) {
+            this.addToOrderedTxMap(tx);
+        }
+        const nBlockHeights = Array.from(this.orderedTxmap.keys()).sort(
+            (a, b) => a - b
+        );
+        for (const nHeight of nBlockHeights) {
+            for (const tx of this.orderedTxmap.get(nHeight)) {
+                this.updateMempool(tx);
+            }
+        }
+        const cNet = getNetwork();
+        cNet.fullSynced = true;
+        cNet.lastBlockSynced = nBlockHeights.at(-1);
+        this.setBalance();
+        return true;
     }
 }

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -385,9 +385,11 @@ export class Mempool {
             if (this.#highestSavedHeight > nHeight) {
                 break;
             }
-            this.orderedTxmap.get(nHeight).forEach(async function (tx) {
-                await database.storeTx(tx);
-            });
+            await Promise.all(
+                this.orderedTxmap.get(nHeight).map(async function (tx) {
+                    await database.storeTx(tx);
+                })
+            );
         }
         this.#highestSavedHeight = nBlockHeights[0];
     }

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -5,7 +5,6 @@ import { getEventEmitter } from './event_bus.js';
 import Multimap from 'multimap';
 import { wallet } from './wallet.js';
 import { COIN, cChainParams } from './chain_params.js';
-
 export class CTxOut {
     /**
      * @param {Object} CTxOut
@@ -417,6 +416,7 @@ export class Mempool {
         const cNet = getNetwork();
         cNet.fullSynced = true;
         cNet.lastBlockSynced = nBlockHeights.at(-1);
+        this.#highestSavedHeight = nBlockHeights.at(-1);
         this.setBalance();
         return true;
     }

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -5,6 +5,7 @@ import { getEventEmitter } from './event_bus.js';
 import Multimap from 'multimap';
 import { wallet } from './wallet.js';
 import { COIN, cChainParams } from './chain_params.js';
+
 export class CTxOut {
     /**
      * @param {Object} CTxOut

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -254,6 +254,7 @@ export class ExplorerNetwork extends Network {
                     mempool.updateMempool(mempool.parseTransaction(tx));
                 }
             }
+            await mempool.saveOnDisk();
         }
         if (debug) {
             console.log(
@@ -274,7 +275,6 @@ export class ExplorerNetwork extends Network {
     async walletFullSync() {
         if (this.fullSynced) return;
         if (!this.wallet || !this.wallet.isLoaded()) return;
-        getEventEmitter().emit('sync-status', 'start');
         await this.getLatestTxs(0);
         const nBlockHeights = Array.from(mempool.orderedTxmap.keys());
         this.lastBlockSynced =
@@ -282,9 +282,6 @@ export class ExplorerNetwork extends Network {
                 ? 0
                 : nBlockHeights.sort((a, b) => a - b).at(-1);
         this.fullSynced = true;
-        await activityDashboard.update(50);
-        await stakingDashboard.update(50);
-        getEventEmitter().emit('sync-status', 'stop');
     }
 
     /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -531,6 +531,10 @@ export async function toggleTestnet() {
         // Nuke the Master Key
         wallet.setMasterKey(null);
 
+        // Clear the transaction DB
+        const database = await Database.getInstance();
+        await database.removeAllTxs();
+
         // Hide all Dashboard info, kick the user back to the "Getting Started" area
         doms.domGenKeyWarning.style.display = 'none';
         doms.domGuiWallet.style.display = 'none';


### PR DESCRIPTION
## Abstract

This pull request is the third part of the "mempool v2" update. During first sync all transactions are saved on database. Then, when the wallet is opened again txs are fetched from the database and this is a very fast operation ( takes around 1 or 2 seconds to load a wallet with 50k transactions).

Apart from the huge sync speed the real benefit of this PR is that network requests are basically reduced to (almost) 0, which will make the wallet scale much better.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Open your wallet, encrypt it, and wait for it to sync.
- Once synced, re-open (Activity will be fetched from database this time), verify that the balance is the same, activity is ok and verify that it loaded fast.


