### PR TITLE
Minimize countries.json

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -69,6 +69,19 @@ export default {
                 },
             },
             {
+                test: /countries.json$/,
+                type: 'json',
+                parser: {
+                    parse: (str) =>
+                        JSON.parse(str).map((c) => {
+                            return {
+                                alpha2: c.alpha2,
+                                currency: c.currency,
+                            };
+                        }),
+                },
+            },
+            {
                 test: /\.svg$/i,
                 type: 'asset/source',
             },
@@ -111,6 +124,10 @@ export default {
         new webpack.IgnorePlugin({
             resourceRegExp: /^\.\/wordlists\/(?!english)/,
             contextRegExp: /bip39\/src$/,
+        }),
+        // Ignore countries-intl
+        new webpack.IgnorePlugin({
+            resourceRegExp: /countries-intl.json$/,
         }),
         // Copy static web-facing files
         new CopyPlugin({


### PR DESCRIPTION
## Abstract

`country-locale-map` contains two giant json, with info that we don't really need.
As a result, it's one of our bigger libraries, which is quite a waste for something we only use once.
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/47313600/d914d878-352c-4e4a-b3da-02342b10d2f5)
This PR tells webpack to: 
- Ignore `countries-intl.json` (Unused by MPW)
- Keep only the alpha2 and currency field

This cuts down the size of the main bundle from 1.44 MB to 1.27 MB unzipped or 455 KB gzipped to 419 KB gzipped.
![image](https://github.com/PIVX-Labs/MyPIVXWallet/assets/47313600/0fd89f40-7cab-49dd-9824-6621654c1b83)

## Testing
- Test that the auto detect currency still works
- (Optional) Test that the bundle sizes are correct (You can use https://www.npmjs.com/package/webpack-bundle-analyzer)