### PR TITLE
[JS] Added postinstall.cjs for win and lin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
                 "@vitest/coverage-istanbul": "^1.0.2",
                 "@vue/test-utils": "^2.4.2",
                 "copy-webpack-plugin": "^11.0.0",
-                "cross-env": "^7.0.3",
                 "css-loader": "^6.7.3",
                 "css-minimizer-webpack-plugin": "^4.2.2",
                 "eslint": "^8.31.0",
@@ -3788,24 +3787,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/cross-env": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.1"
-            },
-            "bin": {
-                "cross-env": "src/bin/cross-env.js",
-                "cross-env-shell": "src/bin/cross-env-shell.js"
-            },
-            "engines": {
-                "node": ">=10.14",
-                "npm": ">=6",
-                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
                 "@vitest/coverage-istanbul": "^1.0.2",
                 "@vue/test-utils": "^2.4.2",
                 "copy-webpack-plugin": "^11.0.0",
+                "cross-env": "^7.0.3",
                 "css-loader": "^6.7.3",
                 "css-minimizer-webpack-plugin": "^4.2.2",
                 "eslint": "^8.31.0",
@@ -3787,6 +3788,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "scripts/index.js",
     "type": "module",
     "scripts": {
-        "postinstall": "test -f chain_params.json || cp chain_params.prod.json chain_params.json",
+        "postinstall": "cross-env OS_TYPE=$(uname) node postinstall.cjs",
         "build": "webpack --config webpack.prod.js",
         "buildDev": "webpack --config webpack.dev.js",
         "watch": "webpack --watch",
@@ -43,6 +43,7 @@
         "css-loader": "^6.7.3",
         "css-minimizer-webpack-plugin": "^4.2.2",
         "eslint": "^8.31.0",
+        "cross-env": "^7.0.3",
         "fake-indexeddb": "^5.0.1",
         "file-loader": "^6.2.0",
         "gh-pages": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "scripts/index.js",
     "type": "module",
     "scripts": {
-        "postinstall": "cross-env OS_TYPE=$(uname) node postinstall.cjs",
+        "postinstall": "node postinstall.cjs",
         "build": "webpack --config webpack.prod.js",
         "buildDev": "webpack --config webpack.dev.js",
         "watch": "webpack --watch",
@@ -43,7 +43,6 @@
         "css-loader": "^6.7.3",
         "css-minimizer-webpack-plugin": "^4.2.2",
         "eslint": "^8.31.0",
-        "cross-env": "^7.0.3",
         "fake-indexeddb": "^5.0.1",
         "file-loader": "^6.2.0",
         "gh-pages": "^5.0.0",

--- a/postinstall.cjs
+++ b/postinstall.cjs
@@ -1,26 +1,27 @@
 const { execSync } = require('child_process');
-const fs = require('fs');
 
 // Determine the operating system type
 const os = require('os');
-const osType = os.type();
+const osType = os.platform();
 
 // Define the command to execute based on the OS
 let command;
-if (osType === 'Linux') {
-  command = 'test -f chain_params.json || cp chain_params.prod.json chain_params.json';
-} else if (osType === 'Windows_NT') {
-  command = 'if not exist chain_params.json copy chain_params.prod.json chain_params.json';
+if (osType.match(/aix|darwin|freebsd|linux|openbsd|sunos|android/)) {
+    command =
+        'test -f chain_params.json || cp chain_params.prod.json chain_params.json';
+} else if (osType.match(/win32/)) {
+    command =
+        'if not exist chain_params.json copy chain_params.prod.json chain_params.json';
 } else {
-  console.error('Unsupported operating system');
-  process.exit(1);
+    console.error('Unsupported operating system');
+    process.exit(1);
 }
 
 // Execute the command
 try {
-  execSync(command, { stdio: 'inherit' });
-  console.log('Postinstall script executed successfully');
+    execSync(command, { stdio: 'inherit' });
+    console.log('Postinstall script executed successfully');
 } catch (error) {
-  console.error('Error executing postinstall script:', error);
-  process.exit(1);
+    console.error('Error executing postinstall script:', error);
+    process.exit(1);
 }

--- a/postinstall.cjs
+++ b/postinstall.cjs
@@ -1,0 +1,26 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+// Determine the operating system type
+const os = require('os');
+const osType = os.type();
+
+// Define the command to execute based on the OS
+let command;
+if (osType === 'Linux') {
+  command = 'test -f chain_params.json || cp chain_params.prod.json chain_params.json';
+} else if (osType === 'Windows_NT') {
+  command = 'if not exist chain_params.json copy chain_params.prod.json chain_params.json';
+} else {
+  console.error('Unsupported operating system');
+  process.exit(1);
+}
+
+// Execute the command
+try {
+  execSync(command, { stdio: 'inherit' });
+  console.log('Postinstall script executed successfully');
+} catch (error) {
+  console.error('Error executing postinstall script:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Abstract

This is taken from #372 to ease review. This PR aims to support non-unix OSes (windows) in the postinstall phase.
First commit is cherry-picked from #372, and was made by @BreadJS  
Second commit tweaks the script a bit to add support for other OSes

## Testing
Run `npm ci` on different platforms (At least windows, linux, macOS).