### PR TITLE
Fix bip39 passphrase not showing in advanced mode

### DIFF
--- a/scripts/dashboard/AccessWallet.vue
+++ b/scripts/dashboard/AccessWallet.vue
@@ -1,7 +1,7 @@
 <script setup>
 import coinPlant from '../../assets/coin_plant.svg';
 import pLogo from '../../assets/p_logo.svg';
-import { ref, watch } from 'vue';
+import { ref, watch, toRefs } from 'vue';
 import { translation } from '../i18n.js';
 import { isBase64 } from '../misc';
 
@@ -13,7 +13,7 @@ const passwordPlaceholder = ref(translation.password);
 const props = defineProps({
     advancedMode: Boolean,
 });
-const advancedMode = ref(props.advancedMode);
+const { advancedMode } = toRefs(props);
 
 /**
  * Secret is the thing being imported:
@@ -26,12 +26,12 @@ const secret = ref('');
  */
 const password = ref('');
 
-watch(secret, (secret) => {
+watch([secret, advancedMode], ([secret, advancedMode]) => {
     // If it cointains spaces, it's likely a bip39 seed
     const fContainsSpaces = secret.trim().includes(' ');
 
     // Show password input if it's a bip39 seed and we're in advanced mode
-    if (fContainsSpaces && advancedMode.value) {
+    if (fContainsSpaces && advancedMode) {
         showPassword.value = true;
     }
     // If it's a Base64 secret, it's likely an MPW encrypted import,

--- a/scripts/dashboard/AccessWallet.vue
+++ b/scripts/dashboard/AccessWallet.vue
@@ -48,6 +48,10 @@ watch([secret, advancedMode], ([secret, advancedMode]) => {
         ? translation.optionalPassphrase
         : translation.password;
 });
+watch(showPassword, (showPassword) => {
+    // Empty password prompt when hidden
+    if (!showPassword) password.value = '';
+});
 const emit = defineEmits(['import-wallet']);
 function importWallet() {
     emit('import-wallet', secret.value, password.value);

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -117,7 +117,7 @@ async function parseSecret(secret, password = '') {
                 );
                 if (!ok) throw new Error(msg);
                 return new HdMasterKey({
-                    seed: await mnemonicToSeed(phrase),
+                    seed: await mnemonicToSeed(phrase, password),
                 });
             },
         },

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -71,10 +71,9 @@ watch(showExportModal, async (showExportModal) => {
         keyToBackup.value = '';
     }
 });
-getEventEmitter().on(
-    'advanced-mode',
-    (fAdvancedMode) => (advancedMode.value = fAdvancedMode)
-);
+getEventEmitter().on('advanced-mode', (fAdvancedMode) => {
+    advancedMode.value = fAdvancedMode;
+});
 
 /**
  * Parses whatever the secret is to a MasterKey
@@ -491,7 +490,11 @@ defineExpose({
 <template>
     <div id="keypair" class="tabcontent">
         <div class="row m-0">
-            <Login v-show="!isImported" @import-wallet="importWallet" />
+            <Login
+                v-show="!isImported"
+                :advancedMode="advancedMode"
+                @import-wallet="importWallet"
+            />
 
             <br />
 

--- a/scripts/dashboard/Login.vue
+++ b/scripts/dashboard/Login.vue
@@ -4,8 +4,14 @@ import pLogo from '../../assets/p_logo.svg';
 import VanityGen from './VanityGen.vue';
 import CreateWallet from './CreateWallet.vue';
 import AccessWallet from './AccessWallet.vue';
+import { watch, toRefs } from 'vue';
 
 defineEmits(['import-wallet']);
+
+const props = defineProps({
+    advancedMode: Boolean,
+});
+const { advancedMode } = toRefs(props);
 </script>
 
 <template>
@@ -67,6 +73,7 @@ defineEmits(['import-wallet']);
 
         <br />
         <AccessWallet
+            :advancedMode="advancedMode"
             @import-wallet="
                 (secret, password) =>
                     $emit('import-wallet', { type: 'hd', secret, password })


### PR DESCRIPTION
## Abstract

Fix bip39 passphrase not showing in advanced mode

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Toggle advanced Mode
- Check that the password field shows up