### PR TITLE
Add temporary Pending Shield UI

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -56,6 +56,7 @@ export function useWallet() {
     };
     const balance = ref(0);
     const shieldBalance = ref(0);
+    const pendingShieldBalance = ref(0);
     const immatureBalance = ref(0);
     const currency = ref('USD');
     const price = ref(0.0);
@@ -63,6 +64,7 @@ export function useWallet() {
         await wallet.sync();
         balance.value = mempool.balance;
         shieldBalance.value = await wallet.getShieldBalance();
+        pendingShieldBalance.value = await wallet.getPendingShieldBalance();
     };
     getEventEmitter().on('shield-loaded-from-disk', () => {
         hasShield.value = wallet.hasShield();
@@ -91,6 +93,7 @@ export function useWallet() {
         immatureBalance.value = mempool.immatureBalance;
         currency.value = strCurrency.toUpperCase();
         shieldBalance.value = await wallet.getShieldBalance();
+        pendingShieldBalance.value = await wallet.getPendingShieldBalance();
         price.value = await cMarket.getPrice(strCurrency);
     });
 
@@ -114,6 +117,7 @@ export function useWallet() {
         balance,
         hasShield,
         shieldBalance,
+        pendingShieldBalance,
         isCreatingTx,
         immatureBalance,
         currency,

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -492,7 +492,14 @@ onMounted(async () => {
     updateLogOutButton();
 });
 
-const { balance, shieldBalance, immatureBalance, currency, price } = wallet;
+const {
+    balance,
+    shieldBalance,
+    pendingShieldBalance,
+    immatureBalance,
+    currency,
+    price,
+} = wallet;
 
 getEventEmitter().on('sync-status', (status) => {
     if (status === 'stop') activity?.value?.update();
@@ -980,6 +987,7 @@ defineExpose({
                     <WalletBalance
                         :balance="balance"
                         :shieldBalance="shieldBalance"
+                        :pendingShieldBalance="pendingShieldBalance"
                         :immatureBalance="immatureBalance"
                         :jdenticonValue="jdenticonValue"
                         :isHdWallet="wallet.isHD.value"

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -20,6 +20,7 @@ const props = defineProps({
     jdenticonValue: String,
     balance: Number,
     shieldBalance: Number,
+    pendingShieldBalance: Number,
     immatureBalance: Number,
     isHdWallet: Boolean,
     isHardwareWallet: Boolean,
@@ -32,6 +33,7 @@ const {
     jdenticonValue,
     balance,
     shieldBalance,
+    pendingShieldBalance,
     immatureBalance,
     isHdWallet,
     isHardwareWallet,
@@ -76,6 +78,11 @@ const balanceStr = computed(() => {
 });
 const shieldBalanceStr = computed(() => {
     const nCoins = shieldBalance.value / COIN;
+    return nCoins.toFixed(displayDecimals.value);
+});
+
+const pendingShieldBalanceStr = computed(() => {
+    const nCoins = pendingShieldBalance.value / COIN;
     return nCoins.toFixed(displayDecimals.value);
 });
 
@@ -315,13 +322,16 @@ function reload() {
             </span>
             <br />
             <div class="dcWallet-usdBalance">
-                <span
-                    class="dcWallet-usdValue"
-                    v-if="shieldEnabled"
-                    v-html="shieldBalanceStr"
+                <span class="dcWallet-usdValue" v-if="shieldEnabled"
+                    >{{ shieldBalanceStr }}
+                    <span
+                        style="opacity: 0.75"
+                        v-if="pendingShieldBalance != 0"
+                    >
+                        ({{ pendingShieldBalanceStr }} Pending)</span
+                    ></span
                 >
-                </span>
-                <span style="margin-left: 5px">
+                <span style="margin-left: 2px">
                     <i class="fas fa-shield fa-xs" v-if="shieldEnabled"> </i>
                 </span>
             </div>

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -322,8 +322,8 @@ function reload() {
             </span>
             <br />
             <div class="dcWallet-usdBalance">
-                <span class="dcWallet-usdValue" v-if="shieldEnabled"
-                    >{{ shieldBalanceStr }}
+                <span class="dcWallet-usdValue" v-if="shieldEnabled">
+                    <i class="fas fa-shield fa-xs" style="margin-right: 4px" v-if="shieldEnabled"> </i>{{ shieldBalanceStr }}
                     <span
                         style="opacity: 0.75"
                         v-if="pendingShieldBalance != 0"
@@ -331,9 +331,6 @@ function reload() {
                         ({{ pendingShieldBalanceStr }} Pending)</span
                     ></span
                 >
-                <span style="margin-left: 2px">
-                    <i class="fas fa-shield fa-xs" v-if="shieldEnabled"> </i>
-                </span>
             </div>
             <div class="dcWallet-usdBalance">
                 <span class="dcWallet-usdValue">{{ balanceValue }}</span>

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -323,7 +323,13 @@ function reload() {
             <br />
             <div class="dcWallet-usdBalance">
                 <span class="dcWallet-usdValue" v-if="shieldEnabled">
-                    <i class="fas fa-shield fa-xs" style="margin-right: 4px" v-if="shieldEnabled"> </i>{{ shieldBalanceStr }}
+                    <i
+                        class="fas fa-shield fa-xs"
+                        style="margin-right: 4px"
+                        v-if="shieldEnabled"
+                    >
+                    </i
+                    >{{ shieldBalanceStr }}
                     <span
                         style="opacity: 0.75"
                         v-if="pendingShieldBalance != 0"


### PR DESCRIPTION
## Abstract

This PR adds a simple (temporary placeholder) pending UI for Shield balances, since I believe this will be clearer for users in the meantime while the "true" Shield UI is developed by our design team, this will just be a short term UI piece.

*Pending Shield balance shown in low-opacity with "Pending", on the right of the Available Shield balance*
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/d446d584-0d02-4d08-bb29-c5c7f0d28e82)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Send a Shield Tx, like a Deshield, and see that your change displays as Pending shortly afterwards.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---