### PR TITLE
Fix "Refresh Address" dropdown button visibility

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -900,8 +900,8 @@ defineExpose({
                     <WalletBalance
                         :balance="balance"
                         :jdenticonValue="jdenticonValue"
-                        :isHdWallet="false"
-                        :isHardwareWallet="false"
+                        :isHdWallet="wallet.isHD()"
+                        :isHardwareWallet="wallet.isHardwareWallet()"
                         :currency="currency"
                         :price="price"
                         :displayDecimals="displayDecimals"


### PR DESCRIPTION
## Abstract

This PR simply fixes the "Refresh Address" button visibility, which was always 'off' as the Dashboard Vue component did not pass the loaded `wallet` types to the WalletBalance component.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test that the "Refresh Address" button displays and works on HD wallets.
- Delete the wallet, re-test with a Legacy wallet, ensure the button is hidden.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---