### PR TITLE
Fix Masternode UTXO detection

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -882,7 +882,10 @@ export async function importMasternode() {
             includeLocked: false,
         });
         for (const u of utxos) {
-            if (wallet.getPath(u.script) === path) {
+            if (
+                u.value === cChainParams.current.collateralInSats &&
+                wallet.getPath(u.script) === path
+            ) {
                 masterUtxo = u;
             }
         }


### PR DESCRIPTION
## Abstract
Masternodes weren't using the right UTXO when you had multiple.
The whole masternode system is pending a refactor anyways, but this patch should at least get it usable for 1.5.0

## Testing
- Create a masternode UTXO
- Send some PIVs to that address
- Test that it successfully creates the masternode