### PR TITLE
Fix lint not working for forks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,10 +37,9 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
 
-      - name: Run linters
-        uses: wearerequired/lint-action@v2
-        with:
-          eslint: true
-          prettier: true
+      - name: Run ESlint
+        run: npm run lint
+      - name: Run prettier
+        run: npx prettier -l .
       - name: Run tests
         run: npm test

--- a/scripts/prices.js
+++ b/scripts/prices.js
@@ -1,4 +1,3 @@
-aeiprheaouthoeathort;
 import { getEventEmitter } from './event_bus.js';
 import { isEmpty } from './misc.js';
 import { cMarket, fillCurrencySelect } from './settings.js';
@@ -15,7 +14,7 @@ export const COINGECKO_ENDPOINT =
  */
 export class MarketSource {
     /** The storage object for raw market data */
-    cData = {};
+     cData = {};
 
     /** The name of the market source */
     strName = '';

--- a/scripts/prices.js
+++ b/scripts/prices.js
@@ -1,3 +1,4 @@
+aeiprheaouthoeathort;
 import { getEventEmitter } from './event_bus.js';
 import { isEmpty } from './misc.js';
 import { cMarket, fillCurrencySelect } from './settings.js';

--- a/scripts/prices.js
+++ b/scripts/prices.js
@@ -14,7 +14,7 @@ export const COINGECKO_ENDPOINT =
  */
 export class MarketSource {
     /** The storage object for raw market data */
-     cData = {};
+    cData = {};
 
     /** The name of the market source */
     strName = '';


### PR DESCRIPTION
## Abstract

`wearerequired/lint-action@v2` automatically annotated PRs, which made it fail for forks. We could set the target to `pull_request_target`, but then there are potential vulnerabilities. 
Since we don't really need annotations, let's just run the npm script 

## Testing
No testing is required