### PR TITLE
Add automatic node switching

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -6,7 +6,6 @@ import { wallet, hasEncryptedWallet, Wallet } from './wallet.js';
 import { getNetwork } from './network.js';
 import {
     start as settingsStart,
-    cExplorer,
     strCurrency,
     fAdvancedMode,
 } from './settings.js';
@@ -389,12 +388,13 @@ export function optimiseCurrencyLocale(nAmount) {
  * @param {string?} strAddress - Optional address to open, if void, the master key is used
  */
 export async function openExplorer(strAddress = '') {
+    const strExplorerURL = getNetwork().strUrl;
     if (wallet.isLoaded() && wallet.isHD() && !strAddress) {
         const xpub = wallet.getXPub();
-        window.open(cExplorer.url + '/xpub/' + xpub, '_blank');
+        window.open(strExplorerURL + '/xpub/' + xpub, '_blank');
     } else {
         const address = strAddress || wallet.getAddress();
-        window.open(cExplorer.url + '/address/' + address, '_blank');
+        window.open(strExplorerURL + '/address/' + address, '_blank');
     }
 }
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -10,7 +10,6 @@ import.meta.webpackContext('@fontsource/montserrat/', {
     regExp: /\.css$/,
 });
 import './global.js';
-import { getNetwork } from './network.js';
 
 // Export global functions to the MPW namespace so we can use them in html
 export {

--- a/scripts/masternode.js
+++ b/scripts/masternode.js
@@ -10,7 +10,7 @@ import { OP } from './script.js';
 import bs58 from 'bs58';
 import base32 from 'base32';
 import { isStandardAddress } from './misc.js';
-import { fetchBlockbook, getNetwork, retryWrapper } from './network.js';
+import { getNetwork } from './network.js';
 
 /**
  * Construct a Masternode
@@ -187,16 +187,6 @@ export default class Masternode {
     }
 
     /**
-     * @return {Promise<string>} The last block hash
-     */
-    static async getLastBlockHash() {
-        const status = await (
-            await retryWrapper(fetchBlockbook, true, `/api/`)
-        ).json();
-        return status.backend.bestBlockHash;
-    }
-
-    /**
      * @return {Promise<string>} The signed message signed with the collateral private key
      */
     async getSignedMessage(sigTime) {
@@ -278,7 +268,7 @@ export default class Masternode {
      */
     async broadcastMessageToHex() {
         const sigTime = Math.round(Date.now() / 1000);
-        const blockHash = await Masternode.getLastBlockHash();
+        const blockHash = await getNetwork().getBestBlockHash();
         let ip, port;
         if (this.addr.includes('.')) {
             // IPv4

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -43,7 +43,7 @@ import { Transaction } from './transaction.js';
  */
 
 /**
- * Virtual class rapresenting any network backend
+ * Virtual class representing any network backend
  *
  */
 export class Network {

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -8,7 +8,7 @@ import {
 } from './debug.js';
 import { sleep } from './utils.js';
 import { getEventEmitter } from './event_bus.js';
-import { setExplorer, fAutoSwitch } from './settings.js';
+import { setExplorer, fAutoSwitch, setNode } from './settings.js';
 import { cNode } from './settings.js';
 import { ALERTS, tr, translation } from './i18n.js';
 import { Transaction } from './transaction.js';
@@ -115,7 +115,7 @@ export class ExplorerNetwork extends Network {
 
     async getBlockCount() {
         const { backend } = await (
-            await retryWrapper(fetchBlockbook, `/api/v2/api`)
+            await retryWrapper(fetchBlockbook, true, `/api/v2/api`)
         ).json();
 
         return backend.blocks;
@@ -133,7 +133,7 @@ export class ExplorerNetwork extends Network {
         let error;
         while (trials < maxTrials) {
             trials += 1;
-            const res = await retryWrapper(fetchBlockbook, strCommand);
+            const res = await retryWrapper(fetchBlockbook, true, strCommand);
             if (!res.ok) {
                 try {
                     error = (await res.json()).error;
@@ -240,7 +240,11 @@ export class ExplorerNetwork extends Network {
             let publicKey = strAddress;
             // Fetch UTXOs for the key
             const arrUTXOs = await (
-                await retryWrapper(fetchBlockbook, `/api/v2/utxo/${publicKey}`)
+                await retryWrapper(
+                    fetchBlockbook,
+                    true,
+                    `/api/v2/utxo/${publicKey}`
+                )
             ).json();
             return arrUTXOs;
         } catch (e) {
@@ -255,14 +259,14 @@ export class ExplorerNetwork extends Network {
      */
     async getXPubInfo(strXPUB) {
         return await (
-            await retryWrapper(fetchBlockbook, `/api/v2/xpub/${strXPUB}`)
+            await retryWrapper(fetchBlockbook, true, `/api/v2/xpub/${strXPUB}`)
         ).json();
     }
 
     async sendTransaction(hex) {
         try {
             const data = await (
-                await retryWrapper(fetchBlockbook, '/api/v2/sendtx/', {
+                await retryWrapper(fetchBlockbook, true, '/api/v2/sendtx/', {
                     method: 'post',
                     body: hex,
                 })
@@ -281,7 +285,11 @@ export class ExplorerNetwork extends Network {
     }
 
     async getTxInfo(txHash) {
-        const req = await retryWrapper(fetchBlockbook, `/api/v2/tx/${txHash}`);
+        const req = await retryWrapper(
+            fetchBlockbook,
+            true,
+            `/api/v2/tx/${txHash}`
+        );
         return await req.json();
     }
 
@@ -289,7 +297,9 @@ export class ExplorerNetwork extends Network {
      * @return {Promise<Number[]>} The list of blocks which have at least one shield transaction
      */
     async getShieldBlockList() {
-        return await (await fetch(`${cNode.url}/getshieldblocks`)).json();
+        return await (
+            await retryWrapper(fetchNode, false, `/getshieldblocks`)
+        ).json();
     }
 }
 
@@ -322,22 +332,38 @@ export function fetchBlockbook(api, options) {
 }
 
 /**
- * A wrapper for Blockbook calls which can, in the event of an unresponsive explorer,
- * seamlessly attempt the same call on multiple other explorers until success.
+ * A Fetch wrapper which uses the current Node's base URL
+ * @param {string} api - The specific Node api to call
+ * @param {RequestInit} options - The Fetch options
+ * @returns {Promise<Response>} - The unresolved Fetch promise
+ */
+export function fetchNode(api, options) {
+    return fetch(cNode.url + api, options);
+}
+
+/**
+ * A wrapper for Blockbook and Node calls which can, in the event of an unresponsive instance,
+ * seamlessly attempt the same call on multiple other instances until success.
  * @param {Function} func - The function to re-attempt with
+ * @param {boolean} isExplorer - Whether this is an Explorer or Node call
  * @param  {...any} args - The arguments to pass to the function
  */
-async function retryWrapper(func, ...args) {
+export async function retryWrapper(func, isExplorer, ...args) {
     // Track internal errors from the wrapper
     let err;
 
-    // If allowed by the user, Max Tries is ALL MPW-supported explorers, otherwise, restrict to only the current one.
-    let nMaxTries = cChainParams.current.Explorers.length;
+    // Select the instances list to use - Explorers or Nodes
+    const arrInstances = isExplorer
+        ? cChainParams.current.Explorers
+        : cChainParams.current.Nodes;
+
+    // If allowed by the user, Max Tries is ALL MPW-supported instances, otherwise, restrict to only the current one.
+    let nMaxTries = arrInstances.length + 1;
     let retries = 0;
 
-    // The explorer index we started at
-    let nIndex = cChainParams.current.Explorers.findIndex(
-        (a) => a.url === getNetwork().strUrl
+    // The instance index we started at
+    let nIndex = arrInstances.findIndex((a) =>
+        a.url === isExplorer ? getNetwork().strUrl : cNode.url
     );
 
     // Run the call until successful, or all attempts exhausted
@@ -354,15 +380,20 @@ async function retryWrapper(func, ...args) {
         } catch (error) {
             err = error;
 
-            // If allowed, switch explorers
+            // If allowed, switch instances
             if (!fAutoSwitch) throw err;
-            nIndex = (nIndex + 1) % cChainParams.current.Explorers.length;
-            const cNewExplorer = cChainParams.current.Explorers[nIndex];
+            nIndex = (nIndex + 1) % arrInstances.length;
+            const cNewInstance = arrInstances[nIndex];
 
-            // Set the explorer at Network-class level, then as a hacky workaround for the current callback; we
-            // ... adjust the internal URL to the new explorer.
-            getNetwork().strUrl = cNewExplorer.url;
-            setExplorer(cNewExplorer, true);
+            if (isExplorer) {
+                // Set the explorer at Network-class level, then as a hacky workaround for the current callback; we
+                // ... adjust the internal URL to the new explorer.
+                getNetwork().strUrl = cNewInstance.url;
+                setExplorer(cNewInstance, true);
+            } else {
+                // For the Node, we change the setting directly
+                setNode(cNewInstance, true);
+            }
 
             // Bump the attempts, and re-try next loop
             retries++;

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -64,6 +64,17 @@ export class Network {
     async getTxInfo(_txHash) {
         throw new Error('getTxInfo must be implemented');
     }
+
+    /**
+     * A safety-wrapped RPC interface for calling Node RPCs with automatic correction handling
+     * @param {string} api - The API endpoint to call
+     * @param {boolean} isText - Optionally parse the result as Text rather than JSON
+     * @returns {Promise<object|string>} - The RPC response; JSON by default, text if `isText` is true.
+     */
+    async callRPC(api, isText = false) {
+        const cRes = await retryWrapper(fetchNode, false, api);
+        return isText ? await cRes.text() : await cRes.json();
+    }
 }
 
 /**
@@ -297,9 +308,7 @@ export class ExplorerNetwork extends Network {
      * @return {Promise<Number[]>} The list of blocks which have at least one shield transaction
      */
     async getShieldBlockList() {
-        return await (
-            await retryWrapper(fetchNode, false, `/getshieldblocks`)
-        ).json();
+        return await this.callRPC('/getshieldblocks');
     }
 }
 

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -57,6 +57,10 @@ export class Network {
         throw new Error('getBlockCount must be implemented');
     }
 
+    getBestBlockHash() {
+        throw new Error('getBestBlockHash must be implemented');
+    }
+
     sendTransaction() {
         throw new Error('sendTransaction must be implemented');
     }
@@ -124,12 +128,28 @@ export class ExplorerNetwork extends Network {
         return block;
     }
 
+    /**
+     * Fetch the block height of the current explorer
+     * @returns {Promise<number>} - Block height
+     */
     async getBlockCount() {
         const { backend } = await (
             await retryWrapper(fetchBlockbook, true, `/api/v2/api`)
         ).json();
 
         return backend.blocks;
+    }
+
+    /**
+     * Fetch the latest block hash of the current explorer
+     * @returns {Promise<string>} - Block hash
+     */
+    async getBestBlockHash() {
+        const { backend } = await (
+            await retryWrapper(fetchBlockbook, true, `/api/v2/api`)
+        ).json();
+
+        return backend.bestBlockHash;
     }
 
     /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -238,10 +238,13 @@ export async function setExplorer(explorer, fSilent = false) {
         );
 }
 
-async function setNode(node, fSilent = false) {
+export async function setNode(node, fSilent = false) {
     cNode = node;
     const database = await Database.getInstance();
     database.setSettings({ node: node.url });
+
+    // Update the selector UI
+    doms.domNodeSelect.value = cNode.url;
 
     if (!fSilent)
         createAlert(


### PR DESCRIPTION
## Abstract

This PR adds the ability for MPW to auto-switch between Nodes, using the same logic as Blockbook auto-switching.

It also fixes a small bug that made the 're-try' attempts too low due to not accounting for array wrapping, so if MPW was on the 'last' available instance, `nMaxRetries` was `1` less than the attempts required to wrap back to `instance[0]`, leading to premature error notifications. This will probably help resolve some of the notification spam, as MPW will properly try *all* instances before giving up.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Try blocking an instance (Explorer or Node), see if MPW auto-switches without user-facing errors.
- Test Masternode + Governance functions, which have been adjusted to use the re-attempt system for stability.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---