### PR TITLE
Bump gh actions to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - "master"
     paths-ignore:
       - "*.md"
-      - LICENCE
+      - LICENSE
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -20,12 +20,10 @@ jobs:
       
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Install npm/nodejs
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
+        uses: actions/setup-node@v4
       - name: Install packages
         run: npm install
       - name: Build 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,20 +26,19 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 19
+        uses: actions/setup-node@v4
 
-      # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies
         run: npm ci
 
       - name: Run ESlint
         run: npm run lint
+        
       - name: Run prettier
         run: npx prettier -l .
+        
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Abstract

Bump some gh actions to v4. This changes the default node runtime to version 20

## Testing
No testing is required

