### PR TITLE
Refactor tx version

### DIFF
--- a/scripts/chain_params.js
+++ b/scripts/chain_params.js
@@ -15,6 +15,9 @@ export const MAX_ACCOUNT_GAP = 20;
 /** The batch size of Shield block synchronisation */
 export const SHIELD_BATCH_SYNC_SIZE = 32;
 
+/** Transaction Sapling Version */
+export const SAPLING_TX_VERSION = 3;
+
 /* Internal tweaking parameters */
 // A new encryption password must be 'at least' this long.
 export const MIN_PASS_LENGTH = 6;

--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -116,10 +116,7 @@ export class Transaction {
     }
 
     get hasSaplingVersion() {
-        return (
-            typeof this.version == typeof 3 &&
-            this.__original.version >= SAPLING_TX_VERSION
-        );
+        return this.version >= SAPLING_TX_VERSION;
     }
 
     get txid() {
@@ -131,7 +128,7 @@ export class Transaction {
         return this.__original.#txid;
     }
 
-    hasShieldData() {
+    get hasShieldData() {
         return this.bindingSig !== '';
     }
 
@@ -337,7 +334,7 @@ export class Transaction {
             valueBalance.writeBigInt64LE(BigInt(this.valueBalance));
             buffer = [
                 ...buffer,
-                Number(this.hasShieldData()),
+                Number(this.hasShieldData),
                 ...valueBalance,
                 ...numToVarInt(BigInt(this.shieldSpend.length)),
             ];

--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -378,6 +378,9 @@ export class Transaction {
      * Using the sighash type SIGHASH_ALL
      */
     transactionHash(index) {
+        if (this.hasSaplingVersion) {
+            throw new Error('tx version too high, cannot use base tx hash');
+        }
         const copy = structuredClone(this.__original);
         // Black out all inputs
         for (let i = 0; i < copy.vin.length; i++) {

--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -214,7 +214,8 @@ export class Transaction {
         }
 
         this.lockTime = Number(bytesToNum(bytes.slice(offset, (offset += 4))));
-
+        this.shieldSpend = []
+        this.shieldOutput = []
         if (this.hasSaplingVersion) {
             const hasShield = bytesToNum(bytes.slice(offset, (offset += 1)));
             if (hasShield) {

--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -214,8 +214,8 @@ export class Transaction {
         }
 
         this.lockTime = Number(bytesToNum(bytes.slice(offset, (offset += 4))));
-        this.shieldSpend = []
-        this.shieldOutput = []
+        this.shieldSpend = [];
+        this.shieldOutput = [];
         if (this.hasSaplingVersion) {
             const hasShield = bytesToNum(bytes.slice(offset, (offset += 1)));
             if (hasShield) {

--- a/scripts/transaction_builder.js
+++ b/scripts/transaction_builder.js
@@ -3,6 +3,7 @@ import bs58 from 'bs58';
 import { OP } from './script.js';
 import { hexToBytes, bytesToHex, dSHA256 } from './utils.js';
 import { isShieldAddress, isExchangeAddress } from './misc.js';
+import { SAPLING_TX_VERSION } from './chain_params.js';
 /**
  * @class Builds a non-signed transaction
  */
@@ -106,7 +107,7 @@ export class TransactionBuilder {
      * @returns {TransactionBuilder}
      */
     #addShieldOutput({ address, value }) {
-        this.#transaction.version = 3;
+        this.#transaction.version = SAPLING_TX_VERSION;
         // We don't know how to create shieldData, so we create
         // a dummy object so we can pass it later to the Shield library
         // upon signing.
@@ -236,7 +237,7 @@ export class TransactionBuilder {
         if (tx && !tx.vin.length) {
             // If the tx doesn't have any clear inputs,
             // it must be a shield transaction
-            tx.version = 3;
+            tx.version = SAPLING_TX_VERSION;
         }
         this.#transaction = null;
         return tx;

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1077,7 +1077,7 @@ export class Wallet {
      * @param {Transaction} transaction
      */
     finalizeTransaction(transaction) {
-        if (transaction.hasShieldData()) {
+        if (transaction.hasShieldData) {
             wallet.#shield.finalizeTransaction(transaction.txid);
         }
 

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1009,8 +1009,10 @@ export class Wallet {
      * @param {Transaction} transaction
      */
     async #signShield(transaction) {
-        if (transaction.version !== 3) {
-            throw new Error('`signShield` was called with a non-shield tx');
+        if (!transaction.hasSaplingVersion) {
+            throw new Error(
+                '`signShield` was called with a tx that cannot have shield data'
+            );
         }
         if (!this.hasShield()) {
             throw new Error(
@@ -1054,7 +1056,8 @@ export class Wallet {
         if (this.isViewOnly()) {
             throw new Error('Cannot sign with a view only wallet');
         }
-        if (transaction.version === 3) {
+        if (!transaction.vin.length || transaction.shieldOutput[0]) {
+            // TODO: separate signing and building process for shield?
             return await this.#signShield(transaction);
         }
         for (let i = 0; i < transaction.vin.length; i++) {
@@ -1074,7 +1077,7 @@ export class Wallet {
      * @param {Transaction} transaction
      */
     finalizeTransaction(transaction) {
-        if (transaction.version === 3) {
+        if (transaction.hasShieldData()) {
             wallet.#shield.finalizeTransaction(transaction.txid);
         }
 

--- a/tests/unit/transaction.spec.js
+++ b/tests/unit/transaction.spec.js
@@ -93,7 +93,7 @@ describe('transaction tests', () => {
         tx.version = 10;
         expect(tx.txid).not.toBe(txid);
         expect(tx.txid).toBe(
-            '416368b2101fab865db162d49d0540560f802e89801cad8eb1d9cf3a4e6ad5be'
+            '69f75c046610514156fdd816ed562ba8a9f1578008740c0cbd752254a9767d2c'
         );
         tx.version = originalVersion;
     });

--- a/tests/unit/wallet/transactions.spec.js
+++ b/tests/unit/wallet/transactions.spec.js
@@ -319,7 +319,7 @@ describe('Wallet transaction tests', () => {
     });
 
     it('finalizes transaction correctly', () => {
-        const tx = {};
+        const tx = new Transaction();
         wallet.finalizeTransaction(tx);
         expect(mempool.updateMempool).toBeCalled(1);
         expect(mempool.updateMempool).toBeCalledWith(tx);


### PR DESCRIPTION
## Abstract

A bit of refactor:

- Do not hardcore version = 3 but use `SAPLING_TX_VERSION` instead 
- Do NOT assume that transactions with version = 3 are shielded
- Make sure that `transactionHash` is called only on transactions with version lower than  `SAPLING_TX_VERSION`
- Fix a test that was using the wrong serialization 

---

## Testing
Unit tests are not broken



