### PR TITLE
Remove Jdenticon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
                 "hdkey": "^2.0.1",
                 "idb": "^7.1.1",
                 "ip-address": "^8.1.0",
-                "jdenticon": "^3.2.0",
                 "jquery": "^3.6.3",
                 "pinia": "^2.1.7",
                 "pivx-promos": "^0.2.0",
@@ -52,7 +51,6 @@
                 "@vue/preload-webpack-plugin": "^2.0.0",
                 "@vue/test-utils": "^2.4.2",
                 "copy-webpack-plugin": "^11.0.0",
-                "cross-env": "^7.0.3",
                 "css-loader": "^6.7.3",
                 "css-minimizer-webpack-plugin": "^4.2.2",
                 "eslint": "^8.31.0",
@@ -1661,6 +1659,7 @@
             "version": "20.12.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
             "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3004,11 +3003,11 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -3339,14 +3338,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ]
-        },
-        "node_modules/canvas-renderer": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.1.tgz",
-            "integrity": "sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg==",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/cctx": {
             "version": "1.0.1",
@@ -3802,24 +3793,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/cross-env": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.1"
-            },
-            "bin": {
-                "cross-env": "src/bin/cross-env.js",
-                "cross-env-shell": "src/bin/cross-env-shell.js"
-            },
-            "engines": {
-                "node": ">=10.14",
-                "npm": ">=6",
-                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {
@@ -4559,9 +4532,9 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-            "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+            "version": "6.5.7",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+            "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -5230,9 +5203,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -6638,20 +6611,6 @@
                 "@pkgjs/parseargs": "^0.11.0"
             }
         },
-        "node_modules/jdenticon": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.2.0.tgz",
-            "integrity": "sha512-z6Iq3fTODUMSOiR2nNYrqigS6Y0GvdXfyQWrUby7htDHvX7GNEwaWR4hcaL+FmhEgBe08Xkup/BKxXQhDJByPA==",
-            "dependencies": {
-                "canvas-renderer": "~2.2.0"
-            },
-            "bin": {
-                "jdenticon": "bin/jdenticon.js"
-            },
-            "engines": {
-                "node": ">=6.4.0"
-            }
-        },
         "node_modules/jest-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -7104,12 +7063,12 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -10474,7 +10433,8 @@
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "node_modules/universalify": {
             "version": "0.1.2",
@@ -11290,9 +11250,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
         "hdkey": "^2.0.1",
         "idb": "^7.1.1",
         "ip-address": "^8.1.0",
-        "jdenticon": "^3.2.0",
         "jquery": "^3.6.3",
         "pinia": "^2.1.7",
         "pivx-promos": "^0.2.0",

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -56,7 +56,6 @@ const { advancedMode, displayDecimals, autoLockWallet } = useSettings();
 const showExportModal = ref(false);
 const showEncryptModal = ref(false);
 const keyToBackup = ref('');
-const jdenticonValue = ref('');
 const transferAddress = ref('');
 const transferDescription = ref('');
 const transferAmount = ref('');
@@ -111,7 +110,6 @@ async function importWallet({ type, secret, password = '' }) {
     if (parsedSecret) {
         await wallet.setMasterKey({ mk: parsedSecret.masterKey });
         wallet.setShield(parsedSecret.shield);
-        jdenticonValue.value = wallet.getAddress();
 
         if (needsToEncrypt.value) showEncryptModal.value = true;
 
@@ -874,7 +872,6 @@ defineExpose({
                         :shieldBalance="shieldBalance"
                         :pendingShieldBalance="pendingShieldBalance"
                         :immatureBalance="immatureBalance"
-                        :jdenticonValue="jdenticonValue"
                         :isHdWallet="wallet.isHD"
                         :isViewOnly="wallet.isViewOnly"
                         :isEncrypted="wallet.isEncrypted"

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -4,7 +4,6 @@ import { tr, translation } from '../i18n';
 import { ref, computed, toRefs, onMounted, watch } from 'vue';
 import { beautifyNumber } from '../misc';
 import { getEventEmitter } from '../event_bus';
-import * as jdenticon from 'jdenticon';
 import { optimiseCurrencyLocale, openExplorer } from '../global';
 import { renderWalletBreakdown } from '../charting.js';
 import {
@@ -28,7 +27,6 @@ import pShieldCheck from '../../assets/icons/icon-shield-check.svg';
 import pRefresh from '../../assets/icons/icon-refresh.svg';
 
 const props = defineProps({
-    jdenticonValue: String,
     balance: Number,
     shieldBalance: Number,
     pendingShieldBalance: Number,
@@ -46,7 +44,6 @@ const props = defineProps({
     publicMode: Boolean,
 });
 const {
-    jdenticonValue,
     balance,
     shieldBalance,
     pendingShieldBalance,

--- a/scripts/dashboard/WalletButtons.vue
+++ b/scripts/dashboard/WalletButtons.vue
@@ -1,6 +1,4 @@
 <script setup>
-import { toRefs, onMounted, watch } from 'vue';
-import * as jdenticon from 'jdenticon';
 import { renderWalletBreakdown } from '../charting.js';
 import { openExplorer } from '../global';
 import { guiRenderContacts } from '../contacts-book';
@@ -12,24 +10,6 @@ import pGift from '../../assets/icons/icon-gift.svg';
 import { useWallet } from '../composables/use_wallet.js';
 
 const wallet = useWallet();
-
-const props = defineProps({
-    jdenticonValue: String,
-});
-const { jdenticonValue } = toRefs(props);
-
-onMounted(() => {
-    jdenticon.configure();
-    watch(
-        jdenticonValue,
-        () => {
-            jdenticon.update('#identicon', jdenticonValue.value);
-        },
-        {
-            immediate: true,
-        }
-    );
-});
 </script>
 
 <template>


### PR DESCRIPTION
## Abstract

This PR simply removes Jdenticon, the old "address-icon" system used by the very first MPW app.

This feature has always had confusion around it, and support has been roughly 50/50 in community votes, but MPW v2.0 was designed without it - one less library, saving us bandwidth and CPU time for a feature most consider obsolete.

---

## Testing
Nothing in particular - just make sure it builds, loads up, and the package files are good. Jdenticon was not displayed in the frontend since the v2.0 design, thus it's already deprecated.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---