### PR TITLE
Don't hot-reload on .git metadata changes

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -27,8 +27,7 @@ export default merge(common, {
                     // ignore changes in '.git' subdirectory (prevent constant hot-reloading in auto-fetch configurations)
                     '**/.git',
                     /node_modules/,
-		    /coverage/,
-
+                    /coverage/,
                 ],
             },
         },

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -26,6 +26,9 @@ export default merge(common, {
                 ignored: [
                     // ignore changes in '.git' subdirectory (prevent constant hot-reloading in auto-fetch configurations)
                     '**/.git',
+                    /node_modules/,
+		    /coverage/,
+
                 ],
             },
         },

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -24,10 +24,10 @@ export default merge(common, {
             directory: path.join(__dirname, './'),
             watch: {
                 ignored: [
-                  // ignore changes in '.git' subdirectory (prevent constant hot-reloading in auto-fetch configurations)
-                  '**/.git'
+                    // ignore changes in '.git' subdirectory (prevent constant hot-reloading in auto-fetch configurations)
+                    '**/.git',
                 ],
-              },
+            },
         },
         compress: true,
         port: 5500,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -22,6 +22,12 @@ export default merge(common, {
     devServer: {
         static: {
             directory: path.join(__dirname, './'),
+            watch: {
+                ignored: [
+                  // ignore changes in '.git' subdirectory (prevent constant hot-reloading in auto-fetch configurations)
+                  '**/.git'
+                ],
+              },
         },
         compress: true,
         port: 5500,


### PR DESCRIPTION
## Abstract

The webpack dev-server was constantly hot-reloading with my IDE configuration (which auto-fetches git on an interval), this PR simply ignores the `.git` directory, since git metadata is modified each time a fetch happened, it caused constant hot-reloads which made testing my changes painful and annoying.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Run `git fetch` in a separate terminal while running `npm run dev`, webpack shouldn't hot-reload.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---