### PR TITLE
Bump protocol version to 70927

### DIFF
--- a/chain_params.prod.json
+++ b/chain_params.prod.json
@@ -11,7 +11,7 @@
         "SECRET_KEY": 212,
         "BIP44_TYPE": 119,
         "BIP44_TYPE_LEDGER": 77,
-        "PROTOCOL_VERSION": 70926,
+        "PROTOCOL_VERSION": 70927,
         "MASTERNODE_PORT": 51472,
         "SHIELD_PREFIX": "ps",
         "Explorers": [
@@ -42,7 +42,7 @@
         "SECRET_KEY": 239,
         "BIP44_TYPE": 1,
         "BIP44_TYPE_LEDGER": 1,
-        "PROTOCOL_VERSION": 70926,
+        "PROTOCOL_VERSION": 70927,
         "MASTERNODE_PORT": 51474,
         "SHIELD_PREFIX": "ptestsapling",
         "Explorers": [


### PR DESCRIPTION
## Abstract

Protocol version was changed to 70927 in 5.6.1.
You may need to `rm chain_params.json && npm ci` to regenerate the config file

## Testing
- Create a masternode and test that it goes enabled with the new protocl version