### PR TITLE
Improve tx creation flow

### DIFF
--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -48,6 +48,15 @@ export class CTxOut {
     isEmpty() {
         return this.value == 0 && (this.script === 'f8' || this.script === '');
     }
+
+    serialize() {
+        const scriptBytes = hexToBytes(this.script);
+        return [
+            ...numToBytes(BigInt(this.value), 8),
+            ...numToVarInt(BigInt(scriptBytes.length)),
+            ...scriptBytes,
+        ];
+    }
 }
 export class CTxIn {
     /**
@@ -66,7 +75,6 @@ export class CTxIn {
         this.sequence = sequence;
     }
 }
-
 export class Transaction {
     /** @type{number} */
     version;

--- a/scripts/transaction_builder.js
+++ b/scripts/transaction_builder.js
@@ -15,7 +15,8 @@ export class TransactionBuilder {
     // Part of the tx fee that has been already handled
     #handledFee = 0;
     MIN_FEE_PER_BYTE = 10;
-    SCRIPT_SIG_AVERAGE_SIZE = 107;
+    // This number is larger or equal than the max size of the script sig for a P2CS and P2PKH transaction
+    SCRIPT_SIG_MAX_SIZE = 108;
 
     get valueIn() {
         return this.#valueIn;
@@ -57,9 +58,7 @@ export class TransactionBuilder {
         for (let vin of this.#transaction.vin) {
             scriptSig.push(vin.scriptSig);
             // Insert a dummy signature just to compute fees
-            vin.scriptSig = bytesToHex(
-                Array(this.SCRIPT_SIG_AVERAGE_SIZE).fill(0)
-            );
+            vin.scriptSig = bytesToHex(Array(this.SCRIPT_SIG_MAX_SIZE).fill(0));
         }
 
         const fee =

--- a/scripts/transaction_builder.js
+++ b/scripts/transaction_builder.js
@@ -12,6 +12,11 @@ export class TransactionBuilder {
     #valueIn = 0;
     #valueOut = 0;
 
+    // Part of the tx fee that has been already handled
+    #handledFee = 0;
+    MIN_FEE_PER_BYTE = 10;
+    SCRIPT_SIG_AVERAGE_SIZE = 107;
+
     get valueIn() {
         return this.#valueIn;
     }
@@ -22,6 +27,14 @@ export class TransactionBuilder {
 
     get value() {
         return this.#valueIn - this.#valueOut;
+    }
+    /**
+     * See if the given CTxOut is plain dust
+     * @param{{out:CTxOut, value: number}}
+     */
+    isDust({ out, value }) {
+        // Dust is a transaction such that its creation costs more than its value
+        return value < out.serialize().length * this.MIN_FEE_PER_BYTE;
     }
 
     constructor() {
@@ -39,8 +52,25 @@ export class TransactionBuilder {
     }
 
     getFee() {
-        // Temporary: 50 sats per byte
-        return this.#transaction.serialize().length * 50;
+        //TODO: find a cleaner way to add the dummy signature
+        let scriptSig = [];
+        for (let vin of this.#transaction.vin) {
+            scriptSig.push(vin.scriptSig);
+            // Insert a dummy signature just to compute fees
+            vin.scriptSig = bytesToHex(
+                Array(this.SCRIPT_SIG_AVERAGE_SIZE).fill(0)
+            );
+        }
+
+        const fee =
+            Math.ceil(this.#transaction.serialize().length / 2) *
+                this.MIN_FEE_PER_BYTE -
+            this.#handledFee;
+        // Re-insert whatever was inside before
+        for (let i = 0; i < scriptSig.length; i++) {
+            this.#transaction.vin[i].scriptSig = scriptSig[i];
+        }
+        return fee;
     }
 
     /**
@@ -135,22 +165,32 @@ export class TransactionBuilder {
         this.#addScript({ script, value });
     }
 
-    #addScript({ script, value }) {
-        this.#transaction.vout.push(
-            new CTxOut({
-                script: bytesToHex(script),
-                value,
-            })
-        );
-        this.#valueOut += value;
+    #addScript({ script, value, subtractFeeFromAmt = false }) {
+        let out = new CTxOut({
+            script: bytesToHex(script),
+            value,
+        });
+        // if subtractFeeFromAmt has been set do NOT add dust
+        // We would end up with an UTXO with negative value
+        if (this.isDust({ out, value }) && subtractFeeFromAmt) {
+            return;
+        }
+        const fee = out.serialize().length * this.MIN_FEE_PER_BYTE;
+        // We have subtracted fees from the value, mark this fee as handled (don't pay them again)
+        if (subtractFeeFromAmt) {
+            out.value -= fee;
+            this.#handledFee += fee;
+        }
+        this.#transaction.vout.push(out);
+        this.#valueOut += out.value;
     }
 
     /**
      * Adds a P2PKH output to the transaction
-     * @param {{address: string, value: number}}
+     * @param {{address: string, value: number, isChange: boolean}}
      * @returns {TransactionBuilder}
      */
-    #addP2pkhOutput({ address, value }) {
+    #addP2pkhOutput({ address, value, isChange }) {
         const decoded = this.#decodeAddress(address);
         const script = [
             OP['DUP'],
@@ -160,21 +200,21 @@ export class TransactionBuilder {
             OP['EQUALVERIFY'],
             OP['CHECKSIG'],
         ];
-        this.#addScript({ script, value });
+        this.#addScript({ script, value, subtractFeeFromAmt: isChange });
     }
 
     /**
      * Adds an output to the transaction
-     * @param {{address: string, value: number}}
+     * @param {{address: string, value: number, isChange: boolean}}
      * @returns {TransactionBuilder}
      */
-    addOutput({ address, value }) {
+    addOutput({ address, value, isChange = false }) {
         if (isShieldAddress(address)) {
             this.#addShieldOutput({ address, value });
         } else if (isExchangeAddress(address)) {
             this.#addExchangeOutput({ address, value });
         } else {
-            this.#addP2pkhOutput({ address, value });
+            this.#addP2pkhOutput({ address, value, isChange });
         }
 
         return this;
@@ -205,7 +245,7 @@ export class TransactionBuilder {
      * @param {{address: string, addressColdStake: string, value: number}}
      * @returns {TransactionBuilder}
      */
-    addColdStakeOutput({ address, addressColdStake, value }) {
+    addColdStakeOutput({ address, addressColdStake, value, isChange }) {
         const decodedAddress = this.#decodeAddress(address);
         const decodedAddressColdStake = this.#decodeAddress(addressColdStake);
         const script = [
@@ -223,13 +263,26 @@ export class TransactionBuilder {
             OP['EQUALVERIFY'],
             OP['CHECKSIG'],
         ];
-        this.#transaction.vout.push(
-            new CTxOut({
-                script: bytesToHex(script),
-                value,
-            })
-        );
+        this.#addScript({ script, value, subtractFeeFromAmt: isChange });
         return this;
+    }
+
+    // Equally subtract a value from every output of the tx
+    equallySubtractAmt(value) {
+        const tx = this.#transaction;
+        let first = true;
+        const outputs = tx.vout.length;
+        if (!outputs || outputs == 0) {
+            throw new Error('tx has no outputs!');
+        }
+        for (let vout of tx.vout) {
+            vout.value -= Math.floor(value / outputs);
+            // The first pays the remainder
+            if (first) {
+                vout.value -= value % outputs;
+                first = false;
+            }
+        }
     }
 
     build() {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -6,7 +6,7 @@ import { ExplorerNetwork, getNetwork } from './network.js';
 import { MAX_ACCOUNT_GAP, SHIELD_BATCH_SYNC_SIZE } from './chain_params.js';
 import { HistoricalTx, HistoricalTxType } from './mempool.js';
 import { Transaction } from './transaction.js';
-import { confirmPopup, createAlert } from './misc.js';
+import { confirmPopup, createAlert, isShieldAddress } from './misc.js';
 import { cChainParams } from './chain_params.js';
 import { COIN } from './chain_params.js';
 import { mempool } from './global.js';
@@ -932,6 +932,7 @@ export class Wallet {
             delegateChange = false,
             changeDelegationAddress = null,
             isProposal = false,
+            subtractFeeFromAmt = true,
             changeAddress = '',
             returnAddress = '',
         } = {}
@@ -952,35 +953,7 @@ export class Wallet {
                 '`delegateChange` was set to true, but no `changeDelegationAddress` was provided.'
             );
         const transactionBuilder = TransactionBuilder.create();
-        if (!useShieldInputs) {
-            const filter = useDelegatedInputs
-                ? UTXO_WALLET_STATE.SPENDABLE_COLD
-                : UTXO_WALLET_STATE.SPENDABLE;
-            const utxos = mempool.getUTXOs({ filter, target: value });
-            transactionBuilder.addUTXOs(utxos);
-            const fee = transactionBuilder.getFee();
-            const changeValue = transactionBuilder.valueIn - value - fee;
-
-            // Add change output
-            if (changeValue > 0) {
-                if (!changeAddress) [changeAddress] = this.getNewAddress(1);
-                if (delegateChange && changeValue > 1.01 * COIN) {
-                    transactionBuilder.addColdStakeOutput({
-                        address: changeAddress,
-                        value: changeValue,
-                        addressColdStake: changeDelegationAddress,
-                    });
-                } else {
-                    transactionBuilder.addOutput({
-                        address: changeAddress,
-                        value: changeValue,
-                    });
-                }
-            } else {
-                // We're sending alot! So we deduct the fee from the send amount. There's not enough change to pay it with!
-                value -= fee;
-            }
-        }
+        const isShieldTx = useShieldInputs || isShieldAddress(address);
 
         // Add primary output
         if (isDelegation) {
@@ -1000,6 +973,45 @@ export class Wallet {
                 address,
                 value,
             });
+        }
+
+        if (!useShieldInputs) {
+            const filter = useDelegatedInputs
+                ? UTXO_WALLET_STATE.SPENDABLE_COLD
+                : UTXO_WALLET_STATE.SPENDABLE;
+            const utxos = mempool.getUTXOs({ filter, target: value });
+            transactionBuilder.addUTXOs(utxos);
+
+            // Shield txs will handle change internally
+            if (isShieldTx) {
+                return transactionBuilder.build();
+            }
+
+            const fee = transactionBuilder.getFee();
+            const changeValue = transactionBuilder.valueIn - value - fee;
+            if (changeValue < 0) {
+                if (!subtractFeeFromAmt) {
+                    throw new Error('Not enough balance');
+                }
+                transactionBuilder.equallySubtractAmt(Math.abs(changeValue));
+            } else if (changeValue > 0) {
+                // TransactionBuilder will internally add the change only if it is not dust
+                if (!changeAddress) [changeAddress] = this.getNewAddress(1);
+                if (delegateChange) {
+                    transactionBuilder.addColdStakeOutput({
+                        address: changeAddress,
+                        value: changeValue,
+                        addressColdStake: changeDelegationAddress,
+                        isChange: true,
+                    });
+                } else {
+                    transactionBuilder.addOutput({
+                        address: changeAddress,
+                        value: changeValue,
+                        isChange: true,
+                    });
+                }
+            }
         }
         return transactionBuilder.build();
     }

--- a/tests/unit/wallet/transactions.spec.js
+++ b/tests/unit/wallet/transactions.spec.js
@@ -63,7 +63,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4997740,
+                value: 4997730,
             })
         );
         expect(tx.vout[0]).toStrictEqual(
@@ -93,7 +93,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4997740,
+                value: 4997730,
             })
         );
         expect(tx.vout[0]).toStrictEqual(
@@ -126,7 +126,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a91421ff8214d09d60713b89809bb413a0651ee6931488ac',
-                value: 4997730,
+                value: 4997720,
             })
         );
         expect(tx.vout[0]).toStrictEqual(
@@ -157,7 +157,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4997650,
+                value: 4997640,
             })
         );
         expect(tx.vout[0]).toStrictEqual(
@@ -188,7 +188,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4997480,
+                value: 4997470,
             })
         );
         expect(tx.vout[0]).toStrictEqual(
@@ -221,7 +221,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: '76a97b63d114291a25b5b4d1802e0611e9bf724a1e57d9210e826714f49b25384b79685227be5418f779b98a6be4c7386888ac',
-                value: 9997820, // 0.1 PIV - fee
+                value: 9997810, // 0.1 PIV - fee
             })
         );
         await checkFees(wallet, tx, MIN_FEE_PER_BYTE);

--- a/tests/unit/wallet/transactions.spec.js
+++ b/tests/unit/wallet/transactions.spec.js
@@ -200,7 +200,7 @@ describe('Wallet transaction tests', () => {
         expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: '76a97b63d114291a25b5b4d1802e0611e9bf724a1e57d9210e826714f49b25384b79685227be5418f779b98a6be4c7386888ac',
-                value: 9992400, // 0.1 PIV - fee
+                value: 9997820, // 0.1 PIV - fee
             })
         );
     });

--- a/tests/unit/wallet/transactions.spec.js
+++ b/tests/unit/wallet/transactions.spec.js
@@ -44,13 +44,13 @@ describe('Wallet transaction tests', () => {
                 scriptSig: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac', // Script sig must be the UTXO script since it's not signed
             })
         );
-        expect(tx.vout[0]).toStrictEqual(
+        expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4992400,
+                value: 4997740,
             })
         );
-        expect(tx.vout[1]).toStrictEqual(
+        expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: '76a914a95cc6408a676232d61ec29dc56a180b5847835788ac',
                 value: 5000000,
@@ -73,13 +73,13 @@ describe('Wallet transaction tests', () => {
                 scriptSig: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac', // Script sig must be the UTXO script since it's not signed
             })
         );
-        expect(tx.vout[0]).toStrictEqual(
+        expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4992400,
+                value: 4997740,
             })
         );
-        expect(tx.vout[1]).toStrictEqual(
+        expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: '76a914a95cc6408a676232d61ec29dc56a180b5847835788ac',
                 value: 5000000,
@@ -105,13 +105,13 @@ describe('Wallet transaction tests', () => {
                 scriptSig: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac', // Script sig must be the UTXO script since it's not signed
             })
         );
-        expect(tx.vout[0]).toStrictEqual(
+        expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a91421ff8214d09d60713b89809bb413a0651ee6931488ac',
-                value: 4992400,
+                value: 4997730,
             })
         );
-        expect(tx.vout[1]).toStrictEqual(
+        expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: 'e076a9141c62aa5fb5bc8a4932491fcfc1832fb5422e0cd288ac',
                 value: 5000000,
@@ -135,13 +135,13 @@ describe('Wallet transaction tests', () => {
                 scriptSig: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac', // Script sig must be the UTXO script since it's not signed
             })
         );
-        expect(tx.vout[0]).toStrictEqual(
+        expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4992400,
+                value: 4997650,
             })
         );
-        expect(tx.vout[1]).toStrictEqual(
+        expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: '6a20bcea39f87b1dd7a5ba9d11d3d956adc6ce57dfff9397860cc30c11f08b3aa7c8',
                 value: 5000000,
@@ -165,13 +165,13 @@ describe('Wallet transaction tests', () => {
                 scriptSig: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac', // Script sig must be the UTXO script since it's not signed
             })
         );
-        expect(tx.vout[0]).toStrictEqual(
+        expect(tx.vout[1]).toStrictEqual(
             new CTxOut({
                 script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                value: 4992400,
+                value: 4997480,
             })
         );
-        expect(tx.vout[1]).toStrictEqual(
+        expect(tx.vout[0]).toStrictEqual(
             new CTxOut({
                 script: '76a97b63d114291a25b5b4d1802e0611e9bf724a1e57d9210e826714f49b25384b79685227be5418f779b98a6be4c7386888ac',
                 value: 5000000,

--- a/tests/unit/wallet/transactions.spec.js
+++ b/tests/unit/wallet/transactions.spec.js
@@ -221,12 +221,6 @@ describe('Wallet transaction tests', () => {
                             '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
                     }),
                 ],
-                vout: [
-                    new CTxOut({
-                        script: '76a914f49b25384b79685227be5418f779b98a6be4c73888ac',
-                        value: 4992400,
-                    }),
-                ],
                 shieldOutput: [
                     {
                         address: addr,

--- a/tests/unit/wallet/transactions.spec.js
+++ b/tests/unit/wallet/transactions.spec.js
@@ -254,11 +254,11 @@ describe('Wallet transaction tests', () => {
         );
     });
 
-    it('it does not insert dust change', async() => {
+    it('it does not insert dust change', async () => {
         // The tipical output has 34 bytes, so a 200 satoshi change is surely going to be dust
         // a P2PKH with 1 input and 1 output will have more or less 190 bytes in size and 1900 satoshi of fees
         // Finally 0.1*10**8 is the value of the UTXO we are spending (0.1 PIVs)
-        const value = 0.1*10 **8 - 1900 - 200;
+        const value = 0.1 * 10 ** 8 - 1900 - 200;
         const tx = wallet.createTransaction(
             'DLabsktzGMnsK5K9uRTMCF6NoYNY6ET4Bb',
             value,
@@ -283,7 +283,7 @@ describe('Wallet transaction tests', () => {
             })
         );
         await checkFees(wallet, tx, MIN_FEE_PER_BYTE);
-    })
+    });
 
     it('creates a s->t tx correctly', async () => {
         const tx = wallet.createTransaction(


### PR DESCRIPTION
## Abstract

tx creation flow was broken, there was many different bugs and inaccuracies:

-  Fees were too high, 50 satoshi per bytes 
-  Fees were calculated quite randomly, without considering the real size of the transaction
-  Change was being added for shield txs (even if the shield lib handles it internally)

With this PR the wallet will create txs with 10 satoshi per byte of fee, which is the minimum standard PIVX core wallet value.
Moreover the concept of dust has been added: a dust is an UTXO that costs more than the value it contains. With this PR the wallet will avoid inserting dust change.
The parameter `subtractFeeFromAmt` has been added to `createTransaction`: if set to true the wallet will try to subtract the fee from the primary output value (which, so far, is the deafut behaviour of the wallet)

To make fee calculation as easy as possible now the wallet insert the change as last (and this + lower fees broke some tests that I had to change, so in tests you will see some vout[1] swapped with vout[0] and some fees lowered)

## How to test:
Make some transactions and verify that the wallet is super greedy
I tested with this P2PKH tx which has  225 bytes of size and fee 2260 satoshi (10 satoshi above the optimal)
https://explorer.duddino.com/tx/93905905304e649acfe3df102d02f33bb6354e958e59dbd0175a3a1f7a3444c6
And this P2CS delegation which has 400 bytes of size and fee 4000 satoshi
https://testnet.duddino.com/tx/c64aae051ab1c80b522198fc70437af7c32c945df3cd0a83a271326c795c6341
 


