### PR TITLE
v2.0.1 finalised

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,16 +5,21 @@ A patch for MPW v2.0, primarily resolving stability, performance and minor UX is
 - Persistant Wallet Mode.
 - Shield sync is visually smoother.
 - Shield sync is persisted better between restarts.
+- Shield now syncs faster, via Nodes.
+- Added notification stacking (no more spam!).
 - Automatic Node switching.
+- Added Duddino2 Node & Explorer.
 - Faster TXDB initialisation.
 
 # Removals
 - Legacy DB migration system.
 
 # Bug Fixes
+- Fixed missed Sapling Root validation.
 - Fixed issues with persisted unconfirmed Txs.
 - Fixed a case in which Txs load in an incorrect order.
 - Fixed Total Rewards counter.
+- Fixed 'Max' button not updating currency.
 - Fixed old v1.0 branding remnant.
 
 # v2.0 - Major Update

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ A patch for MPW v2.0, primarily resolving stability, performance and minor UX is
 - Persistant Wallet Mode.
 - Shield sync is visually smoother.
 - Shield sync is persisted better between restarts.
+- Automatic Node switching.
 - Faster TXDB initialisation.
 
 # Removals

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ A patch for MPW v2.0, primarily resolving stability, performance and minor UX is
 # Bug Fixes
 - Fixed issues with persisted unconfirmed Txs.
 - Fixed a case in which Txs load in an incorrect order.
+- Fixed Total Rewards counter.
 - Fixed old v1.0 branding remnant.
 
 # v2.0 - Major Update

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,21 @@
-# The Big Upgrade
+# Patch 1
+A patch for MPW v2.0, primarily resolving stability, performance and minor UX issues.
+
+# Improvements
+- Persistant Wallet Mode.
+- Shield sync is visually smoother.
+- Shield sync is persisted better between restarts.
+- Faster TXDB initialisation.
+
+# Removals
+- Legacy DB migration system.
+
+# Bug Fixes
+- Fixed issues with persisted unconfirmed Txs.
+- Fixed a case in which Txs load in an incorrect order.
+- Fixed old v1.0 branding remnant.
+
+# v2.0 - Major Update
 This is the largest MPW upgrade since Shield; containing an incredible array of improvements and polish, with the aim of bringing MPW to a professional wallet standard, welcome to v2.0.
 
 There are over 15k line changes in v2.0, this changelog will only show a small subset of notable changes, for more, head to GitHub.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mypivxwallet",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mypivxwallet",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mypivxwallet",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Wallet for PIVX",
     "main": "scripts/index.js",
     "type": "module",

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -56,7 +56,7 @@ export function renderChangelog() {
                 break;
             default:
                 // If no element was recognised, it's just a plaintext line
-                strHTML += `<p>${sanitizeHTML(type + line)}</p>`;
+                strHTML += `<p>${sanitizeHTML(rawLine)}</p>`;
                 break;
         }
     }


### PR DESCRIPTION
## Abstract

This PR bumps My PIVX Wallet to v2.0.1, documenting the patch changes on-top of the v2.0 launch logs.
The extension-style log will be reset at our next minor update, i.e: v2.1.

A tiny changelog bug was also resolved that trimmed small sentences, i.e: "A patch" to "Apatch" on plaintext lines.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test **Imports** and **New Wallet** generations.
- Test that Syncing works as expected, without errors, and that it resumes where it left off **IF** you restart MPW halfway through.
- Test **Sending and Receiving** both **Transparent** and **SHIELD** PIV.
- Test **Contacts**.
- Test Creating and Redeeming **PIVX Promos**.
- Test **Staking and Unstaking**.
- Any other small, quick tests you feel like doing... do them!

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---