### PR TITLE
Polyfill the other secp256k1 libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
+                "@bitcoinerlab/secp256k1": "^1.1.1",
                 "@fontsource/chivo": "^4.5.11",
                 "@fontsource/montserrat": "^4.5.14",
                 "@fortawesome/fontawesome-free": "^6.2.1",
@@ -40,6 +41,7 @@
                 "pivx-shield-rust-multicore": "^1.1.3",
                 "qr-scanner": "^1.4.2",
                 "qrcode-generator": "^1.4.4",
+                "secp256k1-noble": "github:PIVX-Labs/secp256k1-noble",
                 "vue": "^3.3.4",
                 "vue-router": "^4.2.4"
             },
@@ -480,6 +482,15 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bitcoinerlab/secp256k1": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.1.1.tgz",
+            "integrity": "sha512-uhjW51WfVLpnHN7+G0saDcM/k9IqcyTbZ+bDgLF3AX8V/a3KXSE9vn7UPBrcdU72tp0J4YPR7BHp2m7MLAZ/1Q==",
+            "dependencies": {
+                "@noble/hashes": "^1.1.5",
+                "@noble/secp256k1": "^1.7.1"
             }
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -9318,6 +9329,21 @@
             },
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/secp256k1-noble": {
+            "version": "1.0.0",
+            "resolved": "git+ssh://git@github.com/PIVX-Labs/secp256k1-noble.git#cd988bd6d7f626bccea3bca9c5914dfa826a2227",
+            "dependencies": {
+                "@noble/secp256k1": "^2.1.0"
+            }
+        },
+        "node_modules/secp256k1-noble/node_modules/@noble/secp256k1": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.1.0.tgz",
+            "integrity": "sha512-XLEQQNdablO0XZOIniFQimiXsZDNwaYgL96dZwC54Q30imSbAOFf3NKtepc+cXyuZf5Q1HCgbqgZ2UFFuHVcEw==",
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/select-hose": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "webpack-merge": "^5.8.0"
     },
     "dependencies": {
+        "@bitcoinerlab/secp256k1": "^1.1.1",
         "@fontsource/chivo": "^4.5.11",
         "@fontsource/montserrat": "^4.5.14",
         "@fortawesome/fontawesome-free": "^6.2.1",
@@ -93,6 +94,7 @@
         "pivx-shield-rust-multicore": "^1.1.3",
         "qr-scanner": "^1.4.2",
         "qrcode-generator": "^1.4.4",
+        "secp256k1-noble": "github:PIVX-Labs/secp256k1-noble",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
     },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -92,6 +92,10 @@ export default {
             fs: false,
             crypto: path.resolve(__dirname, 'scripts/polyfills/crypto.js'),
         },
+	alias: {
+            'tiny-secp256k1': '@bitcoinerlab/secp256k1',
+            secp256k1: 'secp256k1-noble'
+        },
     },
     plugins: [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
## Abstract

Through various dependencies we are currently using 3 different secp256k1 libraries.
The aim of this PR is to remove these dependencies in favor of @noble/secp256k1.

### tiny-secp256k1
A noble based library was already developed by [bitcoiner lab](https://github.com/bitcoinerlab/secp256k1)

### secp256k1
A replacement for this library was developed in-house [here](https://github.com/PIVX-Labs/secp256k1-noble).
The original tests are being used to test this version of the library.

### Why switch to a single secp256k1?
Using a single library allows us to reduce the bundle size, and the potential vulnerabilities.
The other libraries have a larger amount of dependencies, like `elliptic.js` and `bn.js`, and as far as I can tell have not been audited.

This brings the main bundle size down from 361KB to 325 KB(gzipped)

## Testing
- Test that hd keys work as expected
- Test transactions