### PR TITLE
Remove rockdev explorer

### DIFF
--- a/chain_params.prod.json
+++ b/chain_params.prod.json
@@ -15,9 +15,8 @@
         "MASTERNODE_PORT": 51472,
         "SHIELD_PREFIX": "ps",
         "Explorers": [
-            { "name": "rockdev", "url": "https://explorer.rockdev.org" },
-            { "name": "zkBitcoin", "url": "https://zkbitcoin.com" },
-            { "name": "Duddino", "url": "https://explorer.duddino.com" }
+            { "name": "Duddino", "url": "https://explorer.duddino.com" },
+            { "name": "zkBitcoin", "url": "https://zkbitcoin.com" }
         ],
         "Nodes": [
             { "name": "Duddino", "url": "https://rpc.duddino.com/mainnet" }


### PR DESCRIPTION
## Abstract

This PR simply removes the now-defunct [Rockdev explorer](https://explorer.rockdev.org/) by Sparrow - as you can see by the home page, this explorer has been shut down - in the case that it comes back in the future, we could re-add it, but there's no point in keeping a dead explorer in MPW at the moment.

Duddino's explorer has been set as the new default in replacement, with zkBitcoin being second.

According to the [Settings logic](https://github.com/PIVX-Labs/MyPIVXWallet/blob/590a20bfd336db4229d5f289c9c84857e71db810/scripts/settings.js#L617), even if Rockdev is someone's chosen explorer; if MPW cannot find the explorer in the ChainParams, it will use the default explorer, so no other changes should be necessary for a safe removal.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Use a wallet with `Rockdev` as your chosen explorer, apply the PR, then ensure MPW switches to Duddino's explorer.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---