### PR TITLE
Custom EventEmitter 

### DIFF
--- a/scripts/event_bus.js
+++ b/scripts/event_bus.js
@@ -1,10 +1,53 @@
 import { EventEmitter } from 'events';
 
-const eventEmitter = new EventEmitter();
+/**
+ * Wrapper class around EventEmitter that allow to enable/disable specific events.
+ * By defaults all events are enabled, and can be disabled by calling disableEvent
+ */
+class EventEmitterWrapper {
+    /** @type{EventEmitter} */
+    #internalEmitter;
+    /**
+     * Set of disabled events
+     * @type {Set<string>}
+     */
+    #disabledEvents = new Set();
+    constructor() {
+        this.#internalEmitter = new EventEmitter();
+    }
+
+    on(eventName, listener) {
+        this.#internalEmitter.on(eventName, listener);
+    }
+
+    emit(eventName, ...args) {
+        if (this.#disabledEvents.has(eventName)) {
+            return;
+        }
+        this.#internalEmitter.emit(eventName, ...args);
+    }
+
+    /**
+     * Disable an event
+     * @param {string} eventName
+     */
+    disableEvent(eventName) {
+        this.#disabledEvents.add(eventName);
+    }
+    /**
+     * Enable a (previously disabled) event
+     * @param {string} eventName
+     */
+    enableEvent(eventName) {
+        this.#disabledEvents.delete(eventName);
+    }
+}
+
+const eventEmitter = new EventEmitterWrapper();
 
 /**
  * Get the application wide event emitter.
- * @returns {EventEmitter}
+ * @returns {EventEmitterWrapper}
  */
 export function getEventEmitter() {
     return eventEmitter;

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -231,23 +231,7 @@ export class Mempool {
         this.#balances.immatureBalance.invalidate();
         this.#balances.balance.invalidate();
         this.#balances.coldBalance.invalidate();
-        this.#emitBalanceUpdate();
-    }
-
-    #emittingBalanceUpdate = false;
-
-    #emitBalanceUpdate() {
-        if (this.#emittingBalanceUpdate) return;
-        this.#emittingBalanceUpdate = true;
-        // TODO: This is not ideal, we are limiting the mempool to only emit 1 balance-update per frame,
-        // but we don't want the mempool to know about animation frames. This is needed during
-        // sync to avoid spamming balance-updates and slowing down the sync.
-        // The best course of action is to probably add a loading page/state and avoid
-        // listening to the balance-update event until the sync is done
-        requestAnimationFrame(() => {
-            getEventEmitter().emit('balance-update');
-            this.#emittingBalanceUpdate = false;
-        });
+        getEventEmitter().emit('balance-update');
     }
 
     /**

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -685,6 +685,10 @@ export class Wallet {
         if (this.#isSynced) {
             throw new Error('Attempting to sync when already synced');
         }
+        // While syncing the wallet ( DB read + network sync) disable the event balance-update
+        // This is done to avoid a huge spam of event.
+        getEventEmitter().disableEvent('balance-update');
+
         await this.loadFromDisk();
         await this.loadShieldFromDisk();
         // Let's set the last processed block 5 blocks behind the actual chain tip
@@ -697,6 +701,8 @@ export class Wallet {
         }
         this.#isSynced = true;
         // Update both activities post sync
+        getEventEmitter().enableEvent('balance-update');
+        getEventEmitter().emit('balance-update');
         getEventEmitter().emit('new-tx');
     });
 


### PR DESCRIPTION
## Abstract

Create a wrapper class around EventEmitter that allows us to enable and disable events. In particular, the class is used to disable the event `balance-update`, during the sync (DB read + network calls).

The results is a huge improvement in performance (and IMO also cleaner code in mempool.js).



