### PR TITLE
Fix pt translation not showing properly

### DIFF
--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -31,11 +31,7 @@ function getParentLanguage(langName) {
         ? langName.split('-')[0]
         : defaultLang;
     // Ensure the code exists
-    if (arrActiveLangs.find((lang) => lang.code === strParentCode)) {
-        return strParentCode;
-    } else {
-        return defaultLang;
-    }
+    return strParentCode;
 }
 
 /**


### PR DESCRIPTION
## Abstract

`pt` is not in `arrActiveLangs`, so the code would not get the proper parent language of `pt-pt` and `pt-br`

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Switch language to pt-pt or pt-br and check that all translations show
- (Optional) Switch to other languages and check that everything works as expected