### PR TITLE
[Network] Do not set fullSync after reading txdb

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -179,8 +179,8 @@ async function importWallet({ type, secret, password = '' }) {
         } else {
             needsToEncrypt.value = false;
         }
-        if (!(await mempool.loadFromDisk()))
-            await getNetwork().walletFullSync();
+        await mempool.loadFromDisk();
+        await getNetwork().walletFullSync();
         getEventEmitter().emit('wallet-import');
         if (needsToEncrypt.value) showEncryptModal.value = true;
         return true;

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -416,11 +416,8 @@ export class Mempool {
             }
         }
         const cNet = getNetwork();
-        cNet.fullSynced = true;
         cNet.lastBlockSynced = nBlockHeights.at(-1);
-        getEventEmitter().emit('sync-status-update', 0, 0, true);
         this.#highestSavedHeight = nBlockHeights.at(-1);
-        this.setBalance();
         return true;
     }
 }

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -229,7 +229,10 @@ export class ExplorerNetwork extends Network {
             : null;
         //.txs returns the total number of wallet's transaction regardless the startHeight and we use this for first sync
         // after first sync (so at each new block) we can safely assume that user got less than 1000 new txs
-        const txNumber = !this.fullSynced ? probePage.txs : 1;
+        //in this way we don't have to fetch the probePage after first sync
+        const txNumber = !this.fullSynced
+            ? probePage.txs - mempool.txmap.size
+            : 1;
         // Compute the total pages and iterate through them until we've synced everything
         const totalPages = Math.ceil(txNumber / 1000);
         for (let i = totalPages; i > 0; i--) {
@@ -272,7 +275,7 @@ export class ExplorerNetwork extends Network {
     async walletFullSync() {
         if (this.fullSynced) return;
         if (!this.wallet || !this.wallet.isLoaded()) return;
-        await this.getLatestTxs(0);
+        await this.getLatestTxs(this.lastBlockSynced);
         const nBlockHeights = Array.from(mempool.orderedTxmap.keys());
         this.lastBlockSynced =
             nBlockHeights.length == 0


### PR DESCRIPTION
## Abstract
Do not set fullSync flag after reading txdb since we cannot guarantee that the database is synced. Instead read from database and regardless of the result check if there are any missing txs.


# Testing
Should be pretty easy to test: open a big wallet encrypt it and before it finishes syncing reload the page. Verify that the wallet will keep syncing from the point it was interrupted and that eventually the total balance is the expected one.

