### PR TITLE
Use union merge driver for .toml files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.toml merge=union # Use union merge driver for locale files

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.toml merge=union # Use union merge driver for locale files
+*.toml merge=union


### PR DESCRIPTION
## Abstract

Most .toml conflicts are due to two PRs adding different translations in the same point.
For example, #294 is currently conflicting with master:
```
shieldAddress = "" # Shield address
<<<<<<< tx-modal
noInputs = "" # No inputs
noOutputs = "" # No outputs
=======
cantShieldToExc = "" # This address does not support shield transfers
>>>>>>> master
```
With this PR we are telling git to accept both changes automatically in `toml` files, resulting in:
```
shieldAddress = "" # Shield address
noInputs = "" # No inputs
noOutputs = "" # No outputs
cantShieldToExc = "" # This address does not support shield transfers
```

## Testing
Run the following commands, after having fetched my git remote:
- `git checkout 467432e187342b13e05730131cdad28e2af6567a` (Tx description PR, might need to fetch the remote)
- `git merge master` It should have a lot of locale conflicts
- `git merge --abort`
- `git checkout ad0360d8c0dd0159561fa2bb0a9a87e3548e5d5e -- .gitattributes` (Take this PR .gitattrubutes)
- `git commit -m "Test"` Commit the changes so git doesn't complain about merging
- `git merge master` Should merge cleanly now