### PR TITLE
Fix max button not updating currency in TransferMenu

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -385,7 +385,7 @@ async function send(address, amount, useShieldInputs) {
  */
 function getMaxBalance(useShieldInputs) {
     const coinSatoshi = useShieldInputs ? wallet.shieldBalance : wallet.balance;
-    transferAmount.value = (coinSatoshi / COIN).toString();
+    transferAmount.value = coinSatoshi / COIN;
 }
 
 async function importFromDatabase() {

--- a/scripts/dashboard/TransferMenu.vue
+++ b/scripts/dashboard/TransferMenu.vue
@@ -36,7 +36,9 @@ const props = defineProps({
 
 const address = defineModel('address');
 
-watch(address, () => getAddressColor(value).then((c) => (color.value = c)));
+watch(address, (value) =>
+    getAddressColor(value).then((c) => (color.value = `${c} !important`))
+);
 
 const amount = defineModel('amount', {
     set(value) {

--- a/scripts/dashboard/TransferMenu.vue
+++ b/scripts/dashboard/TransferMenu.vue
@@ -143,6 +143,7 @@ async function selectContact() {
                             autocomplete="nope"
                             onkeydown="javascript: return event.keyCode == 69 ? false : true"
                             data-testid="amount"
+                            @input="syncAmountCurrency"
                             v-model="amount"
                         />
                         <div class="input-group-append">

--- a/scripts/dashboard/TransferMenu.vue
+++ b/scripts/dashboard/TransferMenu.vue
@@ -34,23 +34,17 @@ const props = defineProps({
     publicMode: Boolean,
 });
 
-const address = computed({
-    get() {
-        return props.address;
-    },
+const address = defineModel('address');
+
+watch(address, () => getAddressColor(value).then((c) => (color.value = c)));
+
+const amount = defineModel('amount', {
     set(value) {
-        emit('update:address', value);
-        getAddressColor(value).then((c) => (color.value = c));
+        return value.toString();
     },
 });
-const amount = computed({
-    get() {
-        return props.amount;
-    },
-    set(value) {
-        emit('update:amount', value.toString());
-    },
-});
+
+watch(amount, () => syncAmountCurrency());
 
 function send() {
     // TODO: Maybe in the future do one of those cool animation that set the
@@ -149,7 +143,6 @@ async function selectContact() {
                             autocomplete="nope"
                             onkeydown="javascript: return event.keyCode == 69 ? false : true"
                             data-testid="amount"
-                            @input="$nextTick(syncAmountCurrency)"
                             v-model="amount"
                         />
                         <div class="input-group-append">


### PR DESCRIPTION
## Abstract

Changed address and amount to use the more modern `defineModel` and `watch`.
Changed amountCurrency to sync based on a watch on the `amount` variable. To prevent recursion, `amount` still syncs based on inputs on the amount currency box.

## Testing
- Test that amountCurrency syncs with amount even when pressing the max button.