### PR TITLE
Save shield during first sync

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -742,6 +742,8 @@ export class Wallet {
                         syncing = true;
                         handled++;
                         await this.#shield.handleBlock(blocks[j]);
+                        // Backup every 500 handled blocks
+                        if (handled % 500 == 0) await this.saveShieldOnDisk();
                         // Delete so we don't have to hold all blocks in memory
                         // until we finish syncing
                         delete blocks[j];


### PR DESCRIPTION
## Abstract

Shield can take a lot of time to sync, and in case of failure (for example, a user closes MPW) it start again from zero.
This PR solves the issue by saving shield data every 500 synced blocks.


## Test

Verify that syncing starts from the point where you stopped it

