### PR TITLE
Add in-modal address refresh + automatic type flipping

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -7,6 +7,11 @@ import { ledgerSignTransaction } from '../ledger.js';
 import { defineStore } from 'pinia';
 import { lockableFunction } from '../lock.js';
 import { doms } from '../global.js';
+import {
+    RECEIVE_TYPES,
+    cReceiveType,
+    guiToggleReceiveType,
+} from '../contacts-book.js';
 
 /**
  * This is the middle ground between vue and the wallet class
@@ -22,6 +27,19 @@ export const useWallet = defineStore('wallet', () => {
     watch(publicMode, (publicMode) => {
         doms.domNavbar.classList.toggle('active', !publicMode);
         doms.domLightBackground.style.opacity = publicMode ? '1' : '0';
+        // Depending on our Receive type, flip to the opposite type.
+        // i.e: from `address` to `shield`, `shield contact` to `address`, etc
+        // This reduces steps for someone trying to grab their opposite-type address, which is the primary reason to mode-toggle.
+        const arrFlipTypes = [
+            RECEIVE_TYPES.CONTACT,
+            RECEIVE_TYPES.ADDRESS,
+            RECEIVE_TYPES.SHIELD,
+        ];
+        if (arrFlipTypes.includes(cReceiveType)) {
+            guiToggleReceiveType(
+                publicMode ? RECEIVE_TYPES.ADDRESS : RECEIVE_TYPES.SHIELD
+            );
+        }
     });
 
     const isImported = ref(wallet.isLoaded());

--- a/scripts/contacts-book.js
+++ b/scripts/contacts-book.js
@@ -424,8 +424,15 @@ function renderAddress(strAddress) {
     doms.domModalQrLabel.innerHTML =
         // SanitzeHTML shouldn't be necessary, but let's keep it just in case
         sanitizeHTML(strAddress) +
-        `<i onclick="MPW.toClipboard('${strAddress}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; right: 27px; margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;
+        `<i onclick="MPW.toClipboard('${strAddress}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; right: 55px; margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;
     document.getElementById('clipboard').value = strAddress;
+
+    // HD wallets gain a 'Refresh' button for quick address rotation
+    const cWallet = useWallet();
+    if (cWallet.isHD) {
+        doms.domModalQrLabel.style['padding-right'] = '65px';
+        doms.domModalQrLabel.innerHTML += `<i onclick="MPW.getNewAddress({ updateGUI: true, verify: true, shield: ${!cWallet.publicMode} })" class="pColor fa-solid fa-arrows-rotate fa-lg" style="position: absolute; right: 27px; margin-top: 10px; cursor: pointer; width: 20px;"></i>`;
+    }
 }
 
 /**
@@ -436,6 +443,8 @@ export async function guiRenderReceiveModal(
     cReceiveType = RECEIVE_TYPES.CONTACT
 ) {
     doms.domModalQR.hidden = false;
+    // Default the width to fit non-rotatable Contacts, XPub and non-HD
+    doms.domModalQrLabel.style['padding-right'] = '35px';
     switch (cReceiveType) {
         case RECEIVE_TYPES.CONTACT:
             await renderContactModal();
@@ -451,6 +460,7 @@ export async function guiRenderReceiveModal(
             const strXPub = wallet.getXPub();
 
             // Update the QR Label (we'll show the address here for now, user can set Contact "Name" optionally later)
+
             doms.domModalQrLabel.innerHTML =
                 sanitizeHTML(strXPub) +
                 `<i onclick="MPW.toClipboard('${strXPub}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; right: 27px; margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;

--- a/scripts/contacts-book.js
+++ b/scripts/contacts-book.js
@@ -421,14 +421,17 @@ function renderAddress(strAddress) {
     } catch (e) {
         doms.domModalQR.hidden = true;
     }
+
+    const cWallet = useWallet();
     doms.domModalQrLabel.innerHTML =
-        // SanitzeHTML shouldn't be necessary, but let's keep it just in case
+        // SanitizeHTML shouldn't be necessary, but let's keep it just in case
         sanitizeHTML(strAddress) +
-        `<i onclick="MPW.toClipboard('${strAddress}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; right: 55px; margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;
+        `<i onclick="MPW.toClipboard('${strAddress}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; ${
+            cWallet.isHD ? 'right: 55px;' : ''
+        } margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;
     document.getElementById('clipboard').value = strAddress;
 
     // HD wallets gain a 'Refresh' button for quick address rotation
-    const cWallet = useWallet();
     if (cWallet.isHD) {
         doms.domModalQrLabel.style['padding-right'] = '65px';
         doms.domModalQrLabel.innerHTML += `<i onclick="MPW.getNewAddress({ updateGUI: true, verify: true, shield: ${!cWallet.publicMode} })" class="pColor fa-solid fa-arrows-rotate fa-lg" style="position: absolute; right: 27px; margin-top: 10px; cursor: pointer; width: 20px;"></i>`;


### PR DESCRIPTION
## Abstract

This PR improves the Receive UX flow by adding the ability to refresh address in-modal for appropriate address types, it also makes it easier to grab an address from the opposite mode (i.e: You commonly use Private but you quickly need a Public address) by flipping the Receive type automatically when switching modes.

This video demonstrates both functionalities.

https://github.com/user-attachments/assets/a6eed9a8-1c89-4dc2-8b14-bc40b3a7de70

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Switch between Public and Private mode, ensure the 'Receive' type flips accordingly.
- On refreshable addresses (HD Public + Private), try refreshing your address in the Receive modal.
- Try HD and Non-HD wallets, ensure the refresh button is not displayed on Non-HD.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---