### PR TITLE
Move chain_params to a json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ locale/lang-tools/env
 __pycache__
 coverage/
 coverage.data
+chain_params.json

--- a/chain_params.prod.json
+++ b/chain_params.prod.json
@@ -1,0 +1,63 @@
+{
+    "main": {
+        "name": "mainnet",
+        "collateralInSats": 1000000000000,
+        "isTestnet": false,
+        "TICKER": "PIV",
+        "PUBKEY_PREFIX": ["D"],
+        "STAKING_PREFIX": "S",
+        "PUBKEY_ADDRESS": 30,
+        "STAKING_ADDRESS": 63,
+        "SECRET_KEY": 212,
+        "BIP44_TYPE": 119,
+        "BIP44_TYPE_LEDGER": 77,
+        "PROTOCOL_VERSION": 70926,
+        "MASTERNODE_PORT": 51472,
+        "Explorers": [
+            { "name": "rockdev", "url": "https://explorer.rockdev.org" },
+            { "name": "zkBitcoin", "url": "https://zkbitcoin.com" },
+            { "name": "Duddino", "url": "https://explorer.duddino.com" }
+        ],
+        "Nodes": [
+            { "name": "Duddino", "url": "https://rpc.duddino.com/mainnet" }
+        ],
+        "Consensus": {},
+        "coinbaseMaturity": 100,
+        "budgetCycleBlocks": 43200,
+        "proposalFee": 5000000000,
+        "proposalFeeConfirmRequirement": 6,
+        "maxPaymentCycles": 6,
+        "maxPayment": 43200000000000,
+        "defaultColdStakingAddress": "SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy"
+    },
+    "testnet": {
+        "name": "testnet",
+        "collateralInSats": 1000000000000,
+        "isTestnet": true,
+        "TICKER": "tPIV",
+        "PUBKEY_PREFIX": ["x", "y"],
+        "STAKING_PREFIX": "W",
+        "PUBKEY_ADDRESS": 139,
+        "STAKING_ADDRESS": 73,
+        "SECRET_KEY": 239,
+        "BIP44_TYPE": 1,
+        "BIP44_TYPE_LEDGER": 1,
+        "PROTOCOL_VERSION": 70926,
+        "MASTERNODE_PORT": 51474,
+        "Explorers": [
+            { "name": "rockdev", "url": "https://testnet.rockdev.org" },
+            { "name": "duddino", "url": "https://testnet.duddino.com" }
+        ],
+        "Nodes": [
+            { "name": "Duddino", "url": "https://rpc.duddino.com/testnet" }
+        ],
+        "Consensus": {},
+        "coinbaseMaturity": 15,
+        "budgetCycleBlocks": 144,
+        "proposalFee": 5000000000,
+        "proposalFeeConfirmRequirement": 3,
+        "maxPaymentCycles": 20,
+        "maxPayment": 144000000000,
+        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
         "prebuild": "npm run config",
         "predev": "npm run config",
         "prewatch": "npm run config",
+        "pretest": "npm run config",
+        "precoverage": "npm run config",
         "build": "webpack --config webpack.prod.js",
         "watch": "webpack --watch",
         "dev": "webpack serve --config webpack.dev.js",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
     "main": "scripts/index.js",
     "type": "module",
     "scripts": {
-        "config": "test -f chain_params.json || cp chain_params.prod.json chain_params.json",
-        "prebuild": "npm run config",
-        "predev": "npm run config",
-        "prewatch": "npm run config",
-        "pretest": "npm run config",
-        "precoverage": "npm run config",
+        "postinstall": "test -f chain_params.json || cp chain_params.prod.json chain_params.json",
         "build": "webpack --config webpack.prod.js",
         "watch": "webpack --watch",
         "dev": "webpack serve --config webpack.dev.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "main": "scripts/index.js",
     "type": "module",
     "scripts": {
+        "config": "test -f chain_params.json || cp chain_params.prod.json chain_params.json",
+        "prebuild": "npm run config",
+        "predev": "npm run config",
+        "prewatch": "npm run config",
         "build": "webpack --config webpack.prod.js",
         "watch": "webpack --watch",
         "dev": "webpack serve --config webpack.dev.js",

--- a/scripts/chain_params.js
+++ b/scripts/chain_params.js
@@ -1,4 +1,5 @@
 import { reactive } from 'vue';
+import chainParams from '../chain_params.json';
 
 // In most BTC-derived coins, the below parameters can be found in the 'src/chainparams.cpp' Mainnet configuration.
 // These below params share the same names as the CPP params, so finding and editing these is easy-peasy!
@@ -20,74 +21,6 @@ export const BIP21_PREFIX = 'pivx';
 
 /* chainparams */
 export const cChainParams = reactive({
-    current: null,
-    main: {
-        name: 'mainnet',
-        collateralInSats: 10000 * COIN,
-        isTestnet: false,
-        TICKER: 'PIV',
-        PUBKEY_PREFIX: ['D'],
-        STAKING_PREFIX: 'S',
-        PUBKEY_ADDRESS: 30,
-        STAKING_ADDRESS: 63,
-        SECRET_KEY: 212,
-        BIP44_TYPE: 119,
-        BIP44_TYPE_LEDGER: 77,
-        PROTOCOL_VERSION: 70926,
-        MASTERNODE_PORT: 51472,
-        // A list of Labs-trusted explorers
-        Explorers: [
-            // Display name      Blockbook-compatible API base
-            { name: 'rockdev', url: 'https://explorer.rockdev.org' },
-            { name: 'zkBitcoin', url: 'https://zkbitcoin.com' },
-            { name: 'Duddino', url: 'https://explorer.duddino.com' },
-        ],
-        Nodes: [{ name: 'Duddino', url: 'https://rpc.duddino.com/mainnet' }],
-        Consensus: {
-            // Network upgrades
-            UPGRADE_V6_0: undefined,
-        },
-        coinbaseMaturity: 100,
-        budgetCycleBlocks: 43200,
-        proposalFee: 50 * COIN,
-        proposalFeeConfirmRequirement: 6,
-        maxPaymentCycles: 6,
-        maxPayment: 10 * 43200 * COIN, // 43200 blocks of 10 PIV
-        defaultColdStakingAddress: 'SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy', // Labs Cold Pool
-    },
-    testnet: {
-        name: 'testnet',
-        collateralInSats: 10000 * COIN,
-        isTestnet: true,
-        TICKER: 'tPIV',
-        PUBKEY_PREFIX: ['x', 'y'],
-        STAKING_PREFIX: 'W',
-        PUBKEY_ADDRESS: 139,
-        STAKING_ADDRESS: 73,
-        SECRET_KEY: 239,
-        BIP44_TYPE: 1,
-        BIP44_TYPE_LEDGER: 1,
-        PROTOCOL_VERSION: 70926,
-        MASTERNODE_PORT: 51474,
-        // A list of Labs-trusted explorers
-        Explorers: [
-            // Display name      Blockbook-compatible API base
-            { name: 'rockdev', url: 'https://testnet.rockdev.org' },
-            { name: 'duddino', url: 'https://testnet.duddino.com' },
-        ],
-        Nodes: [{ name: 'Duddino', url: 'https://rpc.duddino.com/testnet' }],
-        Consensus: {
-            // Network upgrades
-            UPGRADE_V6_0: undefined,
-        },
-        coinbaseMaturity: 15,
-        budgetCycleBlocks: 144,
-        proposalFee: 50 * COIN,
-        proposalFeeConfirmRequirement: 3,
-        maxPaymentCycles: 20,
-        maxPayment: 10 * 144 * COIN, // 144 blocks of 10 tPIV
-        defaultColdStakingAddress: 'WmNziUEPyhnUkiVdfsiNX93H6rSJnios44', // Sparrow's Testnet Cold Pool
-    },
+    current: chainParams.main,
+    ...chainParams,
 });
-// Set default chain
-cChainParams.current = cChainParams.main;


### PR DESCRIPTION
## Abstract

In order to write e2e tests we need to differentiate between the testing and production environment.
The configurable chain parameters were moved to a JSON file, this is to allow the configuration to happen outside of the source code.
This also allows custom MPW builds to change their parameters without the need to edit the source code.
A `config` npm script was added that automatically copies the production config if the file doesn't exist

## Testing
Build MPW and test that it receives the same chain_params as before