### PR TITLE
Fix progress bar

### DIFF
--- a/scripts/Loadingbar.vue
+++ b/scripts/Loadingbar.vue
@@ -10,10 +10,10 @@ const props = defineProps({
         <div
             class="progress-bar progress-bar-striped progress-bar-animated"
             role="progressbar"
-            aria-valuenow="percentage"
+            :aria-valuenow="percentage"
             aria-valuemin="0"
             aria-valuemax="100"
-            :style="{ width: percentage + '%' }"
+            :style="{ width: percentage + '% !important' }"
         ></div>
     </div>
 </template>


### PR DESCRIPTION
## Abstract

A simple UI fix for the Progress Bar (used during Shield Tx creation) which was not animating due to CSS overrides, also fixed the `aria-valuenow` property, which was accidentally a string rather than a variable injection.

The progress bar now animates from 0 to 100 as it should, no longer stuck at 50%:
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/a18db9f4-1024-476d-b3e2-cccc7454adb5)
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/38caf904-43af-4321-947a-3d012c0ebbce)
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/e4e95c37-c531-455b-aff2-dc1bd3ea514b)


---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Run a (De)Shield transaction and check the progress bar animates.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---