### PR TITLE
Vitest fixes

### DIFF
--- a/test_setup.js
+++ b/test_setup.js
@@ -1,0 +1,7 @@
+// We need to attach the component to a HTML,
+// or .isVisible() function does not work
+document.body.innerHTML = `
+  <div>
+    <div id="app"></div>
+  </div>
+`;

--- a/tests/components/AccessWallet.test.js
+++ b/tests/components/AccessWallet.test.js
@@ -4,14 +4,6 @@ import { expect } from 'vitest';
 import AccessWallet from '../../scripts/dashboard/AccessWallet.vue';
 import { vi, it, describe } from 'vitest';
 
-// We need to attach the component to a HTML,
-// or .isVisible() function does not work
-document.body.innerHTML = `
-  <div>
-    <div id="app"></div>
-  </div>
-`;
-
 describe('access wallet tests', () => {
     afterEach(() => vi.clearAllMocks());
     it('Access wallet (no advanced)', async () => {

--- a/tests/components/GenKeyWarning.test.js
+++ b/tests/components/GenKeyWarning.test.js
@@ -7,13 +7,6 @@ import { nextTick } from 'vue';
 import * as translation from '../../scripts/i18n.js';
 import * as misc from '../../scripts/misc.js';
 import { MIN_PASS_LENGTH } from '../../scripts/chain_params.js';
-// We need to attach the component to a HTML,
-// or .isVisible() function does not work
-document.body.innerHTML = `
-  <div>
-    <div id="app"></div>
-  </div>
-`;
 
 const checkEventsEmitted = (wrapper, nClose, nOnEncrypt, nOpen) => {
     if (nClose == 0) {

--- a/tests/components/Login.test.js
+++ b/tests/components/Login.test.js
@@ -7,14 +7,6 @@ import VanityGen from '../../scripts/dashboard/VanityGen.vue';
 import AccessWallet from '../../scripts/dashboard/AccessWallet.vue';
 import { vi, it, describe } from 'vitest';
 
-// We need to attach the component to a HTML,
-// or .isVisible() function does not work
-document.body.innerHTML = `
-  <div>
-    <div id="app"></div>
-  </div>
-`;
-
 describe('Login tests', () => {
     afterEach(() => vi.clearAllMocks());
     test('Create wallet login (no advanced)', async () => {

--- a/tests/components/VanityGen.test.js
+++ b/tests/components/VanityGen.test.js
@@ -6,14 +6,6 @@ import { vi, it, describe } from 'vitest';
 import * as translation from '../../scripts/i18n.js';
 import * as misc from '../../scripts/misc.js';
 
-// We need to attach the component to a HTML,
-// or .isVisible() function does not work
-document.body.innerHTML = `
-  <div>
-    <div id="app"></div>
-  </div>
-`;
-
 describe('VanityGen tests', () => {
     beforeEach(() => {
         vi.spyOn(translation, 'tr').mockImplementation((message, variables) => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
         coverage: {
             provider: 'istanbul',
         },
+        setupFiles: ['test_setup.js'],
         pool: 'forks',
     },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,5 +10,6 @@ export default defineConfig({
         coverage: {
             provider: 'istanbul',
         },
+        pool: 'forks',
     },
 });


### PR DESCRIPTION
## Abstract

Vitest occasionally [segfaulted](https://github.com/PIVX-Labs/MyPIVXWallet/actions/runs/7280978364/job/19840540955). According to the [docs](https://vitest.dev/config/#pool), we were using the default multi threaded pool, 
> Enable multi-threading using [tinypool](https://github.com/tinylibs/tinypool) [...] some libraries written in native languages, such as Prisma, bcrypt and canvas, have problems when running in multiple threads and run into segfaults. In these cases it is advised to use forks pool instead.

This PR changes the pool to `fork`, which should not have this issue. This incurs approximately a 10% decrease in performance.

Additionally, a setup file was added where we setup the happy-dom environment with the correct skeleton, instead of doing it each time per test.

## Testing
Run `npm test` a bunch of times, and check that it doesn't segfaut