### PR TITLE
Fix Payment Descriptions regression

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -1067,7 +1067,7 @@ defineExpose({
             :currency="currency"
             :shieldEnabled="wallet.hasShield.value"
             v-model:amount="transferAmount"
-            v-model:desc="transferDescription"
+            :desc="transferDescription"
             v-model:address="transferAddress"
             @openQrScan="openSendQRScanner()"
             @close="showTransferMenu = false"

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -66,6 +66,7 @@ const showEncryptModal = ref(false);
 const keyToBackup = ref('');
 const jdenticonValue = ref('');
 const transferAddress = ref('');
+const transferDescription = ref('');
 const transferAmount = ref('');
 watch(showExportModal, async (showExportModal) => {
     if (showExportModal) {
@@ -470,6 +471,7 @@ async function send(address, amount, useShieldInputs) {
     // Close the send screen and clear inputs
     showTransferMenu.value = false;
     transferAddress.value = '';
+    transferDescription.value = '';
     transferAmount.value = '';
 
     // Create and send the TX
@@ -528,10 +530,9 @@ onMounted(async () => {
         if (urlParams.has('addcontact')) {
             await handleContactRequest(urlParams);
         } else if (urlParams.has('pay')) {
-            const reqAmount = parseFloat(urlParams.get('amount')) ?? 0;
-            const reqTo = urlParams.get('pay') ?? '';
-            transferAddress.value = reqTo;
-            transferAmount.value = reqAmount;
+            transferAddress.value = urlParams.get('pay') ?? '';
+            transferDescription.value = urlParams.get('desc') ?? '';
+            transferAmount.value = parseFloat(urlParams.get('amount')) ?? 0;
             showTransferMenu.value = true;
         }
     }
@@ -1066,6 +1067,7 @@ defineExpose({
             :currency="currency"
             :shieldEnabled="wallet.hasShield.value"
             v-model:amount="transferAmount"
+            v-model:desc="transferDescription"
             v-model:address="transferAddress"
             @openQrScan="openSendQRScanner()"
             @close="showTransferMenu = false"

--- a/scripts/dashboard/TransferMenu.vue
+++ b/scripts/dashboard/TransferMenu.vue
@@ -23,6 +23,7 @@ const props = defineProps({
     price: Number,
     currency: String,
     amount: String,
+    desc: String,
     address: String,
     shieldEnabled: Boolean,
 });
@@ -123,7 +124,7 @@ async function selectContact() {
                         </div>
                     </div>
 
-                    <div style="display: none">
+                    <div v-if="desc && desc.length > 0">
                         <label
                             ><span>{{
                                 translation.paymentRequestMessage
@@ -137,6 +138,7 @@ async function selectContact() {
                                 disabled
                                 placeholder="Payment Request Description"
                                 autocomplete="nope"
+                                :value="desc"
                             />
                         </div>
                     </div>


### PR DESCRIPTION
## Abstract

This PR fixes a small Vue transition regression where Payment Descriptions were not functionally ported, this restores the functionality so that Merchants can display additional messages (i.e: product descriptions, destination, etc) in the user's send dialog.

![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/c4bf797a-334c-49d5-acaf-e2999f9131aa)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- **Prerequisite**: Create/Import your wallet [here](https://deploy-preview-326--cheery-moxie-4f1121.netlify.app/), then **encrypt it**.
- Open [this Payment Request](https://deploy-preview-326--cheery-moxie-4f1121.netlify.app/?pay=D9AbTjZo6crnKmRjSqB4W6EnjLXZvoYVzu&amount=0.01&desc=PIVCards:%2020%20GBP%20Amazon%20UK) and ensure the test dialog displays.
- **Optional**: pay a Payment Request and ensure the UI removes the description from the Send dialog.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---