### PR TITLE
Allow all host headers in dev env

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -20,6 +20,7 @@ export default merge(common, {
         compress: true,
         port: 5500,
         hot: true,
+        allowedHosts: ['all'],
         client: {
             overlay: false,
         },


### PR DESCRIPTION
This PR enables all possible hosts accessing the development environment when it's run.

It's critical to have this if said environment is proxied via nginx (or other front-proxy) if you do not want to spoof/overwrite your hearders within said proxy's config.

Otherwise "Invalid Host header" error will be rendered.