### PR TITLE
Unify shield and transparent sync

### DIFF
--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -39,6 +39,47 @@ export class Mempool {
             this.setSpent(input.outpoint);
         }
     }
+    /**
+     * Return owned vin of a given transaction
+     * @param {import('./transaction.js').Transaction} tx
+     * @returns {UTXO[]} List of UTXO corresponding to the owned vin
+     */
+    getOwnedVin(tx) {
+        return tx.vin
+            .filter(
+                (input) =>
+                    this.getOutpointStatus(input.outpoint) & OutpointState.OURS
+            )
+            .map((i) => this.outpointToUTXO(i.outpoint));
+    }
+    /**
+     * Return owned vout of a given transaction
+     * @param {import('./transaction.js').Transaction} tx
+     * @returns {CTxOut[]} List of UTXO corresponding to the owned vin
+     */
+    getOwnedVout(tx) {
+        const txid = tx.txid;
+        return tx.vout.filter(
+            (_, i) =>
+                this.getOutpointStatus(
+                    new COutpoint({
+                        txid,
+                        n: i,
+                    })
+                ) & OutpointState.OURS
+        );
+    }
+    /**
+     * Check if we own any transparent input our output of a given transaction
+     * @param {import('./transaction.js').Transaction} tx
+     * @returns {boolean} whether we own at least a input or an output of the tx
+     */
+    ownTransaction(tx) {
+        return (
+            this.getOwnedVout(tx).length !== 0 ||
+            this.getOwnedVin(tx).length !== 0
+        );
+    }
 
     /**
      * @param {COutpoint} outpoint
@@ -115,13 +156,10 @@ export class Mempool {
      * @param {import('./transaction.js').Transaction} tx
      */
     getDebit(tx) {
-        return tx.vin
-            .filter(
-                (input) =>
-                    this.getOutpointStatus(input.outpoint) & OutpointState.OURS
-            )
-            .map((i) => this.outpointToUTXO(i.outpoint))
-            .reduce((acc, u) => acc + (u?.value || 0), 0);
+        return this.getOwnedVin(tx).reduce(
+            (acc, u) => acc + (u?.value || 0),
+            0
+        );
     }
 
     /**
@@ -129,19 +167,7 @@ export class Mempool {
      * @param {import('./transaction.js').Transaction} tx
      */
     getCredit(tx) {
-        const txid = tx.txid;
-
-        return tx.vout
-            .filter(
-                (_, i) =>
-                    this.getOutpointStatus(
-                        new COutpoint({
-                            txid,
-                            n: i,
-                        })
-                    ) & OutpointState.OURS
-            )
-            .reduce((acc, u) => acc + u?.value ?? 0, 0);
+        return this.getOwnedVout(tx).reduce((acc, u) => acc + u?.value ?? 0, 0);
     }
 
     /**

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -200,7 +200,7 @@ export class ExplorerNetwork extends Network {
 
     /**
      * //TODO: do not take the wallet as parameter but instead something weaker like a public key or address?
-     * @param {number} nStartHeight - Minimum block height to get
+     * Must be called only for initial wallet sync
      * @param {import('./wallet.js').Wallet} wallet - Wallet that we are getting the txs of
      * @returns {Promise<void>}
      */

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -346,19 +346,7 @@ export class ExplorerNetwork extends Network {
      * @return {Promise<Number[]>} The list of blocks which have at least one shield transaction
      */
     async getShieldBlockList() {
-        /**
-         * @type {Number[]}
-         */
-        const blockCount = await this.getBlockCount(false);
-        const blocks = await (
-            await fetch(`${cNode.url}/getshieldblocks`)
-        ).json();
-        const maxBlock = blocks[blocks.length - 1];
-        //I think
-        if (maxBlock < blockCount - 5) {
-            blocks.push(blockCount - 5);
-        }
-        return blocks;
+        return await (await fetch(`${cNode.url}/getshieldblocks`)).json();
     }
 
     // PIVX Labs Analytics: if you are a user, you can disable this FULLY via the Settings.

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -209,12 +209,6 @@ export class ExplorerNetwork extends Network {
         let nStartHeight = Math.max(
             ...wallet.getTransactions().map((tx) => tx.blockHeight)
         );
-        // Ask some blocks in the past or blockbock might not return a transaction that has just been mined
-        const blockOffset = 10;
-        nStartHeight =
-            nStartHeight > blockOffset
-                ? nStartHeight - blockOffset
-                : nStartHeight;
         if (debug) {
             console.time('getLatestTxsTimer');
         }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -91,7 +91,11 @@ export class Wallet {
 
     #isSynced = false;
     #isFetchingLatestBlocks = false;
-
+    /**
+     * The height of the last processed block in the wallet
+     * @type {number}
+     */
+    #lastProcessedBlock = 0;
     constructor({ nAccount, masterKey, shield, mempool = new Mempool() }) {
         this.#nAccount = nAccount;
         this.#mempool = mempool;
@@ -693,6 +697,10 @@ export class Wallet {
             this.#syncing = true;
             await this.loadFromDisk();
             await this.loadShieldFromDisk();
+            // Let's set the last processed block 5 blocks behind the actual chain tip
+            // This is just to be sure since blockbook (as we know)
+            // usually does not return txs of the actual last block.
+            this.#lastProcessedBlock = (await getNetwork().getBlockCount()) - 5;
             await this.#transparentSync();
             if (this.hasShield()) {
                 await this.#syncShield();

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -5,7 +5,7 @@ import { beforeUnloadListener, stakingDashboard } from './global.js';
 import { getNetwork } from './network.js';
 import { MAX_ACCOUNT_GAP, SHIELD_BATCH_SYNC_SIZE } from './chain_params.js';
 import { HistoricalTx, HistoricalTxType } from './historical_tx.js';
-import { COutpoint } from './transaction.js';
+import { COutpoint, Transaction } from './transaction.js';
 import { confirmPopup, createAlert, isShieldAddress } from './misc.js';
 import { cChainParams } from './chain_params.js';
 import { COIN } from './chain_params.js';
@@ -810,10 +810,7 @@ export class Wallet {
 
     subscribeToNetworkEvents() {
         getEventEmitter().on('new-block', async (block) => {
-            //TODO: unify the transparent sync with the shield sync
-            // in particular in place of getLatestTxs read directly from the block as we do for shielding
             if (this.#isSynced) {
-                await getNetwork().getLatestTxs(this);
                 stakingDashboard.update(0);
                 getEventEmitter().emit('new-tx');
                 await this.getLatestBlocks(block);
@@ -828,25 +825,37 @@ export class Wallet {
         // Exit if this function is still processing
         // (this might take some time if we had many consecutive blocks without shield txs)
         if (this.#isFetchingLatestBlocks) return;
-        // Exit if there is no shield loaded
-        if (!this.hasShield()) return;
         this.#isFetchingLatestBlocks = true;
 
         const cNet = getNetwork();
         // Don't ask for the exact last block that arrived,
         // since it takes around 1 minute for blockbook to make it API available
         for (
-            let blockHeight = this.#shield.getLastSyncedBlock() + 1;
+            let blockHeight = this.#lastProcessedBlock + 1;
             blockHeight < blockCount;
             blockHeight++
         ) {
             try {
                 const block = await cNet.getBlock(blockHeight);
                 if (block.txs) {
-                    await this.#shield.handleBlock(block);
+                    if (this.hasShield()) {
+                        if (blockHeight > this.#shield.getLastSyncedBlock()) {
+                            await this.#shield.handleBlock(block);
+                        }
+                    }
+                    for (const tx of block.txs) {
+                        const parsed = Transaction.fromHex(tx.hex);
+                        parsed.blockHeight = blockHeight;
+                        parsed.blockTime = tx.blocktime;
+                        // Avoid wasting memory on txs that do not regard our wallet
+                        if (this.#mempool.ownTransaction(parsed)) {
+                            await wallet.addTransaction(parsed);
+                        }
+                    }
                 } else {
                     break;
                 }
+                this.#lastProcessedBlock = blockHeight;
             } catch (e) {
                 console.error(e);
                 break;


### PR DESCRIPTION
## Abstract

Main idea: After the initial sync any new block was handled in this way:
```
 if (this.#isSynced) {
                await getNetwork().getLatestTxs(this); // Sync transparent part only
                await this.getLatestBlocks(block); // Sync shield part only
}
```
This method is inefficient, since there are many useless network requests, and at the same time having the two steps separated makes the shield activity difficult to program.

With this PR the the call to getLatestBlock has been removed:
```
 if (this.#isSynced) {
                await this.getLatestBlocks(block); // Sync shield AND transparent together 
}
```

As consequence of this PR both `getShieldBlockList()` and `getLatestTxs` has been simplified.

For reviewer: review the PR commit by commit is much easier than looking at the global diff

## Testing

Test that wallet is still syncing as before


