### PR TITLE
Faster TXDB Initialisation

### DIFF
--- a/scripts/transaction.js
+++ b/scripts/transaction.js
@@ -112,6 +112,7 @@ export class Transaction {
         shieldSpend = [],
         shieldOutput = [],
         bindingSig = '',
+        txid = '',
     } = {}) {
         this.version = version;
         this.blockHeight = blockHeight;
@@ -125,6 +126,8 @@ export class Transaction {
         this.valueBalance = valueBalance;
         /** Handle to the unproxied tx for when we need to clone it */
         this.__original = this;
+        // If a TXID is provided (i.e: loaded from DB), cache it
+        if (txid) this.__original.#txid = txid;
         return new Proxy(this, {
             set(obj, p) {
                 if (p !== 'blockHeight' && p !== 'blockTime') {


### PR DESCRIPTION
## Abstract

This PR improves the speed of loading transactions from the database, primarily by skipping the re-serialisation of TXIDs and instead loading them directly from the DB index.

This improvement will especially affect large wallets, from my testing on a mainnet wallet with ~2k transactions, this gave me a 4x speedup measured from the execution time of `loadFromDisk()`.

# **Before:**
![image](https://github.com/user-attachments/assets/944f4855-5561-4ab4-8877-bb1c19d9248c)

# **After:**
![image](https://github.com/user-attachments/assets/53d008fe-1057-43fa-815b-6ba5c5297a60)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Generally, just make sure MPW loads your transactions from the DB as expected.
- Run a performance debugger (in Firefox or Chromium) and measure the finish time of `loadFromDisk()` pre-PR and with PR.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---