### PR TITLE
Deglobalize wallet.isHardwareWallet

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -86,11 +86,7 @@ export const useWallet = defineStore('wallet', () => {
     );
     const createAndSendTransaction = async (network, address, value, opts) => {
         const tx = wallet.createTransaction(address, value, opts);
-        if (wallet.isHardwareWallet()) {
-            await ledgerSignTransaction(wallet, tx);
-        } else {
-            await wallet.sign(tx);
-        }
+        await wallet.sign(tx);
         const res = await network.sendTransaction(tx.serialize());
         if (res) {
             await wallet.addTransaction(tx);

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -139,7 +139,6 @@ async function encryptWallet(password, currentPassword = '') {
 
 async function restoreWallet(strReason) {
     if (!wallet.isEncrypted) return false;
-    if (wallet.isHardwareWallet) return true;
     showRestoreWallet.value = true;
     return await new Promise((res) => {
         watch(
@@ -206,7 +205,7 @@ function lockWallet() {
  */
 async function send(address, amount, useShieldInputs) {
     // Ensure a wallet is unlocked
-    if (wallet.isViewOnly && !wallet.isHardwareWallet) {
+    if (wallet.isViewOnly) {
         if (
             !(await restoreWallet(
                 tr(ALERTS.WALLET_UNLOCK_IMPORT, [
@@ -516,7 +515,9 @@ defineExpose({
             <div
                 class="col-12"
                 v-if="
-                    !wallet.isViewOnly && !needsToEncrypt && wallet.isImported
+                    !wallet.isViewOnly &&
+                    wallet.isEncrypted &&
+                    wallet.isImported
                 "
             >
                 <center>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -30,7 +30,7 @@ export {
     switchSettings,
     govVote,
 } from './global.js';
-export { wallet, getNewAddress } from './wallet.js';
+export { wallet } from './wallet.js';
 export {
     logOut,
     toggleTestnet,

--- a/scripts/legacy.js
+++ b/scripts/legacy.js
@@ -37,10 +37,7 @@ export async function createAndSendTransaction({
         changeAddress,
         returnAddress: delegationOwnerAddress,
     });
-    if (!wallet.isHardwareWallet()) await wallet.sign(tx);
-    else {
-        await ledgerSignTransaction(wallet, tx);
-    }
+    await wallet.sign(tx);
     const res = await getNetwork().sendTransaction(tx.serialize());
     if (res) {
         await wallet.addTransaction(tx);
@@ -63,7 +60,7 @@ export async function createMasternode() {
 
     // Generate the Masternode collateral
     const [address] = await getNewAddress({
-        verify: wallet.isHardwareWallet(),
+        verify: true,
         nReceiving: 1,
     });
     const result = await createAndSendTransaction({

--- a/scripts/promos.js
+++ b/scripts/promos.js
@@ -469,7 +469,7 @@ export async function updatePromoCreationTick(fRecursive = false) {
             }
 
             // Send the fill transaction if unlocked
-            if (!wallet.isViewOnly() || wallet.isHardwareWallet()) {
+            if (!wallet.isViewOnly()) {
                 const res = await createAndSendTransaction({
                     address: strAddress,
                     amount: Math.round(cThread.amount * COIN + PROMO_FEE),

--- a/scripts/stake/Stake.vue
+++ b/scripts/stake/Stake.vue
@@ -89,7 +89,6 @@ async function unstake(value) {
 
 async function restoreWallet(strReason) {
     if (!wallet.isEncrypted) return false;
-    if (wallet.isHardwareWallet) return true;
     showRestoreWallet.value = true;
     return await new Promise((res) => {
         watch(

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -186,30 +186,6 @@ export class Wallet {
         return this.#masterKey.isHD;
     }
 
-    async hasWalletUnlocked(fIncludeNetwork = false) {
-        if (fIncludeNetwork && !getNetwork().enabled)
-            return createAlert(
-                'warning',
-                ALERTS.WALLET_OFFLINE_AUTOMATIC,
-                5500
-            );
-        if (!this.isLoaded()) {
-            return createAlert(
-                'warning',
-                tr(ALERTS.WALLET_UNLOCK_IMPORT, [
-                    {
-                        unlock: (await hasEncryptedWallet())
-                            ? 'unlock '
-                            : 'import/create',
-                    },
-                ]),
-                3500
-            );
-        } else {
-            return true;
-        }
-    }
-
     /**
      * Set or replace the active Master Key with a new Master Key
      * @param {import('./masterkey.js').MasterKey} mk - The new Master Key to set active


### PR DESCRIPTION
## Abstract

first commit  is refactor: trivially remove an unused function

second commit:  Try to make `wallet.isHardwareWallet()` a private member of the wallet class (I did not manage to remove all the calls but I removed many) this is done by:

- DON'T mark hardware wallets as view only
- Unify wallet.sign()  with ledgerSignTransaction
 


