### PR TITLE
Fix errors for non-SHIELD wallets on sync (like Legacy)

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -866,10 +866,14 @@ export class Wallet {
             }
         }
         this.#isFetchingLatestBlocks = false;
-        if (block?.finalSaplingRoot)
-            if (!(await this.#checkShieldSaplingRoot(block.finalsaplingroot)))
-                return;
-        await this.saveShieldOnDisk();
+
+        // SHIELD-only checks
+        if (this.hasShield()) {
+            if (block?.finalSaplingRoot)
+                if (!(await this.#checkShieldSaplingRoot(block.finalsaplingroot)))
+                    return;
+            await this.saveShieldOnDisk();
+        }
     }
 
     async #checkShieldSaplingRoot(networkSaplingRoot) {


### PR DESCRIPTION
## Abstract

When progressively syncing blocks (after Initial Sync), non-SHIELD wallets such as Legacy will constantly throw errors due to trying to save non-existence SHIELD data, this PR simply disables that if SHIELD data is missing.

**Legacy Wallet Errors:**
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/42538664/a595a4c8-afe3-4da3-a948-5042a342287b)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Import a Legacy wallet, leave it open for a minute, make sure no errors occur each sync interval.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---