### PR TITLE
Fix Reward Aggregator

### DIFF
--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -258,12 +258,8 @@ async function parseTXs(arrTXs) {
 }
 
 const rewardsText = computed(() => {
-    const strBal = rewardAmount.value.toFixed(0);
-    const nLen = strBal.length;
-    return `${beautifyNumber(
-        strBal,
-        nLen >= 10 ? '15px' : '15px'
-    )} <span style="font-size:15px; opacity: 0.55;">${ticker.value}</span>`;
+    const strBal = rewardAmount.value.toLocaleString('en-GB');
+    return `${strBal} <span style="font-size:15px; opacity: 0.55;">${ticker.value}</span>`;
 });
 
 function reset() {

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -91,16 +91,17 @@ async function update(txToAdd = 0) {
     // For Rewards: aggregate the total amount
     if (props.rewards) {
         for (const tx of orderedTxs) {
+            // If this Tx Height is under our last scanned height, we stop
+            if (tx.blockHeight <= nRewardUpdateHeight) break;
             // Only compute rewards
             if (!tx.isCoinStake()) continue;
-            // If this Tx Height is over the last scanned height, we aggregate it
-            if (tx.blockHeight > nRewardUpdateHeight) {
-                // Aggregate the total rewards
-                rewardAmount.value += wallet.toHistoricalTXs([tx])[0].amount;
-            }
+            // Aggregate the total rewards
+            rewardAmount.value += wallet.toHistoricalTXs([tx])[0].amount;
         }
         // Keep track of the scan block height
-        nRewardUpdateHeight = blockCount;
+        if (orderedTxs.length) {
+            nRewardUpdateHeight = orderedTxs[0].blockHeight;
+        }
     }
 
     // Prepare the Tx History list

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -265,6 +265,7 @@ const rewardsText = computed(() => {
 function reset() {
     txs.value = [];
     txCount = 0;
+    nRewardUpdateHeight = 0;
     update(0);
 }
 


### PR DESCRIPTION
## Abstract

This PR fixes the "Total Rewards" counter in the Reward History (Activity) title, which, due to previous limitations when MPW did not have full history locally - only calculated the rewards of Txs loaded in to the Activity history.

Now, MPW will calculate the full history of rewards once at Activity init, caching the height to avoid expensive re-computation, and new rewards will simply be added to the counter as blocks continue to sync.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Import a wallet with Staking, Masternode or Superblock rewards, ensure the total Reward Amount is expected.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---