### PR TITLE
Fix "Max" button conversion on Send menu

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -923,7 +923,7 @@ defineExpose({
             @openQrScan="openSendQRScanner()"
             @close="showTransferMenu = false"
             @send="send"
-            @max-balance="transferAmount = mempool.balance.toString()"
+            @max-balance="transferAmount = (mempool.balance / COIN).toString()"
         />
     </div>
 </template>


### PR DESCRIPTION
## Abstract

This PR simply adds the proper conversion when hitting `Max`, which previously used the balance in Sats, instead of in `COIN` value.

Making: `5340074603400`
Now to: `53400.746034`

**Note:** There are still regressions left from the Vue port, since the `Currency/Fiat` box on the right of the PIVX amount no longer updates when you hit `Max`, but at least the Max button is usable to send without errors now.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test the "Max" button on the `Send` menu.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---