### PR TITLE
Bump to 1.5.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,13 @@ If any errors are found, the PR works unexpectedly, or you have viable suggestio
 
 ---
 
+## PR Checklist
+
+I have:
+- [ ] Tested that the code functions as expected.
+- [ ] Ensured the code is properly formatted using `npm run prettier`.
+- [ ] Updated the changelog with the relevant changes.
+
 <!---
 Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
 --->

--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,5 @@
 # New Features
-- TX Database and Network Rewrite.
-- Ability to delete an MPW wallet.
-
-You'll notice that MPW now requires a small amount of 'syncing time' during your first use of v1.4.0, as MPW now synchronises your full TX history to your machine, so the next time you open the wallet, it instantly resumes using the chain data it previously synced.
-
-This system will save massive amounts of bandwidth long-term, speed up operations, and allow MPW to implement more advanced features that PIVX Core have.
-
-# New Language
-- 🇳🇱 Dutch (by BreadJS).
 
 # Improvements
-- Safer Address validation (B58Check).
-- Better under-the-hood Coin Locking.
-- Dashboard fully ported to Vue.js.
-- Encryption is now actively prompted to users with unencrypted wallets.
 
 # Bug Fixes
-- Fixed various bugs in Chain Switching.
-- Fixed various linting and fork-repo issues.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mypivxwallet",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Wallet for PIVX",
     "main": "scripts/index.js",
     "type": "module",


### PR DESCRIPTION
## Abstract

Bump MPW to 1.5.0, to follow this new proposed release model:

### Branching:
- The `master` will always push to the future release: We recently released `1.4.0`, so we are now developing `1.5.x`.
- For each release, a new branch will be created, which will only receive cherry-picks from bug fix PRs.

### Pull request guidelines:

To maintain clarity during the development of both versions:
- If a PR is only relevant to the next release, it can be created as normal.
- If a PR is only relevant to the current release, it can be created with the current release branch as base. Currently `1.4`
- If a PR is relevant to both the current and next release, it should be created to `master` and have include a `cherrypick-stable` label. It will be the duty of the PR merger to cherrypick the commit to the stable branch.

Additionally, a new section was added to the PR template. This is done mainly to remind developers that the changelog is to be updated per PR, rather than before the release: This allows us to eventually automate the bump version PRs.
### Monthly Version Bump and QA
On the 1st of each month:
- Create a new stable branch with the nomenclature `1.x`,  (e.g. `1.5`, not `1.5.0`). This is because we release the `1.x.y` release from the `1.x` branch.
- Open a PR to `master` and increase the version by one.
- Push the newly created stable branch to QA for testing.
This will give us 10 days to fix any bugs that pop up. Any new features merged into master after the first of each month will therefore _not_ make it into the upcoming release.
---

## Testing
No testing is required.

---

## PR Checklist

I have:
- [x] Tested that the code functions as expected.
- [x] Ensured the code is properly formatted using `npm run prettier`.
- [x] Updated the changelog with the relevant changes.


