### PR TITLE
Fix undefined alerts when locale is missing

### DIFF
--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -24,7 +24,7 @@ const defaultLang = 'en';
  * @example getParentLanguage('es') === defaultLang // true
  * @returns the 'parent' language of a langcode
  */
-function getParentLanguage(langName) {
+export function getParentLanguage(langName) {
     const strParentCode = langName.includes('-')
         ? langName.split('-')[0]
         : defaultLang;
@@ -71,7 +71,7 @@ async function setTranslationKey(key, langName) {
 async function setAlertKey(langName) {
     const lang = await getLanguage(langName);
     translation['ALERTS'] = lang['ALERTS'];
-    for (const subKey in lang['ALERTS']) {
+    for (const subKey in template['ALERTS']) {
         setAlertSubKey(subKey, langName);
     }
 }

--- a/tests/unit/i18n.spec.js
+++ b/tests/unit/i18n.spec.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { getParentLanguage } from '../../scripts/i18n';
+
+describe('i18n tests', () => {
+    it('returns correct parent language', () => {
+        expect(getParentLanguage('es-ES')).toBe('es');
+        expect(getParentLanguage('es')).toBe('en');
+        expect(getParentLanguage('en-US')).toBe('en');
+        expect(getParentLanguage('it')).toBe('en');
+        expect(getParentLanguage('en')).toBe('en');
+    });
+});


### PR DESCRIPTION
## Abstract

When translation is missing, MPW would alert undefined instead of fallbacking to the parent language.
This is because it was using the language to get a list of keys instead of the template, potentially missing some keys.

## Testing
- Unlock a wallet using the portuguese translation, it should display the message in english instead of showing undefined 