### PR TITLE
Don't allow non-shield wallets to send to shield addresses

### DIFF
--- a/locale/cnr/translation.toml
+++ b/locale/cnr/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "Novčanik je uspešno otključan!" # Wallet successfully Unlo
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/de/translation.toml
+++ b/locale/de/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/en/translation.toml
+++ b/locale/en/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "Wallet successfully Unlocked!" # Wallet successfully Unlocked
 CONFIRM_LEDGER_TX = "Confirm this transaction matches the one on your {hardwareWallet}" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "You will send {value} {ticker} to <div class=\"inline-address\">{address}</div>" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "Balance is too small! Missing {sats} sats!" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "Shield is not enabled in this wallet!" # Shield is not enabled in this wallet!

--- a/locale/es-mx/translation.toml
+++ b/locale/es-mx/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/fr/translation.toml
+++ b/locale/fr/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/it/translation.toml
+++ b/locale/it/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/nl/translation.toml
+++ b/locale/nl/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/ph/translation.toml
+++ b/locale/ph/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/pl/translation.toml
+++ b/locale/pl/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "Portfel pomyślnie odblokowany!" # Wallet successfully Unlock
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/pt-br/translation.toml
+++ b/locale/pt-br/translation.toml
@@ -126,3 +126,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/pt-pt/translation.toml
+++ b/locale/pt-pt/translation.toml
@@ -126,3 +126,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/locale/template/translation.toml
+++ b/locale/template/translation.toml
@@ -351,3 +351,4 @@ CONFIRM_POPUP_DELETE_ACCOUNT_TITLE = 'Are you sure?'
 CONFIRM_LEDGER_TX = 'Confirm this transaction matches the one on your {hardwareWallet}'
 CONFIRM_LEDGER_TX_OUT = 'You will send {value} {ticker} to <div class="inline-address">{address}</div>'
 MISSING_FUNDS = 'Balance is too small! Missing {sats} sats!'
+MISSING_SHIELD = "Shield is not enabled in this wallet!"

--- a/locale/uwu/translation.toml
+++ b/locale/uwu/translation.toml
@@ -327,3 +327,4 @@ WALLET_UNLOCKED = "" # Wallet successfully Unlocked!
 CONFIRM_LEDGER_TX = "" # Confirm this transaction matches the one on your {hardwareWallet}
 CONFIRM_LEDGER_TX_OUT = "" # You will send {value} {ticker} to <div class="inline-address">{address}</div>
 MISSING_FUNDS = "" # Balance is too small! Missing {sats} sats!
+MISSING_SHIELD = "" # Shield is not enabled in this wallet!

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -359,6 +359,13 @@ async function send(address, amount, useShieldInputs) {
     // If a Contact were found, we use it's Pubkey
     if (cContact) address = cContact.pubkey;
 
+    // Make sure wallet has shield enabled
+    if (!wallet.hasShield.value) {
+        if (useShieldInputs || isShieldAddress(address)) {
+            return createAlert('warning', ALERTS.MISSING_SHIELD);
+        }
+    }
+
     // If this is an XPub, we'll fetch their last used 'index', and derive a new public key for enhanced privacy
     if (isXPub(address)) {
         const cNet = getNetwork();

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1012,6 +1012,11 @@ export class Wallet {
         if (transaction.version !== 3) {
             throw new Error('`signShield` was called with a non-shield tx');
         }
+        if (!this.hasShield()) {
+            throw new Error(
+                'trying to create a shield transaction without having shield enable'
+            );
+        }
 
         const periodicFunction = setInterval(async () => {
             const percentage = 5 + (await this.#shield.getTxStatus()) * 95;


### PR DESCRIPTION
## Abstract

Handle the case in which a user, without shield enable, tries to send to a shield wallet or use shield inputs

## Test
Create a wallet without shield and try to send to a shield address, error should be handled

