### PR TITLE
better error handling for setColdStake

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1011,6 +1011,11 @@ export function isMasternodeUTXO(cUTXO, cMasternode) {
  * Creates a GUI popup for the user to check or customise their Cold Address
  */
 export async function guiSetColdStakingAddress() {
+    // This operation cannot be done for view only wallets
+    if (wallet.isViewOnly()) {
+        createAlert('warning', ALERTS.PROPOSAL_IMPORT_FIRST, 2500);
+        return false;
+    }
     // Use the Account's cold address, otherwise use the network's default Cold Staking address
     const strColdAddress = await wallet.getColdStakingAddress();
 

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -149,7 +149,7 @@ export class Wallet {
     }
 
     isViewOnly() {
-        if (!this.#masterKey) return false;
+        if (!this.#masterKey) return true;
         return this.#masterKey.isViewOnly;
     }
 


### PR DESCRIPTION
## Abstract

Bail out early with an appropriate error from `guiSetColdStakingAddress` if wallet is in only view mode (this is also the only case in which there could be no cAccount).

