### PR TITLE
Persistant Wallet Mode

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -23,7 +23,7 @@ export const useWallet = defineStore('wallet', () => {
     // For now we'll just import the existing one
     // const wallet = new Wallet();
 
-    // Public/Private Mode will be loaded from disk after 'import-wallet' is emitted 
+    // Public/Private Mode will be loaded from disk after 'import-wallet' is emitted
     const publicMode = ref(true);
     watch(publicMode, (publicMode) => {
         doms.domNavbar.classList.toggle('active', !publicMode);

--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -1,7 +1,7 @@
 import { getEventEmitter } from '../event_bus.js';
 import { hasEncryptedWallet, wallet } from '../wallet.js';
 import { ref, watch } from 'vue';
-import { strCurrency } from '../settings.js';
+import { fPublicMode, strCurrency, togglePublicMode } from '../settings.js';
 import { cOracle } from '../prices.js';
 import { ledgerSignTransaction } from '../ledger.js';
 import { defineStore } from 'pinia';
@@ -23,6 +23,7 @@ export const useWallet = defineStore('wallet', () => {
     // For now we'll just import the existing one
     // const wallet = new Wallet();
 
+    // Public/Private Mode will be loaded from disk after 'import-wallet' is emitted 
     const publicMode = ref(true);
     watch(publicMode, (publicMode) => {
         doms.domNavbar.classList.toggle('active', !publicMode);
@@ -40,6 +41,9 @@ export const useWallet = defineStore('wallet', () => {
                 publicMode ? RECEIVE_TYPES.ADDRESS : RECEIVE_TYPES.SHIELD
             );
         }
+
+        // Save the mode state to DB
+        togglePublicMode(publicMode);
     });
 
     const isImported = ref(wallet.isLoaded());
@@ -120,6 +124,10 @@ export const useWallet = defineStore('wallet', () => {
 
     getEventEmitter().on('toggle-network', async () => {
         isEncrypted.value = await hasEncryptedWallet();
+    });
+
+    getEventEmitter().on('wallet-import', async () => {
+        publicMode.value = fPublicMode;
     });
 
     getEventEmitter().on('balance-update', async () => {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -106,7 +106,7 @@ export class Settings {
         advancedMode = false,
         coldAddress = '',
         autoLockWallet = false,
-        publicMode = true
+        publicMode = true,
     } = {}) {
         this.explorer = explorer;
         this.node = node;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -50,7 +50,7 @@ export let fAutoSwitch = true;
 export let nDisplayDecimals = 2;
 /** A mode which configures MPW towards Advanced users, with low-level feature access and less restrictions (Potentially dangerous) */
 export let fAdvancedMode = false;
-/** automatically lock the wallet after any operation  that requires unlocking */
+/** Automatically lock the wallet after any operation that requires unlocking */
 export let fAutoLockWallet = false;
 /** The user's transaction mode, `true` for public, `false` for private */
 export let fPublicMode = true;
@@ -541,9 +541,13 @@ export async function toggleAdvancedMode() {
     await database.setSettings({ advancedMode: fAdvancedMode });
 }
 
+/**
+ * Toggle Advanced Mode at runtime and in DB
+ */
 export async function toggleAutoLockWallet() {
     fAutoLockWallet = !fAutoLockWallet;
     configureAutoLockWallet();
+
     // Update the setting in the DB
     const database = await Database.getInstance();
     await database.setSettings({ autoLockWallet: fAutoLockWallet });

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -557,8 +557,8 @@ export async function toggleAutoLockWallet() {
  * Toggle the Transaction Mode at runtime and in DB
  * @param {boolean?} fForce - Optionally force the setting to a value
  */
-export async function togglePublicMode(fForce) {
-    fPublicMode = typeof fForce === 'boolean' ? fForce : !fPublicMode;
+export async function togglePublicMode(fNewPublicMode = !fPublicMode) {
+    fPublicMode = fNewPublicMode;
 
     // Update the setting in the DB
     const database = await Database.getInstance();

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -52,6 +52,8 @@ export let nDisplayDecimals = 2;
 export let fAdvancedMode = false;
 /** automatically lock the wallet after any operation  that requires unlocking */
 export let fAutoLockWallet = false;
+/** The user's transaction mode, `true` for public, `false` for private */
+export let fPublicMode = true;
 
 export class Settings {
     /**
@@ -90,6 +92,10 @@ export class Settings {
      * @type {boolean} Whether auto lock feature is enabled or disabled
      */
     autoLockWallet;
+    /**
+     * @type {Boolean} The user's transaction mode, `true` for public, `false` for private
+     */
+    publicMode;
     constructor({
         explorer,
         node,
@@ -100,6 +106,7 @@ export class Settings {
         advancedMode = false,
         coldAddress = '',
         autoLockWallet = false,
+        publicMode = true
     } = {}) {
         this.explorer = explorer;
         this.node = node;
@@ -109,6 +116,7 @@ export class Settings {
         this.displayDecimals = displayDecimals;
         this.advancedMode = advancedMode;
         this.autoLockWallet = autoLockWallet;
+        this.publicMode = publicMode;
         // DEPRECATED: Read-only below here, for migration only
         this.coldAddress = coldAddress;
     }
@@ -169,6 +177,7 @@ export async function start() {
         displayDecimals,
         advancedMode,
         autoLockWallet,
+        publicMode,
         // DEPRECATED: Below here are entries that are read-only due to being moved to a different location in the DB
         coldAddress,
     } = await database.getSettings();
@@ -190,7 +199,10 @@ export async function start() {
             await database.setSettings({ coldAddress: '' });
         }
     }
-    // auto lock wallet
+    // Transaction Mode (Public/Private)
+    fPublicMode = publicMode;
+
+    // Auto lock wallet
     fAutoLockWallet = autoLockWallet;
     doms.domAutoLockModeToggler.checked = fAutoLockWallet;
     configureAutoLockWallet();
@@ -535,6 +547,18 @@ export async function toggleAutoLockWallet() {
     // Update the setting in the DB
     const database = await Database.getInstance();
     await database.setSettings({ autoLockWallet: fAutoLockWallet });
+}
+
+/**
+ * Toggle the Transaction Mode at runtime and in DB
+ * @param {boolean?} fForce - Optionally force the setting to a value
+ */
+export async function togglePublicMode(fForce) {
+    fPublicMode = typeof fForce === 'boolean' ? fForce : !fPublicMode;
+
+    // Update the setting in the DB
+    const database = await Database.getInstance();
+    await database.setSettings({ publicMode: fPublicMode });
 }
 
 /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -555,7 +555,7 @@ export async function toggleAutoLockWallet() {
 
 /**
  * Toggle the Transaction Mode at runtime and in DB
- * @param {boolean?} fForce - Optionally force the setting to a value
+ * @param {boolean?} fNewPublicMode - Optionally force the setting to a value
  */
 export async function togglePublicMode(fNewPublicMode = !fPublicMode) {
     fPublicMode = fNewPublicMode;


### PR DESCRIPTION
## Abstract

This PR adds Persistance to the "Wallet Mode", effectively treating it as a Setting, persisting the user's preferred Wallet Mode throughout their sessions.

A common usecase example being, a PIVCards user wanting maximum privacy.
1. User, whom exclusively uses SHIELD, opens a "Pay with MPW" invoice.
2. MPW loads and opens the Payment UI, which currently defaults to Public.
3. The user must close the dialog, switch mode, then return to the dialog to continue to pay with SHIELD.

With this PR, assuming they last used MPW in Private mode, the invoice will open with Private mode, and allow a smooth one-click-style payment.

This PR does not affect the 'true default', which remains Public Mode, i.e: when a new wallet is created or imported.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test that MPW remembers your last Wallet Mode (Public or Private), and loads accordingly.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---