### PR TITLE
Add password visibility toggles

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -2824,6 +2824,19 @@ input {
     border: 0px;
 }
 
+.input-group-toggle {
+    cursor: pointer;
+    background-color: rgb(127, 32, 255);
+    border: 2px solid #AF9CC6;
+    color: rgb(233, 222, 255);
+    padding: 10px 8px !important;
+    display: inline-block;
+    width: 10%;
+    border-left-width: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
 .cur-pointer {
     cursor: pointer;
 }

--- a/scripts/dashboard/CreateWallet.vue
+++ b/scripts/dashboard/CreateWallet.vue
@@ -37,6 +37,19 @@ async function generateWallet() {
     mnemonic.value = '';
     passphrase.value = '';
 }
+
+const current_password_visibility = ref('password');
+const current_password_visibility_icon = ref('fa-solid fa-eye-slash');
+function toggleCurrentPasswordVisibility() {
+    const fVisible = current_password_visibility.value === 'text';
+
+    // Toggle the password visibility
+    current_password_visibility.value = fVisible ? 'password' : 'text';
+
+    // Toggle the 'eye' icon to open/closed
+    const strIcon = fVisible ? 'eye-slash' : 'eye';
+    current_password_visibility_icon.value = 'fa-solid fa-' + strIcon;
+}
 </script>
 
 <template>
@@ -91,12 +104,23 @@ async function generateWallet() {
                     <div v-if="advancedMode">
                         <br />
                         <input
-                            class="center-text"
-                            type="password"
+                            class="center-text textboxTransparency"
+                            :type="current_password_visibility"
                             :placeholder="translation.optionalPassphrase"
                             v-model="passphrase"
+                            style="
+                                width: 85%;
+                                font-family: monospace;
+                                border-top-right-radius: 0;
+                                border-bottom-right-radius: 0;
+                            "
                             data-testid="passPhrase"
-                        />
+                        /><span
+                            @click="toggleCurrentPasswordVisibility()"
+                            class="input-group-toggle input-group-text p-0"
+                        >
+                            <i :class="current_password_visibility_icon"></i>
+                        </span>
                     </div>
                 </div>
             </template>

--- a/scripts/dashboard/GenKeyWarning.vue
+++ b/scripts/dashboard/GenKeyWarning.vue
@@ -26,6 +26,32 @@ function close() {
     emit('close');
 }
 
+const current_password_visibility = ref('password');
+const current_password_visibility_icon = ref('fa-solid fa-eye-slash');
+function toggleCurrentPasswordVisibility() {
+    const fVisible = current_password_visibility.value === 'text';
+
+    // Toggle the password visibility
+    current_password_visibility.value = fVisible ? 'password' : 'text';
+
+    // Toggle the 'eye' icon to open/closed
+    const strIcon = fVisible ? 'eye-slash' : 'eye';
+    current_password_visibility_icon.value = 'fa-solid fa-' + strIcon;
+}
+
+const new_password_visibility = ref('password');
+const new_password_visibility_icon = ref('fa-solid fa-eye-slash');
+function toggleNewPasswordVisibility() {
+    const fVisible = new_password_visibility.value === 'text';
+
+    // Toggle the password visibility
+    new_password_visibility.value = fVisible ? 'password' : 'text';
+
+    // Toggle the 'eye' icon to open/closed
+    const strIcon = fVisible ? 'eye-slash' : 'eye';
+    new_password_visibility_icon.value = 'fa-solid fa-' + strIcon;
+}
+
 /**
  * Perform basic checks, then emit the event to our parent
  */
@@ -90,35 +116,56 @@ function submit() {
                 </h5>
             </template>
             <template #body>
+                <div v-show="isEncrypt">
+                    <input
+                        class="center-text textboxTransparency"
+                        data-i18n="encryptPasswordCurrent"
+                        v-model="currentPassword"
+                        style="
+                            width: 85%;
+                            font-family: monospace;
+                            border-top-right-radius: 0;
+                            border-bottom-right-radius: 0;
+                        "
+                        :type="current_password_visibility"
+                        :placeholder="translation.encryptPasswordCurrent"
+                        data-testid="currentPasswordModal"
+                    /><span
+                        @click="toggleCurrentPasswordVisibility()"
+                        class="input-group-toggle input-group-text p-0"
+                    >
+                        <i :class="current_password_visibility_icon"></i>
+                    </span>
+                </div>
                 <input
-                    class="center-text textboxTransparency passwordTxtbox"
-                    data-i18n="encryptPasswordCurrent"
-                    v-model="currentPassword"
-                    style="width: 100%; font-family: monospace"
-                    type="password"
-                    :placeholder="translation.encryptPasswordCurrent"
-                    v-show="isEncrypt"
-                    data-testid="currentPasswordModal"
-                />
-                <input
-                    class="center-text textboxTransparency passwordTxtbox"
+                    class="center-text textboxTransparency"
                     v-model="password"
                     data-i18n="encryptPasswordFirst"
-                    style="width: 100%; font-family: monospace"
-                    type="password"
+                    style="
+                        width: 85%;
+                        font-family: monospace;
+                        border-top-right-radius: 0;
+                        border-bottom-right-radius: 0;
+                    "
+                    :type="new_password_visibility"
                     :placeholder="translation.encryptPasswordFirst"
                     data-testid="newPasswordModal"
-                />
+                /><span
+                    @click="toggleNewPasswordVisibility()"
+                    class="input-group-toggle input-group-text p-0"
+                >
+                    <i :class="new_password_visibility_icon"></i>
+                </span>
                 <input
-                    class="center-text textboxTransparency passwordTxtbox"
+                    class="center-text textboxTransparency"
                     v-model="passwordConfirm"
                     data-i18n="encryptPasswordSecond"
                     style="
-                        width: 100%;
+                        width: 95%;
                         font-family: monospace;
                         margin-bottom: 0px;
                     "
-                    type="password"
+                    :type="new_password_visibility"
                     :placeholder="translation.encryptPasswordSecond"
                     data-testid="confirmPasswordModal"
                 />

--- a/scripts/dashboard/RestoreWallet.vue
+++ b/scripts/dashboard/RestoreWallet.vue
@@ -33,9 +33,23 @@ async function submit() {
         createAlert('warning', ALERTS.FAILED_TO_IMPORT);
     }
 }
+
 function close() {
     emit('close');
     password.value = '';
+}
+
+const password_visibility = ref('password');
+const password_visibility_icon = ref('fa-solid fa-eye-slash');
+function togglePasswordVisibility() {
+    const fVisible = password_visibility.value === 'text';
+
+    // Toggle the password visibility
+    password_visibility.value = fVisible ? 'password' : 'text';
+
+    // Toggle the 'eye' icon to open/closed
+    const strIcon = fVisible ? 'eye-slash' : 'eye';
+    password_visibility_icon.value = 'fa-solid fa-' + strIcon;
 }
 </script>
 <template>
@@ -53,12 +67,22 @@ function close() {
             <template #body>
                 <p style="opacity: 0.75" v-if="!!reason">{{ reason }}</p>
                 <input
-                    type="password"
+                    :type="password_visibility"
                     ref="passwordInput"
                     v-model="password"
                     :placeholder="translation.walletPassword"
-                    style="text-align: center"
-                />
+                    style="
+                        text-align: center;
+                        width: 80%;
+                        border-top-right-radius: 0;
+                        border-bottom-right-radius: 0;
+                    "
+                /><span
+                    @click="togglePasswordVisibility()"
+                    class="input-group-toggle input-group-text p-0"
+                >
+                    <i :class="password_visibility_icon"></i>
+                </span>
             </template>
             <template #footer>
                 <button


### PR DESCRIPTION
## Abstract

Resolves #321 by adding the ability to toggle visibility on a per-password basis.

Each password box (provided it's not linked to a primary one, i.e: "re-type confirmations") has an "eye" toggle which reveals and cloaks the password to the user.


https://github.com/user-attachments/assets/0847acb4-aecc-4492-9b0d-3b9a8bf17ff8


Passwords are still hidden by default.

---

## Dev Note
I'm not quite proficient enough in Vue yet, this code is very bloated, using the same duplicated code for every 'toggle' button - this can be refactored using a Vue "module" in the same way the Progress Bar is re-usable - might need some help on doing this before merging this PR.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Enable Advanced Mode, create a new wallet, and see if the "BIP39 Passphrase" has a working toggle.
- When setting a password after creating a wallet, check that the toggle works as expected.
- After encrypting a wallet, visit Settings and "Change Password", again, ensure the toggles work.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---