### PR TITLE
Network refactor

### DIFF
--- a/scripts/__mocks__/network.js
+++ b/scripts/__mocks__/network.js
@@ -2,8 +2,8 @@ import { vi } from 'vitest';
 
 export const getNetwork = vi.fn(() => {
     return {
-        cachedBlockCount: 1504903,
-        reset: vi.fn(),
-        setWallet: vi.fn(),
+        getBlockCount: vi.fn(() => {
+            return 1504903;
+        }),
     };
 });

--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -17,6 +17,7 @@ export function useWallet() {
 
     const isImported = ref(wallet.isLoaded());
     const isViewOnly = ref(wallet.isViewOnly());
+    const isSynced = ref(wallet.isSynced);
     const getKeyToBackup = async () => await wallet.getKeyToBackup();
     const isEncrypted = ref(true);
     const loadFromDisk = () => wallet.loadFromDisk();
@@ -32,6 +33,7 @@ export function useWallet() {
         isHD.value = wallet.isHD();
         isViewOnly.value = wallet.isViewOnly();
         isEncrypted.value = await hasEncryptedWallet();
+        isSynced.value = await wallet.isSynced;
     };
     const setExtsk = async (extsk) => {
         await wallet.setExtsk(extsk);
@@ -65,6 +67,7 @@ export function useWallet() {
         balance.value = wallet.balance;
         shieldBalance.value = await wallet.getShieldBalance();
         pendingShieldBalance.value = await wallet.getPendingShieldBalance();
+        isSynced.value = wallet.isSynced;
     };
     getEventEmitter().on('shield-loaded-from-disk', () => {
         hasShield.value = wallet.hasShield();
@@ -101,6 +104,7 @@ export function useWallet() {
         isImported,
         isViewOnly,
         isEncrypted,
+        isSynced,
         getKeyToBackup,
         setMasterKey,
         setExtsk,

--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -33,7 +33,7 @@ export function useWallet() {
         isHD.value = wallet.isHD();
         isViewOnly.value = wallet.isViewOnly();
         isEncrypted.value = await hasEncryptedWallet();
-        isSynced.value = await wallet.isSynced;
+        isSynced.value = wallet.isSynced;
     };
     const setExtsk = async (extsk) => {
         await wallet.setExtsk(extsk);

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -62,7 +62,7 @@ const txMap = computed(() => {
 async function update(txToAdd = 0) {
     const cNet = getNetwork();
     // Return if wallet is not synced yet
-    if (!cNet || !cNet.fullSynced) {
+    if (!wallet.isSynced) {
         return;
     }
 

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -109,6 +109,7 @@ watch(translation, async () => await update());
 async function parseTXs(arrTXs) {
     const newTxs = [];
     const cNet = getNetwork();
+    const blockCount = await cNet.getBlockCount();
 
     // Prepare time formatting
     const dateOptions = {
@@ -155,7 +156,7 @@ async function parseTXs(arrTXs) {
 
         // Coinbase Transactions (rewards) require coinbaseMaturity confs
         const fConfirmed =
-            cNet.cachedBlockCount - cTx.blockHeight >=
+            blockCount - cTx.blockHeight >=
             (props.rewards ? cChainParams.current.coinbaseMaturity : 6);
 
         // Choose the content type, for the Dashboard; use a generative description, otherwise, a TX-ID

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -368,7 +368,7 @@ async function send(address, amount, useShieldInputs) {
     }
 
     // Ensure wallet is synced
-    if (!getNetwork()?.fullSynced) {
+    if (!wallet.isSynced.value) {
         return createAlert('warning', `${ALERTS.WALLET_NOT_SYNCED}`, 3000);
     }
 

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -958,7 +958,7 @@ export async function sweepAddress(arrUTXOs, sweepingMasterKey, nFixedFee) {
         .build();
 
     // Sign using the given Master Key, then broadcast the sweep, returning the TXID (or a failure)
-    const sweepingWallet = new Wallet({ nAccount: 0, isMainWallet: false });
+    const sweepingWallet = new Wallet({ nAccount: 0 });
     sweepingWallet.setMasterKey(sweepingMasterKey);
 
     await sweepingWallet.sign(tx);

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -1663,8 +1663,7 @@ export async function updateMasternodeTab() {
         return;
     }
 
-    const cNet = getNetwork();
-    if (!cNet || !cNet.fullSynced) {
+    if (!wallet.isSynced) {
         doms.domMnTextErrors.innerHTML =
             'Your wallet is empty or still loading, re-open the tab in a few seconds!';
         return;

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -42,6 +42,9 @@ export function isLoaded() {
     return fIsLoaded;
 }
 
+// Block count
+let blockCount = 0;
+
 export let doms = {};
 
 export const dashboard = createApp(Dashboard).mount('#DashboardTab');
@@ -324,14 +327,6 @@ export async function start() {
     // Register native app service
     registerWorker();
     await settingsStart();
-    // Just load the block count, for use in non-wallet areas
-    try {
-        await getNetwork().getBlockCount();
-    } catch (e) {
-        // Block count failed, keep loading the wallet
-        // the network already creates an alert
-        console.error(e);
-    }
 
     subscribeToNetworkEvents();
 
@@ -377,10 +372,11 @@ function subscribeToNetworkEvents() {
         }
     });
 
-    getEventEmitter().on('new-block', (block, oldBlock) => {
-        console.log(`New block detected! ${oldBlock} --> ${block}`);
+    getEventEmitter().on('new-block', (block) => {
+        console.log(`New block detected! ${block}`);
         // Fetch latest Activity
         stakingDashboard.update();
+        blockCount = block;
 
         // If it's open: update the Governance Dashboard
         if (doms.domGovTab.classList.contains('active')) {
@@ -1059,25 +1055,18 @@ export async function updateGovernanceTab() {
     fRenderingGovernance = true;
 
     // Setup the Superblock countdown (if not already done), no need to block thread with await, either.
-    let cNet = getNetwork();
-
-    // When switching to mainnet from testnet or vise versa, you ned to use an await on getBlockCount() or cNet.cachedBlockCount returns 0
     if (!isTestnetLastState == cChainParams.current.isTestnet) {
         // Reset flipdown
         governanceFlipdown = null;
         doms.domFlipdown.innerHTML = '';
-
-        // Get new network blockcount
-        await getNetwork().getBlockCount();
-        cNet = getNetwork();
     }
 
     // Update governance counter when testnet/mainnet has been switched
-    if (!governanceFlipdown && cNet.cachedBlockCount > 0) {
+    if (!governanceFlipdown && blockCount > 0) {
         Masternode.getNextSuperblock().then((nSuperblock) => {
             // The estimated time to the superblock (using the block target and remaining blocks)
             const nTimestamp =
-                Date.now() / 1000 + (nSuperblock - cNet.cachedBlockCount) * 60;
+                Date.now() / 1000 + (nSuperblock - blockCount) * 60;
             governanceFlipdown = new FlipDown(nTimestamp).start();
         });
         isTestnetLastState = cChainParams.current.isTestnet;
@@ -1165,14 +1154,13 @@ async function waitForSubmissionBlockHeight(cProposalCache) {
  * @returns {string} The string status, for display purposes
  */
 function getProposalFinalisationStatus(cPropCache) {
-    const cNet = getNetwork();
     // Confirmations left until finalisation, by network consensus
     const nConfsLeft =
         cPropCache.nSubmissionHeight +
         cChainParams.current.proposalFeeConfirmRequirement -
-        cNet.cachedBlockCount;
+        blockCount;
 
-    if (cPropCache.nSubmissionHeight === 0 || cNet.cachedBlockCount === 0) {
+    if (cPropCache.nSubmissionHeight === 0 || blockCount === 0) {
         return translation.proposalFinalisationConfirming;
     } else if (nConfsLeft > 0) {
         return (
@@ -1986,7 +1974,8 @@ export async function refreshChainData() {
     if (!wallet.isLoaded()) return;
 
     // Fetch block count
-    await cNet.getBlockCount();
+    const blockCount = await cNet.getBlockCount();
+    getEventEmitter().emit('new-block', blockCount);
 }
 
 // A safety mechanism enabled if the user attempts to leave without encrypting/saving their keys

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -358,15 +358,6 @@ export class ExplorerNetwork extends Network {
         return blocks;
     }
 
-    /**
-     * Waits for next block
-     * @returns {Promise<Number>} Resolves when the next block is obtained
-     */
-    waitForNextBlock() {
-        return new Promise((res, _rej) => {
-            getEventEmitter().once('new-block', (block) => res(block));
-        });
-    }
     // PIVX Labs Analytics: if you are a user, you can disable this FULLY via the Settings.
     // ... if you're a developer, we ask you to keep these stats to enhance upstream development,
     // ... but you are free to completely strip MPW of any analytics, if you wish, no hard feelings.

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -181,7 +181,7 @@ export class ExplorerNetwork extends Network {
         const maxTrials = 6;
         while (trials < maxTrials) {
             trials += 1;
-            const res = await fetchBlockbook(strCommand);
+            const res = await retryWrapper(fetchBlockbook, strCommand);
             if (!res.ok) {
                 if (debug) {
                     console.log(

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -204,8 +204,11 @@ export class ExplorerNetwork extends Network {
      * @param {import('./wallet.js').Wallet} wallet - Wallet that we are getting the txs of
      * @returns {Promise<void>}
      */
-    async getLatestTxs(nStartHeight, wallet) {
+    async getLatestTxs(wallet) {
         const isFirstSync = wallet.isSynced;
+        let nStartHeight = Math.max(
+            ...wallet.getTransactions().map((tx) => tx.blockHeight)
+        );
         // Ask some blocks in the past or blockbock might not return a transaction that has just been mined
         const blockOffset = 10;
         nStartHeight =

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -205,7 +205,7 @@ export class ExplorerNetwork extends Network {
      * @returns {Promise<void>}
      */
     async getLatestTxs(wallet) {
-        const isFirstSync = wallet.isSynced;
+        const isFirstSync = !wallet.isSynced;
         let nStartHeight = Math.max(
             ...wallet.getTransactions().map((tx) => tx.blockHeight)
         );

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -48,16 +48,11 @@ import { Transaction } from './transaction.js';
  *
  */
 export class Network {
-    wallet;
-    /**
-     * @param {import('./wallet.js').Wallet} wallet
-     */
-    constructor(wallet) {
+    constructor() {
         if (this.constructor === Network) {
             throw new Error('Initializing virtual class');
         }
         this._enabled = true;
-        this.wallet = wallet;
     }
 
     /**
@@ -100,10 +95,6 @@ export class Network {
 
     submitAnalytics(_strType, _cData = {}) {
         throw new Error('submitAnalytics must be implemented');
-    }
-
-    setWallet(wallet) {
-        this.wallet = wallet;
     }
 
     async getTxInfo(_txHash) {

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -89,7 +89,7 @@ export class Network {
         throw new Error('getBlockCount must be implemented');
     }
 
-    sentTransaction() {
+    sendTransaction() {
         throw new Error('sendTransaction must be implemented');
     }
 

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -126,14 +126,7 @@ export class ExplorerNetwork extends Network {
          */
         this.strUrl = strUrl;
 
-        /**
-         * @type{Number}
-         * @private
-         */
-        this.blocks = 0;
-
         this.fullSynced = false;
-        this.lastBlockSynced = 0;
     }
 
     error() {
@@ -293,8 +286,6 @@ export class ExplorerNetwork extends Network {
 
     reset() {
         this.fullSynced = false;
-        this.blocks = 0;
-        this.lastBlockSynced = 0;
     }
 
     /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -524,11 +524,7 @@ export async function logOut() {
  * Toggle between Mainnet and Testnet
  */
 export async function toggleTestnet() {
-    const cNet = getNetwork();
-    if (
-        (!cNet.fullSynced && wallet.isLoaded()) ||
-        (!wallet.isSynced && wallet.hasShield())
-    ) {
+    if (wallet.isLoaded() && !wallet.isSynced) {
         createAlert('warning', `${ALERTS.WALLET_NOT_SYNCED}`, 3000);
         doms.domTestnetToggler.checked = cChainParams.current.isTestnet;
         return;

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -797,16 +797,10 @@ export class Wallet {
             //TODO: unify the transparent sync with the shield sync
             // in particular in place of getLatestTxs read directly from the block as we do for shielding
             if (this.#isSynced) {
-                if (this.#lastProcessedBlock > block) {
-                    throw new Error(
-                        'Received an older block than the last processed one!'
-                    );
-                }
                 await getNetwork().getLatestTxs(this.#lastProcessedBlock, this);
                 stakingDashboard.update(0);
                 getEventEmitter().emit('new-tx');
                 await this.getLatestBlocks(block);
-                this.#lastProcessedBlock = block;
             }
         });
     }
@@ -1084,6 +1078,7 @@ export class Wallet {
      * @param {import('./transaction.js').Transaction} transaction
      */
     async addTransaction(transaction, skipDatabase = false) {
+        // TODO: this part will be changed once shield sync is merged with transparent sync
         if (transaction.isConfirmed()) {
             if (transaction.blockHeight < this.#lastProcessedBlock) {
                 throw new Error(

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -83,11 +83,6 @@ export class Wallet {
      * @type {Map<String,String>}
      */
     #knownPKH = new Map();
-    /**
-     * True if this is the global wallet, false otherwise
-     * @type {Boolean}
-     */
-    #isMainWallet;
 
     /**
      * @type {Mempool}
@@ -101,15 +96,8 @@ export class Wallet {
      */
     #lastProcessedBlock = 0;
 
-    constructor({
-        nAccount,
-        isMainWallet,
-        masterKey,
-        shield,
-        mempool = new Mempool(),
-    }) {
+    constructor({ nAccount, masterKey, shield, mempool = new Mempool() }) {
         this.#nAccount = nAccount;
-        this.#isMainWallet = isMainWallet;
         this.#mempool = mempool;
         this.#masterKey = masterKey;
         this.#shield = shield;
@@ -1188,7 +1176,7 @@ export class Wallet {
 /**
  * @type{Wallet}
  */
-export const wallet = new Wallet({ nAccountL: 0, isMainWallet: true }); // For now we are using only the 0-th account, (TODO: update once account system is done)
+export const wallet = new Wallet({ nAccountL: 0 }); // For now we are using only the 0-th account, (TODO: update once account system is done)
 
 /**
  * Clean a Seed Phrase string and verify it's integrity

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -275,10 +275,6 @@ export class Wallet {
             this.#addressIndices.set(i, 0);
         }
         this.#mempool = new Mempool();
-        // TODO: This needs to be refactored to remove the getNetwork dependency
-        if (this.#isMainWallet) {
-            getNetwork().reset();
-        }
         this.#lastProcessedBlock = 0;
     }
 

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -234,10 +234,6 @@ export class Wallet {
         this.#nAccount = nAccount;
         if (isNewAcc) {
             this.reset();
-            // If this is the global wallet update the network master key
-            if (this.#isMainWallet) {
-                getNetwork().setWallet(this);
-            }
             for (let i = 0; i < Wallet.chains; i++) this.loadAddresses(i);
         }
     }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -696,6 +696,9 @@ export class Wallet {
         } finally {
             this.#syncing = false;
         }
+        // Update both activities post sync
+        stakingDashboard.update(0);
+        getEventEmitter().emit('new-tx');
     }
 
     async #transparentSync() {

--- a/tests/unit/wallet/signature.spec.js
+++ b/tests/unit/wallet/signature.spec.js
@@ -26,14 +26,14 @@ describe('Wallet signature tests', () => {
     });
 
     it('throws when is view only', async () => {
-        const wallet = new Wallet(0, false);
+        const wallet = new Wallet(0);
         const mk = getLegacyMainnet();
         mk.wipePrivateData();
         wallet.setMasterKey(mk);
         expect(wallet.sign({})).rejects.toThrow(/view only/i);
     });
     it('signs a transaction correctly', async () => {
-        const wallet = new Wallet(0, false);
+        const wallet = new Wallet(0);
         const mk = getLegacyMainnet();
         wallet.setMasterKey(mk);
         const tx = new Transaction();
@@ -68,7 +68,7 @@ describe('Wallet signature tests', () => {
     });
 
     it('signs a s->s transaction correctly', async () => {
-        const wallet = new Wallet(0, false);
+        const wallet = new Wallet(0);
         wallet.setMasterKey(getLegacyMainnet());
         wallet.setShield(new PIVXShield());
         const tx = new Transaction({
@@ -88,7 +88,7 @@ describe('Wallet signature tests', () => {
         expect(PIVXShield.prototype.createTransaction).toHaveBeenCalledWith({
             address: 'ptest1234567',
             amount: 100000,
-            blockHeight: 1504903,
+            blockHeight: 1,
             transparentChangeAddress: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             useShieldInputs: true, // Because vin is empty
             utxos: [
@@ -105,7 +105,7 @@ describe('Wallet signature tests', () => {
         });
     });
     it('signs a s->t tx correctly', async () => {
-        const wallet = new Wallet(0, false);
+        const wallet = new Wallet(0);
         wallet.setMasterKey(getLegacyMainnet());
         wallet.setShield(new PIVXShield());
         const tx = new Transaction({
@@ -125,7 +125,7 @@ describe('Wallet signature tests', () => {
         expect(PIVXShield.prototype.createTransaction).toHaveBeenCalledWith({
             address: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             amount: 4992400,
-            blockHeight: 1504903,
+            blockHeight: 1,
             transparentChangeAddress: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             useShieldInputs: true, // Because vin is empty
             utxos: [
@@ -142,7 +142,7 @@ describe('Wallet signature tests', () => {
         });
     });
     it('signs a t->s tx correctly', async () => {
-        const wallet = new Wallet(0, false);
+        const wallet = new Wallet(0);
         wallet.setMasterKey(getLegacyMainnet());
         wallet.setShield(new PIVXShield());
         const tx = new Transaction({
@@ -170,7 +170,7 @@ describe('Wallet signature tests', () => {
         expect(PIVXShield.prototype.createTransaction).toHaveBeenCalledWith({
             address: 'ptest1234567',
             amount: 100000,
-            blockHeight: 1504903,
+            blockHeight: 1,
             transparentChangeAddress: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             useShieldInputs: false,
             utxos: [

--- a/tests/unit/wallet/signature.spec.js
+++ b/tests/unit/wallet/signature.spec.js
@@ -88,7 +88,7 @@ describe('Wallet signature tests', () => {
         expect(PIVXShield.prototype.createTransaction).toHaveBeenCalledWith({
             address: 'ptest1234567',
             amount: 100000,
-            blockHeight: 1,
+            blockHeight: 1504904,
             transparentChangeAddress: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             useShieldInputs: true, // Because vin is empty
             utxos: [
@@ -125,7 +125,7 @@ describe('Wallet signature tests', () => {
         expect(PIVXShield.prototype.createTransaction).toHaveBeenCalledWith({
             address: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             amount: 4992400,
-            blockHeight: 1,
+            blockHeight: 1504904,
             transparentChangeAddress: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             useShieldInputs: true, // Because vin is empty
             utxos: [
@@ -170,7 +170,7 @@ describe('Wallet signature tests', () => {
         expect(PIVXShield.prototype.createTransaction).toHaveBeenCalledWith({
             address: 'ptest1234567',
             amount: 100000,
-            blockHeight: 1,
+            blockHeight: 1504904,
             transparentChangeAddress: 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC',
             useShieldInputs: false,
             utxos: [


### PR DESCRIPTION
## Abstract

Hugely simplify the `Network` class and the relation between `Wallet` and `Network`. The main idea behind this refactor is that the `Network` should only perform tasks and return values, without having to know the "state" of the wallet and of the blockchain  (synced, number of blocks, etc...). 
See each commit for the precise diff

---

## Testing

Verify that everything is working as before

