### PR TITLE
Fix PIVX Promos text spacing

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -673,7 +673,7 @@ defineExpose({
                         <div class="modal-body center-text">
                             <center>
                                 <p class="mono" style="font-size: small">
-                                    <b>PIVX Promos</b>
+                                    <b>PIVX Promos </b>
                                     <span
                                         style="font-family: inherit !important"
                                     >


### PR DESCRIPTION
## Abstract

Simply adds a space to fix the PIVX Promos subtext.

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/6a96f8a3-b3cd-49dc-a5cb-c6a4c5a594d1)
---
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/bef709b8-4b43-4f60-b098-61e1dffbc9b2)


---