### PR TITLE
Use country map json instead of the provided functions

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -18,7 +18,7 @@ import {
 } from './i18n.js';
 import { Database } from './database.js';
 import { getEventEmitter } from './event_bus.js';
-import { getCurrencyByAlpha2 } from 'country-locale-map';
+import countries from 'country-locale-map/countries.json';
 
 // --- Default Settings
 /** A mode that emits verbose console info for internal MPW operations */
@@ -34,7 +34,10 @@ export let strCurrency = getDefaultCurrency();
  */
 function getDefaultCurrency() {
     const langCode = navigator.languages[0]?.split('-')?.at(-1) || 'US';
-    return getCurrencyByAlpha2(langCode)?.toLowerCase() || 'usd';
+    return (
+        countries.find((c) => c.alpha2 === langCode).currency.toLowerCase() ||
+        'usd'
+    );
 }
 
 /** The user-selected explorer, used for most of MPW's data synchronisation */

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -35,7 +35,7 @@ export let strCurrency = getDefaultCurrency();
 function getDefaultCurrency() {
     const langCode = navigator.languages[0]?.split('-')?.at(-1) || 'US';
     return (
-        countries.find((c) => c.alpha2 === langCode).currency.toLowerCase() ||
+        countries.find((c) => c.alpha2 === langCode)?.currency?.toLowerCase() ||
         'usd'
     );
 }


### PR DESCRIPTION
## Abstract

In addition to #355, we can import the json directly instead of using the provided functions in order to skip the import of some libraries.
This brings down the main bundle to 394KB (gzipped) from 419KB

## Testing
- Test that the auto currency detection still works