### PR TITLE
[DB] Make txDB persistent

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -379,7 +379,6 @@ getEventEmitter().on('toggle-network', async () => {
         await importWallet({ type: 'hd', secret: account.publicKey });
     } else {
         isImported.value = false;
-        await (await Database.getInstance()).removeAllTxs();
     }
     await updateEncryptionGUI(wallet.isLoaded());
     updateLogOutButton();
@@ -405,8 +404,6 @@ onMounted(async () => {
             transferAmount.value = reqAmount;
             showTransferMenu.value = true;
         }
-    } else {
-        await (await Database.getInstance()).removeAllTxs();
     }
     updateLogOutButton();
 });

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -375,6 +375,7 @@ export class Mempool {
      * Save txs on database
      */
     async saveOnDisk() {
+        console.log(wallet.getKeyToExport());
         const nBlockHeights = Array.from(this.orderedTxmap.keys())
             .sort((a, b) => a - b)
             .reverse();
@@ -400,6 +401,14 @@ export class Mempool {
      */
     async loadFromDisk() {
         const database = await Database.getInstance();
+        // Check if the stored txs are linked to this wallet
+        if ((await database.getTxDbIdentifier()) != wallet.getKeyToExport()) {
+            await database.removeAllTxs();
+            await database.storeTxDbIdentifier(wallet.getKeyToExport());
+            console.log('D E S T R O Y E D');
+            return;
+        }
+        console.log('passed');
         const txs = await database.getTxs();
         if (txs.length == 0) {
             return false;

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -375,7 +375,6 @@ export class Mempool {
      * Save txs on database
      */
     async saveOnDisk() {
-        console.log(wallet.getKeyToExport());
         const nBlockHeights = Array.from(this.orderedTxmap.keys())
             .sort((a, b) => a - b)
             .reverse();
@@ -405,10 +404,8 @@ export class Mempool {
         if ((await database.getTxDbIdentifier()) != wallet.getKeyToExport()) {
             await database.removeAllTxs();
             await database.storeTxDbIdentifier(wallet.getKeyToExport());
-            console.log('D E S T R O Y E D');
             return;
         }
-        console.log('passed');
         const txs = await database.getTxs();
         if (txs.length == 0) {
             return false;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -496,7 +496,6 @@ export async function logOut() {
     });
     if (!fContinue) return;
     const database = await Database.getInstance();
-    await database.removeAllTxs();
     await database.removeAccount({ publicKey: null });
 
     getEventEmitter().emit('toggle-network');


### PR DESCRIPTION
## Abstract

This solves the issue of txdb not being used on ledger and also simplifies the txdb flow in general:

-  the (Key, pair) = ("keyToExport", wallet.getKeyToExport()) has been added to, so we can easily understand if a given wallet can load from a given txDB
- So now the txDB is not erased if the wallet is not locked or in some weird edge cases, but only if the "keyToExport" saved is different from the one of the wallet we are using.  And this is checked only in `loadFromDisk` (instead of in many files of the code like setting, dashboard...)

---

## Testing
To test use either a ledger or import a xpub/ single address. wait for it to sync, reload MPW reimport the same wallet and check that it is fully loaded from DB and balance matches the expected one

---


