### PR TITLE
Fix Changepassword and refactor

### DIFF
--- a/scripts/aes-gcm.js
+++ b/scripts/aes-gcm.js
@@ -6,20 +6,24 @@ const base64_to_buf = (b64) =>
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
-export async function encrypt(data, strPassword = '') {
-    const strPass =
-        strPassword ||
-        window.prompt('Please enter your wallet encryption password');
-    if (!strPass) return false;
-    return await encryptData(data, strPass);
+/**
+ * @param {String} data - The data you want to encrypt
+ * @param {String} strPassword - The password used to encrypt
+ * @returns {Promise<String|false>} Encrypt data or false if the process failed
+ */
+export async function encrypt(data, strPassword) {
+    if (!strPassword) return false;
+    return await encryptData(data, strPassword);
 }
 
+/**
+ * @param {String} data - The data you want to decrypt
+ * @param {String} strPassword - The password used to decrypt
+ * @returns {Promise<String|false>} Decrypted data or false if the process failed
+ */
 export async function decrypt(data, strPassword) {
-    const strPass =
-        strPassword ||
-        window.prompt('Please enter your wallet unlock password');
-    if (!strPass) return false;
-    return (await decryptData(data, strPass)) || 'decryption failed!';
+    if (!strPassword) return false;
+    return (await decryptData(data, strPassword)) || false;
 }
 
 const getPasswordKey = (password) =>

--- a/scripts/dashboard/GenKeyWarning.vue
+++ b/scripts/dashboard/GenKeyWarning.vue
@@ -1,17 +1,15 @@
 <script setup>
 import { translation, tr, ALERTS } from '../i18n.js';
-import { onMounted, ref, toRef } from 'vue';
+import { ref } from 'vue';
 import Modal from '../Modal.vue';
-import { hasEncryptedWallet as isEncrypt } from '../wallet.js';
 import { MIN_PASS_LENGTH } from '../chain_params.js';
 import { createAlert } from '../misc';
 
 const props = defineProps({
     showModal: Boolean,
     showBox: Boolean,
+    isEncrypt: Boolean,
 });
-
-const hasEncryptedWallet = ref(false);
 
 const currentPassword = ref('');
 const password = ref('');
@@ -45,10 +43,6 @@ function submit() {
     emit('onEncrypt', password.value, currentPassword.value);
     close();
 }
-
-onMounted(async () => {
-    hasEncryptedWallet.value = await isEncrypt();
-});
 </script>
 
 <template>
@@ -109,7 +103,7 @@ onMounted(async () => {
                         style="width: 100%; font-family: monospace"
                         type="password"
                         placeholder="Current Password"
-                        v-show="hasEncryptedWallet"
+                        v-show="isEncrypt"
                     />
                     <div class="col-12 col-md-6 p-0 pr-0 pr-md-1">
                         <input

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -250,7 +250,7 @@ export class Wallet {
         return !!this.#masterKey;
     }
 
-    async encryptWallet(strPassword = '') {
+    async encryptWallet(strPassword) {
         // Encrypt the wallet WIF with AES-GCM and a user-chosen password - suitable for browser storage
         let strEncWIF = await encrypt(this.#masterKey.keyToBackup, strPassword);
         if (!strEncWIF) return false;


### PR DESCRIPTION
## Abstract
`GenKeyWarning` set the variable `hasEncryptedWallet` only `onMounted`.  This means that if a new wallet was created `hasEncryptedWallet` remains `false` even after the user encrypted the wallet (and so for example when you click on changepassword the wrong input box is displayed).

This PR fixes the bug and in addition does a bit of refactor:

- `GenKeyWarning` does not know anymore the state of the wallet and takes `hasEncryptedWallet`  (that I renamed `isEncrypted`) externally
- The function `decrypt` in `aes-gcm` has been simplified: `strPassword` must be set externallly, if it isn't we return false directly (UI prompt has been removed)
- Added some JSDoc

---

