### PR TITLE
Enable undelegation on hardware wallets

### DIFF
--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -6,7 +6,8 @@ import { confirmPopup, createAlert } from './misc.js';
 import { getNetwork } from './network.js';
 import { Transaction } from './transaction.js';
 import { COIN, cChainParams } from './chain_params.js';
-import { hexToBytes } from './utils.js';
+import { hexToBytes, bytesToHex } from './utils.js';
+import { OP } from './script.js';
 
 /**
  * @type{TransportWebUSB}

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -6,7 +6,7 @@ import { confirmPopup, createAlert } from './misc.js';
 import { getNetwork } from './network.js';
 import { Transaction } from './transaction.js';
 import { COIN, cChainParams } from './chain_params.js';
-import { hexToBytes } from './utils';
+import { hexToBytes } from './utils.js';
 
 /**
  * @type{TransportWebUSB}

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -191,9 +191,9 @@ export async function ledgerSignTransaction(wallet, transaction) {
             const sigLength = bytes[0];
             input.scriptSig = bytesToHex([
                 bytes[0],
-                ...bytes.splice(1, sigLength),
+                ...bytes.slice(1, sigLength + 1),
                 OP['FALSE'],
-                ...bytes.splice(sigLength + 1),
+                ...bytes.slice(sigLength + 1),
             ]);
         }
     }

--- a/scripts/legacy.js
+++ b/scripts/legacy.js
@@ -30,6 +30,7 @@ export async function createAndSendTransaction({
     delegateChange = false,
     changeDelegationAddress = null,
     isProposal = false,
+    changeAddress = '',
 }) {
     const tx = wallet.createTransaction(address, amount, {
         isDelegation,
@@ -37,6 +38,7 @@ export async function createAndSendTransaction({
         delegateChange,
         changeDelegationAddress,
         isProposal,
+        changeAddress,
     });
     if (!wallet.isHardwareWallet()) await wallet.sign(tx);
     else {
@@ -72,7 +74,10 @@ export async function undelegateGUI() {
     if (!validateAmount(nAmount)) return;
 
     // Generate a new address to undelegate towards
-    const [address] = wallet.getNewAddress(1);
+
+    const [address] = await getNewAddress({
+        verify: wallet.isHardwareWallet(),
+    });
 
     // Perform the TX
     const cTxRes = await createAndSendTransaction({
@@ -82,6 +87,7 @@ export async function undelegateGUI() {
         useDelegatedInputs: true,
         delegateChange: !wallet.isHardwareWallet(),
         changeDelegationAddress: await wallet.getColdStakingAddress(),
+        changeAddress: address,
     });
 
     if (!cTxRes.ok && cTxRes.err === 'No change addr') {

--- a/scripts/legacy.js
+++ b/scripts/legacy.js
@@ -80,7 +80,7 @@ export async function undelegateGUI() {
         amount: nAmount,
         isDelegation: false,
         useDelegatedInputs: true,
-        delegateChange: true,
+        delegateChange: !wallet.isHardwareWallet(),
         changeDelegationAddress: await wallet.getColdStakingAddress(),
     });
 

--- a/scripts/legacy.js
+++ b/scripts/legacy.js
@@ -107,6 +107,9 @@ export async function undelegateGUI() {
  * @deprecated use the new wallet method instead
  */
 export async function delegateGUI() {
+    if (wallet.isHardwareWallet()) {
+        return createAlert('warning', ALERTS.STAKING_LEDGER_NO_SUPPORT);
+    }
     // Ensure the wallet is unlocked
     if (
         wallet.isViewOnly() &&

--- a/scripts/legacy.js
+++ b/scripts/legacy.js
@@ -31,6 +31,7 @@ export async function createAndSendTransaction({
     changeDelegationAddress = null,
     isProposal = false,
     changeAddress = '',
+    delegationOwnerAddress,
 }) {
     const tx = wallet.createTransaction(address, amount, {
         isDelegation,
@@ -39,6 +40,7 @@ export async function createAndSendTransaction({
         changeDelegationAddress,
         isProposal,
         changeAddress,
+        returnAddress: delegationOwnerAddress,
     });
     if (!wallet.isHardwareWallet()) await wallet.sign(tx);
     else {

--- a/scripts/legacy.js
+++ b/scripts/legacy.js
@@ -54,18 +54,16 @@ export async function createAndSendTransaction({
  * @deprecated use the new wallet method instead
  */
 export async function undelegateGUI() {
-    if (wallet.isHardwareWallet()) {
-        return createAlert('warning', ALERTS.STAKING_LEDGER_NO_SUPPORT, 6000);
-    }
-
     // Ensure the wallet is unlocked
-    if (
-        wallet.isViewOnly() &&
-        !(await restoreWallet(
-            `${translation.walletUnlockUnstake} ${cChainParams.current.TICKER}!`
-        ))
-    )
-        return;
+    if (!wallet.isHardwareWallet()) {
+        if (
+            wallet.isViewOnly() &&
+            !(await restoreWallet(
+                `${translation.walletUnlockUnstake} ${cChainParams.current.TICKER}!`
+            ))
+        )
+            return;
+    }
 
     // Verify the amount
     const nAmount = Math.round(

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -666,6 +666,7 @@ export class Wallet {
             delegateChange = false,
             changeDelegationAddress = null,
             isProposal = false,
+            changeAddress = '',
         } = {}
     ) {
         const balance = useDelegatedInputs
@@ -689,7 +690,7 @@ export class Wallet {
 
         // Add change output
         if (changeValue > 0) {
-            const [changeAddress] = this.getNewAddress(1);
+            if (!changeAddress) [changeAddress] = this.getNewAddress(1);
             if (delegateChange && changeValue > 1.01 * COIN) {
                 transactionBuilder.addColdStakeOutput({
                     address: changeAddress,

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -667,6 +667,7 @@ export class Wallet {
             changeDelegationAddress = null,
             isProposal = false,
             changeAddress = '',
+            returnAddress = '',
         } = {}
     ) {
         const balance = useDelegatedInputs
@@ -710,7 +711,7 @@ export class Wallet {
 
         // Add primary output
         if (isDelegation) {
-            const [returnAddress] = this.getNewAddress(1);
+            if (!returnAddress) [returnAddress] = this.getNewAddress(1);
             transactionBuilder.addColdStakeOutput({
                 address: returnAddress,
                 addressColdStake: address,

--- a/tests/unit/wallet.spec.js
+++ b/tests/unit/wallet.spec.js
@@ -77,6 +77,38 @@ describe('Wallet transaction tests', () => {
         );
     });
 
+    it('Creates a tx with change address', async () => {
+        const wallet = new Wallet(0, false);
+        wallet.setMasterKey(getLegacyMainnet());
+        const tx = wallet.createTransaction(
+            'DLabsktzGMnsK5K9uRTMCF6NoYNY6ET4Bb',
+            0.05 * 10 ** 8,
+            { changeAddress: 'D8Ervc3Ka6TuKgvXZH9Eo4ou24AiVwTbL6' }
+        );
+        expect(tx.version).toBe(1);
+        expect(tx.vin[0]).toStrictEqual(
+            new CTxIn({
+                outpoint: new COutpoint({
+                    txid: 'f8f968d80ac382a7b64591cc166489f66b7c4422f95fbd89f946a5041d285d7c',
+                    n: 1,
+                }),
+                scriptSig: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac', // Script sig must be the UTXO script since it's not signed
+            })
+        );
+        expect(tx.vout[0]).toStrictEqual(
+            new CTxOut({
+                script: '76a91421ff8214d09d60713b89809bb413a0651ee6931488ac',
+                value: 4992400,
+            })
+        );
+        expect(tx.vout[1]).toStrictEqual(
+            new CTxOut({
+                script: '76a914a95cc6408a676232d61ec29dc56a180b5847835788ac',
+                value: 5000000,
+            })
+        );
+    });
+
     it('Creates a proposal tx correctly', async () => {
         const wallet = new Wallet(0, false);
         wallet.setMasterKey(getLegacyMainnet());


### PR DESCRIPTION
## Abstract

Ledgers should be able to undelegate. This enables users to follow this guide
https://forum.pivx.org/threads/how-to-setup-cold-staking-with-ledger-hardware-wallet.650/.

(Disclaimer: I haven't tested this, as I don't have my ledger with me)

## Testing
- Send a p2cs tx to a ledger address (This can be done with MPW by toggling advanced mode)
- Check that you can spend the tx on ledger