### PR TITLE
Round satoshis when creating promo code

### DIFF
--- a/scripts/promos.js
+++ b/scripts/promos.js
@@ -472,7 +472,7 @@ export async function updatePromoCreationTick(fRecursive = false) {
             if (!wallet.isViewOnly() || wallet.isHardwareWallet()) {
                 const res = await createAndSendTransaction({
                     address: strAddress,
-                    amount: cThread.amount * COIN + PROMO_FEE,
+                    amount: Math.round(cThread.amount * COIN + PROMO_FEE),
                 }).catch((_) => {
                     // Failed to create this code - mark it as errored
                     cThread.end_state = 'Errored';


### PR DESCRIPTION
## Abstract

Round satoshis when creating promo code. Because of floating point errors, MPW would try to send a decimal amount of satoshis and the promo code creation would fail.

## Testing
- Create a promo code with `1.1` PIV