### PR TITLE
Remove console.logs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
         ],
         "no-empty": ["error", { "allowEmptyCatch": true }],
         "no-constant-condition": "off",
-        "@typescript-eslint/no-empty-function": "off"
+        "@typescript-eslint/no-empty-function": "off",
+        "no-console": "error"
     }
 }

--- a/debug_config.json
+++ b/debug_config.json
@@ -2,5 +2,11 @@
     "net": true,
     "global": true,
     "wallet": true,
-    "mempool": true
+    "mempool": true,
+    "aes_gcm": true,
+    "database": true,
+    "governance": true,
+    "i18n": true,
+    "ledger": true,
+    "masternode": true
 }

--- a/scripts/__mocks__/network.js
+++ b/scripts/__mocks__/network.js
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { Transaction } from '../transaction.js';
+import { DebugTopics, debugWarn } from '../debug.js';
 
 export const getNetwork = vi.fn(() => {
     return globalNetwork;
@@ -62,7 +63,8 @@ class TestNetwork {
                     '0100000001458de14f4f4fecfdeebfef09fb16e761bbd15029f37bec0a63b86808cbb8a512010000006b483045022100ef4f4364aea7604d749aaff7a2609e3a51a12f49500b7910b34ced0d0837e1db022012d153d96ebcb94e9b905a609c0ea97cdc99ae961be2848e0e8f2f695379c21201210371eca6799221b82cbba9e880a8a5a0f47d811f3ff5cad346931406ab0a0469eeffffffff0200e1f505000000001976a9148952bf31104625a7b3e6fcf4c79b35c6849ef74d88ac905cfb2f010000001976a9144e8d2fcf6d909c62597e4defd1c26d50842d73df88ac00000000';
                 await wallet.addTransaction(Transaction.fromHex(tx_1));
             } else {
-                console.warn(
+                debugWarn(
+                    DebugTopics.NET,
                     'getLatestTxs did not find any txs this wallet! ' +
                         wallet.getKeyToExport()
                 );

--- a/scripts/aes-gcm.js
+++ b/scripts/aes-gcm.js
@@ -1,4 +1,4 @@
-import { debugError, DebugTopics } from './debug';
+import { debugError, DebugTopics } from './debug.js';
 
 const buff_to_base64 = (buff) => btoa(String.fromCharCode.apply(null, buff));
 

--- a/scripts/aes-gcm.js
+++ b/scripts/aes-gcm.js
@@ -1,3 +1,5 @@
+import { debugError, DebugTopics } from './debug';
+
 const buff_to_base64 = (buff) => btoa(String.fromCharCode.apply(null, buff));
 
 const base64_to_buf = (b64) =>
@@ -73,7 +75,8 @@ async function encryptData(secretData, password) {
         buff.set(encryptedContentArr, salt.byteLength + iv.byteLength);
         return buff_to_base64(buff);
     } catch (e) {
-        console.log(`Error - ${e}`);
+        debugError(DebugTopics.AES_GCM, `Error while encrypting`);
+        debugError(DebugTopics.AES_GCM, e);
         return '';
     }
 }
@@ -96,7 +99,8 @@ async function decryptData(encryptedData, password) {
         );
         return dec.decode(decryptedContent);
     } catch (e) {
-        console.log(`Error - ${e}`);
+        debugError(DebugTopics.AES_GCM, `Error while decrypting`);
+        debugError(DebugTopics.AES_GCM, e);
         return '';
     }
 }

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -13,6 +13,7 @@ import { PromoWallet } from './promos.js';
 import { ALERTS, translation } from './i18n.js';
 import { Account } from './accounts.js';
 import { COutpoint, CTxIn, CTxOut, Transaction } from './transaction.js';
+import { debugError, debugLog, DebugTopics } from './debug.js';
 
 export class Database {
     /**
@@ -118,11 +119,11 @@ export class Database {
     async addAccount(account) {
         // Critical: Ensure the input is an Account instance
         if (!(account instanceof Account)) {
-            console.error(
+            debugError(
                 '---- addAccount() called with invalid input, input dump below ----'
             );
-            console.error(account);
-            console.error('---- end of account dump ----');
+            debugError(DebugTopics.DATABASE, account);
+            debugError(DebugTopics.DATABASE, '---- end of account dump ----');
             createAlert(
                 'warning',
                 '<b>Account Creation Error</b><br>Logs were dumped in your Browser Console<br>Please submit these privately to PIVX Labs Developers!'
@@ -141,7 +142,8 @@ export class Database {
         for (const strKey of Object.keys(cDBAccount)) {
             // Ensure the Type is correct for the Key against the Account class
             if (!isSameType(account[strKey], cDBAccount[strKey])) {
-                console.error(
+                debugError(
+                    DebugTopics.DATABASE,
                     'DB: addAccount() key "' +
                         strKey +
                         '" does NOT match the correct class type, likely data mismatch, please report!'
@@ -183,11 +185,12 @@ export class Database {
     async updateAccount(account, allowDeletion = false) {
         // Critical: Ensure the input is an Account instance
         if (!(account instanceof Account)) {
-            console.error(
+            debugError(
+                DebugTopics.DATABASE,
                 '---- updateAccount() called with invalid input, input dump below ----'
             );
-            console.error(account);
-            console.error('---- end of account dump ----');
+            debugError(DebugTopics.DATABASE, account);
+            debugError(DebugTopics.DATABASE, '---- end of account dump ----');
             createAlert(
                 'warning',
                 '<b>DB Update Error</b><br>Your wallet is safe, logs were dumped in your Browser Console<br>Please submit these privately to PIVX Labs Developers!'
@@ -203,11 +206,12 @@ export class Database {
         // If none exists; we should throw an error, as there's no reason for MPW to call `updateAccount` before an account was added using `addAccount`
         // Note: This is mainly to force "good standards" in which we don't lazily use `updateAccount` to create NEW accounts.
         if (!cDBAccount) {
-            console.error(
+            debugError(
+                DebugTopics.DATABASE,
                 '---- updateAccount() called without an account existing, input dump below ----'
             );
-            console.error(account);
-            console.error('---- end of input dump ----');
+            debugError(DebugTopics.DATABASE, account);
+            debugError(DebugTopics.DATABASE, '---- end of input dump ----');
             createAlert(
                 'warning',
                 '<b>DB Update Error</b><br>Logs were dumped in your Browser Console<br>Please submit these privately to PIVX Labs Developers!'
@@ -223,7 +227,8 @@ export class Database {
         for (const strKey of Object.keys(cDBAccount)) {
             // Ensure the Type is correct for the Key against the Account class
             if (!isSameType(account[strKey], cDBAccount[strKey])) {
-                console.error(
+                debugError(
+                    DebugTopics.DATABASE,
                     'DB: updateAccount() key "' +
                         strKey +
                         '" does NOT match the correct class type, likely data mismatch, please report!'
@@ -283,7 +288,8 @@ export class Database {
 
             // Ensure the Type is correct for the Key against the Account class (with instanceof to also check Class validity)
             if (!isSameType(cDBAccount[strKey], cAccount[strKey])) {
-                console.error(
+                debugError(
+                    DebugTopics.DATABASE,
                     'DB: getAccount() key "' +
                         strKey +
                         '" does NOT match the correct class type, likely bad data saved, please report!'
@@ -425,7 +431,8 @@ export class Database {
         const database = new Database({ db: null });
         const db = await openDB(`MPW-${name}`, Database.version, {
             upgrade: (db, oldVersion, _, transaction) => {
-                console.log(
+                debugLog(
+                    DebugTopics.DATABASE,
                     'DB: Upgrading from ' +
                         oldVersion +
                         ' to ' +

--- a/scripts/debug.js
+++ b/scripts/debug.js
@@ -1,26 +1,17 @@
+/* eslint-disable no-console */
+
 import { debug } from './settings.js';
 import debugParams from '../debug_config.json';
 
 /**
- * Execute a given function if we are in debug mode
- * @param {Function} func - a function we want to execute
- * @param {...any} args - The arguments to pass to the function
- */
-function debugEval(func, ...args) {
-    if (debug) {
-        func(...args);
-    }
-}
-
-/**
- * Execute a given function if we are in debug mode and the provided topic is in the filtered list
+ * Execute a given function if the provided topic is in the filtered list
  * @param {Function} func - a function we want to execute
  * @param {DebugTopic} topic - the topic of the debug
  * @param {...any} args - The arguments to pass to the function
  */
 function debugEvalFilter(func, topic, ...args) {
     if (topic.value & enabledDebug) {
-        debugEval(func, ...args);
+        func(...args);
     }
 }
 /**
@@ -29,11 +20,13 @@ function debugEvalFilter(func, topic, ...args) {
  * @param args - arguments to print
  */
 export function debugLog(topic, ...args) {
-    debugEvalFilter(console.log, topic, topic.name, ...args);
+    if (debug) {
+        debugEvalFilter(console.log, topic, topic.name, ...args);
+    }
 }
 
 /**
- * call console.warn if we are in debug mode
+ * call console.warn
  * @param {DebugTopic} topic - topic of the debug
  * @param args - arguments to print
  */
@@ -42,7 +35,7 @@ export function debugWarn(topic, ...args) {
 }
 
 /**
- * call console.error if we are in debug mode
+ * call console.error
  * @param {DebugTopic} topic - topic of the debug
  * @param args - arguments to print
  */
@@ -56,7 +49,9 @@ export function debugError(topic, ...args) {
  * @param {String} label - the label of the timer
  */
 export function debugTimerStart(topic, label) {
-    debugEvalFilter(console.time, topic, topic.name + ' ' + label);
+    if (debug) {
+        debugEvalFilter(console.time, topic, topic.name + ' ' + label);
+    }
 }
 
 /**
@@ -65,7 +60,9 @@ export function debugTimerStart(topic, label) {
  * @param {String} label - the label of the timer
  */
 export function debugTimerEnd(topic, label) {
-    debugEvalFilter(console.timeEnd, topic, topic.name + ' ' + label);
+    if (debug) {
+        debugEvalFilter(console.timeEnd, topic, topic.name + ' ' + label);
+    }
 }
 
 class DebugTopic {
@@ -79,6 +76,12 @@ export const DebugTopics = {
     GLOBAL: new DebugTopic('[GLOBAL]', 1 << 1),
     WALLET: new DebugTopic('[WALLET]', 1 << 2),
     MEMPOOL: new DebugTopic('[MEMPOOL]', 1 << 3),
+    AES_GCM: new DebugTopic('[AES_GMC]', 1 << 4),
+    DATABASE: new DebugTopic('[DATABASE]', 1 << 5),
+    GOVERNANCE: new DebugTopic('[GOVERNANCE]', 1 << 6),
+    I18N: new DebugTopic('[I18N]', 1 << 7),
+    LEDGER: new DebugTopic('[LEDGER]', 1 << 8),
+    MASTERNODE: new DebugTopic('[MASTERNODE]', 1 << 9),
 };
 
 let enabledDebug = 0;

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -21,7 +21,7 @@ import { checkForUpgrades } from './changelog.js';
 import { FlipDown } from './flipdown.js';
 import { createApp } from 'vue';
 import Dashboard from './dashboard/Dashboard.vue';
-import { loadDebug, debugLog, DebugTopics } from './debug.js';
+import { loadDebug, debugLog, DebugTopics, debugError } from './debug.js';
 import Stake from './stake/Stake.vue';
 import { createPinia } from 'pinia';
 import { cOracle } from './prices.js';
@@ -306,8 +306,8 @@ function subscribeToNetworkEvents() {
                 result ? 1250 + result.length * 50 : 3000
             );
         } else {
-            console.error('Error sending transaction:');
-            console.error(result);
+            debugError(DebugTopics.NET, 'Error sending transaction:');
+            debugError(DebugTopics.NET, result);
             createAlert('warning', ALERTS.TX_FAILED, 2500);
         }
     });
@@ -498,7 +498,7 @@ export async function govVote(hash, voteCode) {
                 createAlert('warning', ALERTS.VOTE_SIG_BAD, 6000);
             } else {
                 //this could be everything
-                console.error(result);
+                debugError(DebugTopics.GOVERNANCE, result);
                 createAlert('warning', ALERTS.INTERNAL_ERROR, 6000);
             }
         } else {

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -5,6 +5,7 @@ import { wallet } from './wallet.js';
 import { cReceiveType, guiToggleReceiveType } from './contacts-book.js';
 import { reactive } from 'vue';
 import { negotiateLanguages } from '@fluent/langneg';
+import { debugLog, DebugTopics } from './debug.js';
 
 /**
  * @type {translation_template}
@@ -127,7 +128,8 @@ export async function switchTranslation(langName) {
         }
         return true;
     } else {
-        console.log(
+        debugLog(
+            DebugTopics.I18N,
             'i18n: The language (' +
                 langName +
                 ") is not supported yet, if you'd like to contribute translations (for rewards!) contact us on GitHub or Discord!"

--- a/scripts/ledger.js
+++ b/scripts/ledger.js
@@ -6,6 +6,7 @@ import { Transaction } from './transaction.js';
 import { COIN, cChainParams } from './chain_params.js';
 import { hexToBytes, bytesToHex } from './utils.js';
 import { OP } from './script.js';
+import { debugError, DebugTopics } from './debug.js';
 
 /**
  * @type{import('@ledgerhq/hw-transport-webusb').default}
@@ -111,13 +112,15 @@ export async function getHardwareWalletKeys(path, xpub = false, verify = true) {
                 createAlert('warning', ALERTS.WALLET_HARDWARE_NO_ACCESS, 5500);
             }
 
-            console.error(e);
+            debugError(DebugTopics.LEDGER, e);
             return;
         }
 
         // Check if this is an expected error
         if (!e.statusCode || !LEDGER_ERRS.has(e.statusCode)) {
-            console.error(
+            debugError(DebugTopics.LEDGER, e);
+            debugError(
+                DebugTopics.LEDGER,
                 'MISSING LEDGER ERROR-CODE TRANSLATION! - Please report this below error on our GitHub so we can handle it more nicely!'
             );
             throw e;

--- a/scripts/masternode.js
+++ b/scripts/masternode.js
@@ -11,6 +11,7 @@ import bs58 from 'bs58';
 import base32 from 'base32';
 import { isStandardAddress } from './misc.js';
 import { getNetwork } from './network.js';
+import { debugError, DebugTopics } from './debug.js';
 
 /**
  * Construct a Masternode
@@ -61,7 +62,7 @@ export default class Masternode {
             }
         } catch (e) {
             //this is the unfortunate state in which the node is not reachable
-            console.error(e);
+            debugError(DebugTopics.MASTERNODE, e);
             return 'EXPLORER_DOWN';
         }
     }
@@ -537,7 +538,7 @@ export default class Masternode {
                 return { ok: false, err: 'other' };
             }
         } catch (e) {
-            console.error(e);
+            debugError(DebugTopics.MASTERNODE, e);
             return { ok: false, err: e };
         }
     }

--- a/scripts/native-worker.js
+++ b/scripts/native-worker.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 // Listen for native worker installs
 self.addEventListener('install', function (_event) {
     console.log('[ServiceWorker] Install');

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -1,6 +1,7 @@
 import { cChainParams } from './chain_params.js';
 import { createAlert } from './misc.js';
 import {
+    debugError,
     debugLog,
     debugTimerEnd,
     debugTimerStart,
@@ -279,7 +280,7 @@ export class ExplorerNetwork extends Network {
             ).json();
             return arrUTXOs;
         } catch (e) {
-            console.error(e);
+            debugError(DebugTopics.NET, e);
         }
     }
 
@@ -306,7 +307,7 @@ export class ExplorerNetwork extends Network {
             // Throw and catch if the data is not a TXID
             if (!data.result || data.result.length !== 64) throw data;
 
-            console.log('Transaction sent! ' + data.result);
+            debugLog(DebugTopics.NET, 'Transaction sent! ' + data.result);
             getEventEmitter().emit('transaction-sent', true, data.result);
             return data.result;
         } catch (e) {

--- a/scripts/prices.js
+++ b/scripts/prices.js
@@ -1,3 +1,4 @@
+import { DebugTopics, debugWarn } from './debug.js';
 import { getEventEmitter } from './event_bus.js';
 import { sleep } from './utils.js';
 
@@ -71,12 +72,13 @@ export class Oracle {
             // And finally return it
             return cCurrency.value;
         } catch (e) {
-            console.warn(
+            debugWarn(
+                DebugTopics.NET,
                 'Oracle: Failed to fetch ' +
                     strCurrency.toUpperCase() +
                     ' price!'
-            );
-            console.warn(e);
+            ),
+                debugWarn(DebugTopics.NET, e);
             return this.getCachedPrice(strCurrency);
         }
     }
@@ -108,8 +110,9 @@ export class Oracle {
             this.#fLoadedCurrencies = true;
             return arrCurrencies;
         } catch (e) {
-            console.warn('Oracle: Failed to fetch currencies!');
-            console.warn(e);
+            debugWarn(DebugTopics.NET, 'Oracle: Failed to fetch currencies!'),
+                debugWarn(DebugTopics.NET, e);
+
             return this.getCachedCurrencies();
         }
     }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -33,6 +33,7 @@ import { PIVXShield } from 'pivx-shield';
 import { guiToggleReceiveType } from './contacts-book.js';
 import { TransactionBuilder } from './transaction_builder.js';
 import { AsyncInterval } from './async_interval.js';
+import { debugError, DebugTopics } from './debug.js';
 /**
  * Class Wallet, at the moment it is just a "realization" of Masterkey with a given nAccount
  * it also remembers which addresses we generated.
@@ -764,7 +765,7 @@ export class Wallet {
             );
             getEventEmitter().emit('shield-sync-status-update', 0, 0, true);
         } catch (e) {
-            console.error(e);
+            debugError(DebugTopics.WALLET, e);
         }
 
         // At this point it should be safe to assume that shield is ready to use
@@ -852,7 +853,7 @@ export class Wallet {
                     }
                     this.#lastProcessedBlock = blockHeight;
                 } catch (e) {
-                    console.error(e);
+                    debugError(DebugTopics.WALLET, e);
                     break;
                 }
             }


### PR DESCRIPTION
## Abstract

Remove console.logs and use the debug config we have
Add no-console lint as an error, so we avoid merging PRs with left over console.logs

Console.logs can still be used for temporary debugging, but if we want a permanent log we must use the debug functions. 

## Testing
- Watch the console emit logs