### PR TITLE
Handle shield tx creation errors

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -440,9 +440,14 @@ async function send(address, amount, useShieldInputs) {
     transferAmount.value = '';
 
     // Create and send the TX
-    await wallet.createAndSendTransaction(getNetwork(), address, nValue, {
-        useShieldInputs,
-    });
+    try {
+        await wallet.createAndSendTransaction(getNetwork(), address, nValue, {
+            useShieldInputs,
+        });
+    } catch (e) {
+        console.error(e);
+        createAlert('warning', e);
+    }
 }
 
 /**

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -16,7 +16,7 @@ import { Database } from './database.js';
 import { RECEIVE_TYPES } from './contacts-book.js';
 import { Account } from './accounts.js';
 import { fAdvancedMode } from './settings.js';
-import { bytesToHex, hexToBytes, startBatch } from './utils.js';
+import { bytesToHex, hexToBytes, sleep, startBatch } from './utils.js';
 import { strHardwareName } from './ledger.js';
 import { COutpoint, UTXO_WALLET_STATE } from './mempool.js';
 import { getEventEmitter } from './event_bus.js';
@@ -1031,20 +1031,31 @@ export class Wallet {
 
         const value =
             transaction.shieldOutput[0]?.value || transaction.vout[0].value;
-        const { hex } = await this.#shield.createTransaction({
-            address:
-                transaction.shieldOutput[0]?.address ||
-                this.getAddressesFromScript(transaction.vout[0].script)
-                    .addresses[0],
-            amount: value,
-            blockHeight: getNetwork().cachedBlockCount,
-            useShieldInputs: transaction.vin.length === 0,
-            utxos: this.#getUTXOsForShield(),
-            transparentChangeAddress: this.getNewAddress(1)[0],
-        });
-        clearInterval(periodicFunction);
-        getEventEmitter().emit('shield-transaction-creation-update', 0.0, true);
-        return transaction.fromHex(hex);
+        try {
+            const { hex } = await this.#shield.createTransaction({
+                address:
+                    transaction.shieldOutput[0]?.address ||
+                    this.getAddressesFromScript(transaction.vout[0].script)
+                        .addresses[0],
+                amount: value,
+                blockHeight: getNetwork().cachedBlockCount,
+                useShieldInputs: transaction.vin.length === 0,
+                utxos: this.#getUTXOsForShield(),
+                transparentChangeAddress: this.getNewAddress(1)[0],
+            });
+            return transaction.fromHex(hex);
+        } catch (e) {
+            // sleep a full period of periodicFunction
+            await sleep(500);
+            throw new Error(e);
+        } finally {
+            clearInterval(periodicFunction);
+            getEventEmitter().emit(
+                'shield-transaction-creation-update',
+                0.0,
+                true
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Abstract

When shield tx creation fails the system gets stuck, progress bar is not removed and users cannot create any more txs. 

Handle those failures better and show an alert to the user
(NB: those errors are likely "good" errors like "not enough balance")

---

## Testing
Create a bunch of faulty shield tx and test that the system doesnt get stuck

