### PR TITLE
Add PIVX Labs RPC + fix Node selector

### DIFF
--- a/chain_params.prod.json
+++ b/chain_params.prod.json
@@ -20,7 +20,8 @@
             { "name": "zkBitcoin", "url": "https://zkbitcoin.com" }
         ],
         "Nodes": [
-            { "name": "Duddino", "url": "https://rpc.duddino.com/mainnet" }
+            { "name": "Duddino", "url": "https://rpc.duddino.com/mainnet" },
+            { "name": "PIVX Labs", "url": "https://rpc.pivxla.bz/mainnet" }
         ],
         "Consensus": {},
         "coinbaseMaturity": 100,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -146,6 +146,13 @@ export async function start() {
         );
     };
 
+    // Hook up the 'node' select UI
+    document.getElementById('node').onchange = function (evt) {
+        setNode(
+            cChainParams.current.Nodes.find((a) => a.url === evt.target.value)
+        );
+    };
+
     // Hook up the 'translation' select UI
     document.getElementById('translation').onchange = function (evt) {
         setTranslation(evt.target.value);


### PR DESCRIPTION
## Abstract

This PR simply adds the new PIVX Labs Mainnet RPC server, as well as fixing the non-functional Node selector in the Settings.

This PR does not add auto-switching for node failures, but we should do this in a future PR, keeping it small for easy review purposes prior to v2.0 launch, it is still nice to have the ability to switch to multiple Mainnet RPCs now.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Switch "Node" to "PIVX Labs" in the settings, test the Governance page and Shield block syncing.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---