### PR TITLE
Update txid in fromHex

### DIFF
--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -94,6 +94,7 @@ export class Transaction {
         shieldSpend = [],
         shieldOutput = [],
         bindingSig = '',
+        txid,
     } = {}) {
         this.version = version;
         this.blockHeight = blockHeight;
@@ -105,11 +106,15 @@ export class Transaction {
         this.shieldOutput = shieldOutput;
         this.bindingSig = bindingSig;
         this.valueBalance = valueBalance;
+        this.#txid = txid;
         /** Handle to the unproxied tx for when we need to clone it */
         this.__original = this;
         return new Proxy(this, {
-            set(obj) {
-                obj.#txid = '';
+            set(obj, p) {
+                if (p !== 'blockHeight' && p !== 'blockTime') {
+                    if (obj.#txid) throw new Error('what the fuck?');
+                    obj.#txid = '';
+                }
                 return Reflect.set(...arguments);
             },
         });
@@ -296,7 +301,7 @@ export class Transaction {
                 );
             }
         }
-
+        this.__original.#txid = bytesToHex(dSHA256(hexToBytes(hex)).reverse());
         return this;
     }
 

--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -112,7 +112,6 @@ export class Transaction {
         return new Proxy(this, {
             set(obj, p) {
                 if (p !== 'blockHeight' && p !== 'blockTime') {
-                    if (obj.#txid) throw new Error('what the fuck?');
                     obj.#txid = '';
                 }
                 return Reflect.set(...arguments);

--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -94,7 +94,6 @@ export class Transaction {
         shieldSpend = [],
         shieldOutput = [],
         bindingSig = '',
-        txid,
     } = {}) {
         this.version = version;
         this.blockHeight = blockHeight;
@@ -106,7 +105,6 @@ export class Transaction {
         this.shieldOutput = shieldOutput;
         this.bindingSig = bindingSig;
         this.valueBalance = valueBalance;
-        this.#txid = txid;
         /** Handle to the unproxied tx for when we need to clone it */
         this.__original = this;
         return new Proxy(this, {


### PR DESCRIPTION
## Abstract

MPW was spending a lot of time serializing the transaction when calculating the txid.
To prevent this, we can calculate the txid during the serialization, when we have the hex.

This is the benchmark before the PR, on a very big testnet wallet:
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/47313600/df857c90-8d4e-4372-87c9-62e2c0e78c79)

This is after:
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/47313600/eb846f06-8165-4972-8ea4-59235dac28b4)


## Testing
Test that the general functionality works

