### PR TITLE
Disable iOS auto-zoom

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -101,7 +101,7 @@ export default {
             favicon: './assets/favicon.ico',
             meta: {
                 viewport:
-                    'width=device-width, initial-scale=1, shrink-to-fit=no',
+                    'width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no',
             },
         }),
         new VueLoaderPlugin(),


### PR DESCRIPTION
This tiny adjustment stops a very annoying iOS feature which "auto zooms" on user inputs. This is typically quite disorienting, especially in an app that often requires input like MPW, so let's finally disable it.

## *Example of the "Auto Zoom" affecting PIVX Rewards*
https://github.com/user-attachments/assets/e975c68b-b73a-4f8d-9770-9df3645cb113

https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone