### PR TITLE
Add commit hash to dev builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "postinstall": "test -f chain_params.json || cp chain_params.prod.json chain_params.json",
         "build": "webpack --config webpack.prod.js",
+        "buildDev": "webpack --config webpack.dev.js",
         "watch": "webpack --watch",
         "dev": "webpack serve --config webpack.dev.js",
         "predeploy": "npm run build",

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -13,16 +13,15 @@ export function checkForUpgrades() {
     // Check if the last used version doesn't match the current version.
     // Note: it's intended to skip if `lastVersion` is null, as this stops the popups for NEW users.
     const lastVersion = localStorage.getItem('version');
-    if (lastVersion && lastVersion !== VERSION) {
+    if (lastVersion && lastVersion !== VERSION.split('-')[0]) {
         // Old user's first time on this update; display the changelog
         renderChangelog();
     }
-
     // Update the footer with our version
-    doms.domVersion.innerText = 'v' + VERSION;
+    doms.domVersion.innerText = `v${VERSION}`;
 
     // Update the last-used app version
-    localStorage.setItem('version', VERSION);
+    localStorage.setItem('version', VERSION.split('-')[0]);
 }
 
 /**

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -19,9 +19,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Inject the Changelog and Version to the app
 const changelog = readFileSync('./changelog.md', { encoding: 'utf8' });
-const version = JSON.parse(
-    readFileSync('./package.json', { encoding: 'utf8' })
-).version;
 
 export default {
     entry: './scripts/index.js',
@@ -109,7 +106,6 @@ export default {
         // Make the Changelog available globally
         new webpack.DefinePlugin({
             CHANGELOG: JSON.stringify(changelog),
-            VERSION: JSON.stringify(version),
         }),
         // Ignore non english bip39 wordlists
         new webpack.IgnorePlugin({

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,8 +8,14 @@ import common from './webpack.common.js';
 import webpack from 'webpack';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+const version = JSON.parse(
+    readFileSync('./package.json', { encoding: 'utf8' })
+).version;
 
 export default merge(common, {
     mode: 'development',
@@ -33,6 +39,7 @@ export default merge(common, {
         new webpack.DefinePlugin({
             __VUE_OPTIONS_API__: false,
             __VUE_PROD_DEVTOOLS__: true,
+            VERSION: JSON.stringify(`${version}-${commitHash}`),
         }),
     ],
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -6,6 +6,11 @@ import { merge } from 'webpack-merge';
 import common from './webpack.common.js';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import webpack from 'webpack';
+import { readFileSync } from 'fs';
+
+const version = JSON.parse(
+    readFileSync('./package.json', { encoding: 'utf8' })
+).version;
 
 export default merge(common, {
     mode: 'production',
@@ -17,6 +22,7 @@ export default merge(common, {
         new webpack.DefinePlugin({
             __VUE_OPTIONS_API__: false,
             __VUE_PROD_DEVTOOLS__: false,
+            VERSION: JSON.stringify(version),
         }),
     ],
 });


### PR DESCRIPTION
## Abstract

Add commit hash to dev builds. This allows us to quickly see which version of a wallet is affected by the bug.
This also adds a `buildDev` command, that builds MPW with the dev config, and is now used in the netlify build 
## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Open a dev build and watch the commit hash appended to the version
- Open a production build and assert that there is no commit hash