### PR TITLE
Fix Receive Flow

### DIFF
--- a/scripts/contacts-book.js
+++ b/scripts/contacts-book.js
@@ -464,10 +464,21 @@ export const RECEIVE_TYPES = {
     ADDRESS: 1,
     SHIELD: 2,
     XPUB: 3,
+    MAX_RECEIVE: 4,
 };
 
 /** The current Receive Type used by Receive UIs */
 export let cReceiveType = RECEIVE_TYPES.CONTACT;
+
+/**
+ * Helper function for guiToggleReceiveType
+ */
+function findNextAvailableType(startType, availableTypes) {
+    do {
+        startType = (startType + 1) % RECEIVE_TYPES.MAX_RECEIVE;
+    } while (!availableTypes.includes(startType));
+    return startType;
+}
 
 /**
  * Cycles through the Receive Types with each run
@@ -488,10 +499,10 @@ export async function guiToggleReceiveType(nForceType = null) {
     cReceiveType =
         nForceType !== null
             ? nForceType
-            : (cReceiveType + 1) % availableTypes.length;
+            : findNextAvailableType(cReceiveType, availableTypes);
 
     // Convert the *next* Type to text (also runs through i18n system)
-    const nNextType = (cReceiveType + 1) % availableTypes.length;
+    const nNextType = findNextAvailableType(cReceiveType, availableTypes);
     let strNextType = '';
     switch (nNextType) {
         case RECEIVE_TYPES.CONTACT:


### PR DESCRIPTION
## Abstract

Wallets without shield were trying to generate shield addresses in the "Receive" flow

---

## Testing
Open a wallet which has no shield, click on "Receive", cycle through all possible outcomes (xPub, address, contact etc...) and verify that no errors are thrown

