### PR TITLE
[TEST] Add unit tests for GenKeyWarning

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -875,6 +875,7 @@ defineExpose({
                 <GenKeyWarning
                     @onEncrypt="encryptWallet"
                     @close="showEncryptModal = false"
+                    @open="showEncryptModal = true"
                     :showModal="showEncryptModal"
                     :showBox="needsToEncrypt"
                     :isEncrypt="wallet.isEncrypted.value"

--- a/scripts/dashboard/GenKeyWarning.vue
+++ b/scripts/dashboard/GenKeyWarning.vue
@@ -15,10 +15,9 @@ const currentPassword = ref('');
 const password = ref('');
 const passwordConfirm = ref('');
 
-const emit = defineEmits(['onEncrypt', 'close']);
+const emit = defineEmits(['onEncrypt', 'close', 'open']);
 
 function close() {
-    props.showModal = false;
     currentPassword.value = '';
     password.value = '';
     passwordConfirm.value = '';
@@ -48,7 +47,11 @@ function submit() {
 <template>
     <div class="col-12" v-show="showBox">
         <center>
-            <div class="dcWallet-warningMessage" @click="showModal = true">
+            <div
+                class="dcWallet-warningMessage"
+                @click="emit('open')"
+                data-testid="encryptBox"
+            >
                 <div class="shieldLogo">
                     <div class="shieldBackground">
                         <span
@@ -90,6 +93,7 @@ function submit() {
                     class="close"
                     aria-label="Close"
                     @click="close()"
+                    data-testid="closeBtn"
                 >
                     <i class="fa-solid fa-xmark closeCross"></i>
                 </button>
@@ -104,6 +108,7 @@ function submit() {
                         type="password"
                         :placeholder="translation.encryptPasswordCurrent"
                         v-show="isEncrypt"
+                        data-testid="currentPasswordModal"
                     />
                     <div class="col-12 col-md-6 p-0 pr-0 pr-md-1">
                         <input
@@ -113,6 +118,7 @@ function submit() {
                             style="width: 100%; font-family: monospace"
                             type="password"
                             :placeholder="translation.encryptPasswordFirst"
+                            data-testid="newPasswordModal"
                         />
                     </div>
                     <div class="col-12 col-md-6 p-0 pl-0 pl-md-1">
@@ -123,12 +129,17 @@ function submit() {
                             style="width: 100%; font-family: monospace"
                             type="password"
                             :placeholder="translation.encryptPasswordSecond"
+                            data-testid="confirmPasswordModal"
                         />
                     </div>
                 </div>
             </template>
             <template #footer>
-                <button class="pivx-button-small" @click="submit()">
+                <button
+                    class="pivx-button-small"
+                    @click="submit()"
+                    data-testid="submitBtn"
+                >
                     <span class="dcWallet-svgIconPurple">
                         <svg
                             xmlns="http://www.w3.org/2000/svg"

--- a/scripts/dashboard/GenKeyWarning.vue
+++ b/scripts/dashboard/GenKeyWarning.vue
@@ -81,11 +81,7 @@ function submit() {
     </div>
 
     <Teleport to="body">
-        <Modal
-            :show="showModal"
-            @close="close()"
-            modalClass="exportKeysModalColor"
-        >
+        <Modal :show="showModal" modalClass="exportKeysModalColor">
             <template #header>
                 <h5 class="modal-title">{{ translation.encryptWallet }}</h5>
                 <button

--- a/tests/components/GenKeyWarning.test.js
+++ b/tests/components/GenKeyWarning.test.js
@@ -162,7 +162,8 @@ describe('GenKeyWarning tests', () => {
         );
 
         // Ok now the length has been changed to the minimum allowed value but passwords dont match!
-        newPassword.element.value = 'secure';
+        const safePassword = new Array(MIN_PASS_LENGTH + 1).join('x');
+        newPassword.element.value = safePassword;
         newPassword.trigger('input');
         await nextTick();
         await submitBtn.trigger('click');
@@ -172,13 +173,15 @@ describe('GenKeyWarning tests', () => {
         expect(misc.createAlert).toHaveBeenCalled();
         expect(misc.createAlert).toHaveReturnedWith('pass_doesnt_match');
         // Finally passwords match
-        confirmPassword.element.value = 'secure';
+        confirmPassword.element.value = safePassword;
         confirmPassword.trigger('input');
         await nextTick();
         await submitBtn.trigger('click');
         await nextTick();
         checkEventsEmitted(wrapper, 1, 1, 0);
-        expect(wrapper.emitted('onEncrypt')).toStrictEqual([['secure', '']]);
+        expect(wrapper.emitted('onEncrypt')).toStrictEqual([
+            [safePassword, ''],
+        ]);
         expect(wrapper.emitted('close')).toStrictEqual([[]]);
 
         // Test the close button
@@ -242,7 +245,8 @@ describe('GenKeyWarning tests', () => {
         );
 
         // Ok now the length has been changed to the minimum allowed value but passwords dont match!
-        newPassword.element.value = 'secure';
+        const safePassword = new Array(MIN_PASS_LENGTH + 1).join('x');
+        newPassword.element.value = safePassword;
         newPassword.trigger('input');
         await nextTick();
         await submitBtn.trigger('click');
@@ -255,14 +259,14 @@ describe('GenKeyWarning tests', () => {
         currentPassword.element.value = 'panleon';
         currentPassword.trigger('input');
         await nextTick();
-        confirmPassword.element.value = 'secure';
+        confirmPassword.element.value = safePassword;
         confirmPassword.trigger('input');
         await nextTick();
         await submitBtn.trigger('click');
         await nextTick();
         checkEventsEmitted(wrapper, 1, 1, 0);
         expect(wrapper.emitted('onEncrypt')).toStrictEqual([
-            ['secure', 'panleon'],
+            [safePassword, 'panleon'],
         ]);
         expect(wrapper.emitted('close')).toStrictEqual([[]]);
         // Test the close button

--- a/tests/components/GenKeyWarning.test.js
+++ b/tests/components/GenKeyWarning.test.js
@@ -1,0 +1,280 @@
+import { mount } from '@vue/test-utils';
+import { expect } from 'vitest';
+import GenKeyWarning from '../../scripts/dashboard/GenKeyWarning.vue';
+import Modal from '../../scripts/Modal.vue';
+import { vi, it, describe } from 'vitest';
+import { nextTick } from 'vue';
+import * as translation from '../../scripts/i18n.js';
+import * as misc from '../../scripts/misc.js';
+// We need to attach the component to a HTML,
+// or .isVisible() function does not work
+document.body.innerHTML = `
+  <div>
+    <div id="app"></div>
+  </div>
+`;
+
+const checkEventsEmitted = (wrapper, nClose, nOnEncrypt, nOpen) => {
+    if (nClose == 0) {
+        expect(wrapper.emitted('close')).toBeUndefined();
+    } else {
+        expect(wrapper.emitted('close')).toHaveLength(nClose);
+    }
+    if (nOnEncrypt == 0) {
+        expect(wrapper.emitted('onEncrypt')).toBeUndefined();
+    } else {
+        expect(wrapper.emitted('onEncrypt')).toHaveLength(nOnEncrypt);
+    }
+    if (nOpen == 0) {
+        expect(wrapper.emitted('open')).toBeUndefined();
+    } else {
+        expect(wrapper.emitted('open')).toHaveLength(nOpen);
+    }
+};
+
+const checkModalExistence = (wrapper, exist) => {
+    expect(
+        wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=currentPasswordModal]')
+    ).toHaveLength(exist);
+    expect(
+        wrapper.findComponent(Modal).findAll('[data-testid=newPasswordModal]')
+    ).toHaveLength(exist);
+    expect(
+        wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=confirmPasswordModal]')
+    ).toHaveLength(exist);
+    expect(
+        wrapper.findComponent(Modal).findAll('[data-testid=submitBtn]')
+    ).toHaveLength(exist);
+    expect(
+        wrapper.findComponent(Modal).findAll('[data-testid=closeBtn]')
+    ).toHaveLength(exist);
+};
+
+describe('GenKeyWarning tests', () => {
+    afterEach(() => vi.clearAllMocks());
+    it('GenKeyWarning (no box)', async () => {
+        const wrapper = mount(GenKeyWarning, {
+            props: {
+                showModal: false,
+                showBox: false,
+                isEncrypt: false,
+            },
+            attachTo: document.getElementById('app'),
+        });
+        // No events emitted and nothing to see in this case!
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        const encryptBox = wrapper.find('[data-testid=encryptBox]');
+        expect(encryptBox.isVisible()).toBeFalsy();
+        checkModalExistence(wrapper, 0);
+    });
+    it('GenKeyWarning (no modal)', async () => {
+        const wrapper = mount(GenKeyWarning, {
+            props: {
+                showModal: false,
+                showBox: true,
+                isEncrypt: false,
+            },
+            attachTo: document.getElementById('app'),
+        });
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        const encryptBox = wrapper.find('[data-testid=encryptBox]');
+        expect(encryptBox.isVisible()).toBeTruthy();
+        // Modal does not exist
+        checkModalExistence(wrapper, 0);
+
+        // Click the encryptBox and the open event should be emitted
+        await encryptBox.trigger('click');
+        await nextTick();
+        checkEventsEmitted(wrapper, 0, 0, 1);
+    });
+    it('GenKeyWarning (no encrypt)', async () => {
+        // Mock translate and createAlert and the two translations used
+        vi.spyOn(translation, 'tr').mockImplementation((message, variables) => {
+            return message + variables[0].MIN_PASS_LENGTH;
+        });
+        vi.spyOn(misc, 'createAlert').mockImplementation(
+            (type, message, timeout = 0) => {
+                return message;
+            }
+        );
+        vi.spyOn(translation, 'ALERTS', 'get').mockReturnValue({
+            PASSWORD_TOO_SMALL: 'pass_too_small',
+            PASSWORD_DOESNT_MATCH: 'pass_doesnt_match',
+        });
+        const wrapper = mount(GenKeyWarning, {
+            props: {
+                showModal: true,
+                showBox: true,
+                isEncrypt: false,
+            },
+            attachTo: document.getElementById('app'),
+        });
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        const encryptBox = wrapper.find('[data-testid=encryptBox]');
+        expect(encryptBox.isVisible()).toBeTruthy();
+        // Modal exist
+        checkModalExistence(wrapper, 1);
+
+        const newPassword = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=newPasswordModal]')[0];
+        const confirmPassword = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=confirmPasswordModal]')[0];
+        const submitBtn = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=submitBtn]')[0];
+        const currentPassword = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=currentPasswordModal]')[0];
+        const closeBtn = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=closeBtn]')[0];
+        // Everything but currentPassword is visible
+        expect(newPassword.isVisible()).toBeTruthy();
+        expect(confirmPassword.isVisible()).toBeTruthy();
+        expect(submitBtn.isVisible()).toBeTruthy();
+        expect(currentPassword.isVisible()).toBeFalsy();
+        expect(closeBtn.isVisible()).toBeTruthy();
+
+        // Let's try to insert a password
+        // Password match but it's too short!
+        newPassword.element.value = 'p';
+        newPassword.trigger('input');
+        await nextTick();
+        confirmPassword.element.value = 'p';
+        confirmPassword.trigger('input');
+        await nextTick();
+        await submitBtn.trigger('click');
+        await nextTick();
+        // no event should have been emitted
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        expect(misc.createAlert).toHaveBeenCalled();
+        expect(misc.createAlert).toHaveReturnedWith('pass_too_small6');
+
+        // Ok now the lenght has been changed to the minimum allowed value but passwords dont match!
+        newPassword.element.value = 'secure';
+        newPassword.trigger('input');
+        await nextTick();
+        await submitBtn.trigger('click');
+        await nextTick();
+        // no event should have been emitted
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        expect(misc.createAlert).toHaveBeenCalled();
+        expect(misc.createAlert).toHaveReturnedWith('pass_doesnt_match');
+        // Finally passwords match
+        confirmPassword.element.value = 'secure';
+        confirmPassword.trigger('input');
+        await nextTick();
+        await submitBtn.trigger('click');
+        await nextTick();
+        checkEventsEmitted(wrapper, 1, 1, 0);
+        expect(wrapper.emitted('onEncrypt')).toStrictEqual([['secure', '']]);
+        expect(wrapper.emitted('close')).toStrictEqual([[]]);
+
+        // Test the close button
+        await closeBtn.trigger('click');
+        await nextTick();
+        checkEventsEmitted(wrapper, 2, 1, 0);
+        expect(wrapper.emitted('close')).toStrictEqual([[], []]);
+    });
+    it('GenKeyWarning (with encrypt)', async () => {
+        // Mock translate and createAlert and the two translations used
+        vi.spyOn(translation, 'tr').mockImplementation((message, variables) => {
+            return message + variables[0].MIN_PASS_LENGTH;
+        });
+        vi.spyOn(misc, 'createAlert').mockImplementation(
+            (type, message, timeout = 0) => {
+                return message;
+            }
+        );
+        vi.spyOn(translation, 'ALERTS', 'get').mockReturnValue({
+            PASSWORD_TOO_SMALL: 'pass_too_small',
+            PASSWORD_DOESNT_MATCH: 'pass_doesnt_match',
+        });
+        const wrapper = mount(GenKeyWarning, {
+            props: {
+                showModal: true,
+                showBox: true,
+                isEncrypt: true,
+            },
+            attachTo: document.getElementById('app'),
+        });
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        const encryptBox = wrapper.find('[data-testid=encryptBox]');
+        expect(encryptBox.isVisible()).toBeTruthy();
+        // Modal exist
+        checkModalExistence(wrapper, 1);
+
+        const newPassword = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=newPasswordModal]')[0];
+        const confirmPassword = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=confirmPasswordModal]')[0];
+        const submitBtn = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=submitBtn]')[0];
+        const currentPassword = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=currentPasswordModal]')[0];
+        const closeBtn = wrapper
+            .findComponent(Modal)
+            .findAll('[data-testid=closeBtn]')[0];
+        // Every input box/ button must be visible
+        expect(newPassword.isVisible()).toBeTruthy();
+        expect(confirmPassword.isVisible()).toBeTruthy();
+        expect(submitBtn.isVisible()).toBeTruthy();
+        expect(currentPassword.isVisible()).toBeTruthy();
+        expect(closeBtn.isVisible()).toBeTruthy();
+
+        // Let's try to insert a password
+        // Password match but it's too short!
+        newPassword.element.value = 'p';
+        newPassword.trigger('input');
+        await nextTick();
+        confirmPassword.element.value = 'p';
+        confirmPassword.trigger('input');
+        await nextTick();
+        await submitBtn.trigger('click');
+        await nextTick();
+        // no event should have been emitted
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        expect(misc.createAlert).toHaveBeenCalled();
+        expect(misc.createAlert).toHaveReturnedWith('pass_too_small6');
+
+        // Ok now the lenght has been changed to the minimum allowed value but passwords dont match!
+        newPassword.element.value = 'secure';
+        newPassword.trigger('input');
+        await nextTick();
+        await submitBtn.trigger('click');
+        await nextTick();
+        // no event should have been emitted
+        checkEventsEmitted(wrapper, 0, 0, 0);
+        expect(misc.createAlert).toHaveBeenCalled();
+        expect(misc.createAlert).toHaveReturnedWith('pass_doesnt_match');
+        // Finally passwords matches and verify also current password
+        currentPassword.element.value = 'panleon';
+        currentPassword.trigger('input');
+        await nextTick();
+        confirmPassword.element.value = 'secure';
+        confirmPassword.trigger('input');
+        await nextTick();
+        await submitBtn.trigger('click');
+        await nextTick();
+        checkEventsEmitted(wrapper, 1, 1, 0);
+        expect(wrapper.emitted('onEncrypt')).toStrictEqual([
+            ['secure', 'panleon'],
+        ]);
+        expect(wrapper.emitted('close')).toStrictEqual([[]]);
+        // Test the close button
+        await closeBtn.trigger('click');
+        await nextTick();
+        checkEventsEmitted(wrapper, 2, 1, 0);
+        expect(wrapper.emitted('close')).toStrictEqual([[], []]);
+    });
+});

--- a/tests/components/GenKeyWarning.test.js
+++ b/tests/components/GenKeyWarning.test.js
@@ -1,11 +1,12 @@
 import { mount } from '@vue/test-utils';
-import { expect } from 'vitest';
+import { beforeEach, expect } from 'vitest';
 import GenKeyWarning from '../../scripts/dashboard/GenKeyWarning.vue';
 import Modal from '../../scripts/Modal.vue';
 import { vi, it, describe } from 'vitest';
 import { nextTick } from 'vue';
 import * as translation from '../../scripts/i18n.js';
 import * as misc from '../../scripts/misc.js';
+import { MIN_PASS_LENGTH } from '../../scripts/chain_params.js';
 // We need to attach the component to a HTML,
 // or .isVisible() function does not work
 document.body.innerHTML = `
@@ -55,6 +56,21 @@ const checkModalExistence = (wrapper, exist) => {
 };
 
 describe('GenKeyWarning tests', () => {
+    beforeEach(() => {
+        // Mock translate and createAlert and the two translations used
+        vi.spyOn(translation, 'tr').mockImplementation((message, variables) => {
+            return message + variables[0].MIN_PASS_LENGTH;
+        });
+        vi.spyOn(misc, 'createAlert').mockImplementation(
+            (type, message, timeout = 0) => {
+                return message;
+            }
+        );
+        vi.spyOn(translation, 'ALERTS', 'get').mockReturnValue({
+            PASSWORD_TOO_SMALL: 'pass_too_small',
+            PASSWORD_DOESNT_MATCH: 'pass_doesnt_match',
+        });
+    });
     afterEach(() => vi.clearAllMocks());
     it('GenKeyWarning (no box)', async () => {
         const wrapper = mount(GenKeyWarning, {
@@ -92,19 +108,6 @@ describe('GenKeyWarning tests', () => {
         checkEventsEmitted(wrapper, 0, 0, 1);
     });
     it('GenKeyWarning (no encrypt)', async () => {
-        // Mock translate and createAlert and the two translations used
-        vi.spyOn(translation, 'tr').mockImplementation((message, variables) => {
-            return message + variables[0].MIN_PASS_LENGTH;
-        });
-        vi.spyOn(misc, 'createAlert').mockImplementation(
-            (type, message, timeout = 0) => {
-                return message;
-            }
-        );
-        vi.spyOn(translation, 'ALERTS', 'get').mockReturnValue({
-            PASSWORD_TOO_SMALL: 'pass_too_small',
-            PASSWORD_DOESNT_MATCH: 'pass_doesnt_match',
-        });
         const wrapper = mount(GenKeyWarning, {
             props: {
                 showModal: true,
@@ -154,9 +157,11 @@ describe('GenKeyWarning tests', () => {
         // no event should have been emitted
         checkEventsEmitted(wrapper, 0, 0, 0);
         expect(misc.createAlert).toHaveBeenCalled();
-        expect(misc.createAlert).toHaveReturnedWith('pass_too_small6');
+        expect(misc.createAlert).toHaveReturnedWith(
+            'pass_too_small' + MIN_PASS_LENGTH
+        );
 
-        // Ok now the lenght has been changed to the minimum allowed value but passwords dont match!
+        // Ok now the length has been changed to the minimum allowed value but passwords dont match!
         newPassword.element.value = 'secure';
         newPassword.trigger('input');
         await nextTick();
@@ -183,19 +188,6 @@ describe('GenKeyWarning tests', () => {
         expect(wrapper.emitted('close')).toStrictEqual([[], []]);
     });
     it('GenKeyWarning (with encrypt)', async () => {
-        // Mock translate and createAlert and the two translations used
-        vi.spyOn(translation, 'tr').mockImplementation((message, variables) => {
-            return message + variables[0].MIN_PASS_LENGTH;
-        });
-        vi.spyOn(misc, 'createAlert').mockImplementation(
-            (type, message, timeout = 0) => {
-                return message;
-            }
-        );
-        vi.spyOn(translation, 'ALERTS', 'get').mockReturnValue({
-            PASSWORD_TOO_SMALL: 'pass_too_small',
-            PASSWORD_DOESNT_MATCH: 'pass_doesnt_match',
-        });
         const wrapper = mount(GenKeyWarning, {
             props: {
                 showModal: true,
@@ -245,9 +237,11 @@ describe('GenKeyWarning tests', () => {
         // no event should have been emitted
         checkEventsEmitted(wrapper, 0, 0, 0);
         expect(misc.createAlert).toHaveBeenCalled();
-        expect(misc.createAlert).toHaveReturnedWith('pass_too_small6');
+        expect(misc.createAlert).toHaveReturnedWith(
+            'pass_too_small' + MIN_PASS_LENGTH
+        );
 
-        // Ok now the lenght has been changed to the minimum allowed value but passwords dont match!
+        // Ok now the length has been changed to the minimum allowed value but passwords dont match!
         newPassword.element.value = 'secure';
         newPassword.trigger('input');
         await nextTick();


### PR DESCRIPTION
## Abstract

Add unit tests for the GenKeyWarning class, I have also found a bug since we were trying to change a props, which is readonly. The event `open` has been added in place.
Tests do the following:

- Check that all input boxes/buttons are visible only when they should be
- Check that events are emitted as expected with the expected amount of arguments
- Check that errors are throwed as expected (this has been done by mocking alerts and createalert)

