### PR TITLE
Fix wallet not loading when explorer request fails

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -328,7 +328,13 @@ export async function start() {
     registerWorker();
     await settingsStart();
     // Just load the block count, for use in non-wallet areas
-    await getNetwork().getBlockCount();
+    try {
+        await getNetwork().getBlockCount();
+    } catch (e) {
+        // Block count failed, keep loading the wallet
+        // the network already creates an alert
+        console.error(e);
+    }
 
     subscribeToNetworkEvents();
 


### PR DESCRIPTION
## Abstract

Wallet didn't load when an explorer request failed and  Auto-select Explorers and Nodes 

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Block an explorer of your choice
- Turn off auto-select explorer
- Open the wallet and assert that it's accessible and that it's possible to switch to a different explorer

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!