### PR TITLE
Add ability for MPW to run explorer-less

### DIFF
--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -130,9 +130,9 @@ const emit = defineEmits([
 
 getEventEmitter().on(
     'transparent-sync-status-update',
-    (i, totalPages, finished, message) => {
+    (i, totalPages, finished, warning) => {
         const str =
-            message ||
+            warning ||
             tr(translation.syncStatusHistoryProgress, [
                 { current: totalPages - i + 1 },
                 { total: totalPages },

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -508,16 +508,16 @@ function restoreWallet() {
                 </div>
                 <div style="width: 100%">
                     {{
-                        transparentSyncing
-                            ? syncTStr
-                            : `Syncing ${shieldBlockRemainingSyncing} Blocks...`
+                        shieldSyncing
+                            ? `Syncing ${shieldBlockRemainingSyncing} Blocks...`
+                            : syncTStr
                     }}
                     <LoadingBar
                         :show="true"
                         :percentage="
-                            transparentSyncing
-                                ? transparentProgressSyncing
-                                : shieldPercentageSyncing
+                            shieldSyncing
+                                ? shieldPercentageSyncing 
+                                : transparentProgressSyncing
                         "
                         style="
                             border: 1px solid #932ecd;

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { cChainParams, COIN } from '../chain_params.js';
-import { translation } from '../i18n';
+import { translation, tr } from '../i18n';
 import { ref, computed, toRefs } from 'vue';
 import { beautifyNumber } from '../misc';
 import { getEventEmitter } from '../event_bus';
@@ -130,11 +130,13 @@ const emit = defineEmits([
 
 getEventEmitter().on(
     'transparent-sync-status-update',
-    (i, totalPages, finished) => {
-        const str = tr(translation.syncStatusHistoryProgress, [
-            { current: totalPages - i + 1 },
-            { total: totalPages },
-        ]);
+    (i, totalPages, finished, message) => {
+        const str =
+            message ||
+            tr(translation.syncStatusHistoryProgress, [
+                { current: totalPages - i + 1 },
+                { total: totalPages },
+            ]);
         const progress = ((totalPages - i) / totalPages) * 100;
         syncTStr.value = str;
         transparentProgressSyncing.value = progress;

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -516,7 +516,7 @@ function restoreWallet() {
                         :show="true"
                         :percentage="
                             shieldSyncing
-                                ? shieldPercentageSyncing 
+                                ? shieldPercentageSyncing
                                 : transparentProgressSyncing
                         "
                         style="

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -107,13 +107,7 @@ export class ExplorerNetwork extends Network {
             '&filter=' +
             encodeURI(`. | .txs = [.tx[] | { hex: .hex, txid: .txid}]`);
         // Fetch the full block (verbose)
-        const block = await this.callRPC(
-            `/getblock?params=${strHash},2${strFilter}`
-        );
-        // Always skip the coinbase transaction and in case the coinstake one
-        // TODO: once v6.0 and shield stake is activated we might need to change this optimization
-        block.txs = block.txs.slice(skipCoinstake ? 2 : 1);
-        return block;
+        return await this.callRPC(`/getblock?params=${strHash},2${strFilter}`);
     }
 
     /**

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -124,11 +124,11 @@ export class ExplorerNetwork extends Network {
             // Fetch the full block (verbose)
             block = await this.callRPC(`/getblock?params=${strHash},true`);
             // Fetch every Tx of the block (verbose)
-            block.txs = block.tx.map(async (a) => {
+            block.txs = await Promise.all(block.tx.map(async (a) => {
                 return await this.callRPC(
                     `/getrawtransaction?params=${a},true`
                 );
-            });
+            }));
         }
         const newTxs = [];
         // This is bad. We're making so many requests

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -92,12 +92,11 @@ export class ExplorerNetwork extends Network {
     }
 
     /**
-     * Fetch a block from the explorer given the height
+     * Fetch a block from the current node given the height
      * @param {number} blockHeight
-     * @param {boolean} skipCoinstake - if true coinstake tx will be skipped
-     * @returns {Promise<Object>} the block fetched from explorer
+     * @returns {Promise<Object>} the block
      */
-    async getBlock(blockHeight, skipCoinstake = false) {
+    async getBlock(blockHeight) {
         // First we fetch the blockhash (and strip RPC's quotes)
         const strHash = (
             await this.callRPC(`/getblockhash?params=${blockHeight}`, true)

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -115,14 +115,19 @@ export class ExplorerNetwork extends Network {
             // Use Nodes as fallback
             fUseNodes = true;
             // First we fetch the blockhash
-            let strHash = await this.callRPC(`/getblockhash?params=${blockHeight}`, true);
+            let strHash = await this.callRPC(
+                `/getblockhash?params=${blockHeight}`,
+                true
+            );
             // Strip quotes from the RPC response
             strHash = strHash.replace(/"/g, '');
             // Fetch the full block (verbose)
             block = await this.callRPC(`/getblock?params=${strHash},true`);
             // Fetch every Tx of the block (verbose)
-            block.txs = block.tx.map(async a => {
-                return await this.callRPC(`/getrawtransaction?params=${a},true`)
+            block.txs = block.tx.map(async (a) => {
+                return await this.callRPC(
+                    `/getrawtransaction?params=${a},true`
+                );
             });
         }
         const newTxs = [];

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -121,16 +121,16 @@ export class ExplorerNetwork extends Network {
             );
             // Strip quotes from the RPC response
             strHash = strHash.replace(/"/g, '');
+            // Craft a filter to retrieve only raw Tx hex and txid
+            const strFilter =
+                '&filter=' +
+                encodeURI(`. | .tx = [.tx[] | { hex: .hex, txid: .txid}]`);
             // Fetch the full block (verbose)
-            block = await this.callRPC(`/getblock?params=${strHash},true`);
-            // Fetch every Tx of the block (verbose)
-            block.txs = await Promise.all(
-                block.tx.map(async (a) => {
-                    return await this.callRPC(
-                        `/getrawtransaction?params=${a},true`
-                    );
-                })
+            block = await this.callRPC(
+                `/getblock?params=${strHash},2${strFilter}`
             );
+            // Shift the array to `txs` to match Blockbook format
+            block.txs = block.tx;
         }
         const newTxs = [];
         // This is bad. We're making so many requests

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -716,7 +716,14 @@ export class Wallet {
         } catch {
             // If all Explorers are down, we'll just rely on the local TXDB and display a warning
         }
-        getEventEmitter().emit('transparent-sync-status-update', fSynced ? '' : 'Explorers are unreachable, your wallet may not be fully synced!', fSynced ? 100 : 0, fSynced);
+        getEventEmitter().emit(
+            'transparent-sync-status-update',
+            fSynced
+                ? ''
+                : 'Explorers are unreachable, your wallet may not be fully synced!',
+            fSynced ? 100 : 0,
+            fSynced
+        );
     }
 
     /**

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -876,11 +876,9 @@ export class Wallet {
         async (blockCount) => {
             const cNet = getNetwork();
             let block;
-            // Don't ask for the exact last block that arrived,
-            // since it takes around 1 minute for blockbook to make it API available
             for (
-                let blockHeight = this.#lastProcessedBlock + 1;
-                blockHeight < blockCount;
+                let blockHeight = this.#lastProcessedBlock;
+                blockHeight <= blockCount;
                 blockHeight++
             ) {
                 try {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -786,7 +786,7 @@ export class Wallet {
             await startBatch(
                 async (i) => {
                     let block;
-                    block = await cNet.getBlock(blockHeights[i], true);
+                    block = await cNet.getBlock(blockHeights[i]);
                     downloaded++;
                     blocks[i] = block;
                     // We need to process blocks monotically

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -691,16 +691,13 @@ export class Wallet {
         if (this.#isSynced) {
             throw new Error('Attempting to sync when already synced');
         }
-        // While syncing the wallet ( DB read + network sync) disable the event balance-update
+        // While syncing the wallet (DB read + network sync) disable the event balance-update
         // This is done to avoid a huge spam of event.
         getEventEmitter().disableEvent('balance-update');
 
         await this.loadFromDisk();
         await this.loadShieldFromDisk();
-        // Let's set the last processed block 5 blocks behind the actual chain tip
-        // This is just to be sure since blockbook (as we know)
-        // usually does not return txs of the actual last block.
-        this.#lastProcessedBlock = blockCount - 5;
+        this.#lastProcessedBlock = blockCount;
         // Transparent sync is inherently less stable than Shield since it requires heavy
         // explorer indexing, so we'll attempt once asynchronously, and if it fails, set a
         // recurring "background" sync interval until it's finally successful.

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -709,8 +709,14 @@ export class Wallet {
     async #transparentSync() {
         if (!this.isLoaded() || this.#isSynced) return;
         const cNet = getNetwork();
-        await cNet.getLatestTxs(this);
-        getEventEmitter().emit('transparent-sync-status-update', '', '', true);
+        let fSynced = false;
+        try {
+            await cNet.getLatestTxs(this);
+            fSynced = true;
+        } catch {
+            // If all Explorers are down, we'll just rely on the local TXDB and display a warning
+        }
+        getEventEmitter().emit('transparent-sync-status-update', fSynced ? '' : 'Explorers are unreachable, your wallet may not be fully synced!', fSynced ? 100 : 0, fSynced);
     }
 
     /**

--- a/tests/integration/wallet/sync.spec.js
+++ b/tests/integration/wallet/sync.spec.js
@@ -22,7 +22,7 @@ vi.mock('../../../scripts/network.js');
  * @param{number} value - amounts to transfer
  * @returns {Promise<void>}
  */
-async function crateAndSendTransaction(wallet, address, value) {
+async function createAndSendTransaction(wallet, address, value) {
     const tx = wallet.createTransaction(address, value);
     await wallet.sign(tx);
     expect(getNetwork().sendTransaction(tx.serialize())).toBeTruthy();
@@ -65,7 +65,7 @@ describe('Wallet sync tests', () => {
     it('Basic 2 wallets sync test', async () => {
         // --- Verify that funds are received after sending a transaction ---
         // The legacy wallet sends the HD wallet 0.05 PIVs
-        await crateAndSendTransaction(
+        await createAndSendTransaction(
             walletLegacy,
             walletHD.getCurrentAddress(),
             0.05 * 10 ** 8
@@ -77,7 +77,7 @@ describe('Wallet sync tests', () => {
 
         // Sends funds back to the legacy wallet and verify that he also correctly receives funds
         const legacyBalance = walletLegacy.balance;
-        await crateAndSendTransaction(
+        await createAndSendTransaction(
             walletHD,
             walletLegacy.getCurrentAddress(),
             1 * 10 ** 8
@@ -100,7 +100,7 @@ describe('Wallet sync tests', () => {
                 path.slice(0, -1) + String(nAddress)
             );
             // Create a Tx to the new account address
-            await crateAndSendTransaction(
+            await createAndSendTransaction(
                 walletLegacy,
                 newAddress,
                 0.01 * 10 ** 8

--- a/tests/integration/wallet/sync.spec.js
+++ b/tests/integration/wallet/sync.spec.js
@@ -70,12 +70,8 @@ describe('Wallet sync tests', () => {
             walletHD.getCurrentAddress(),
             0.05 * 10 ** 8
         );
+
         // Mint the block with the transaction
-        await mineAndSync();
-        // getLatestBlocks sync up until chain tip - 1 block,
-        // so at this point walletHD doesn't still know about the UTXO he received
-        expect(walletHD.balance).toBe(1 * 10 ** 8);
-        // mine an empty block and verify that the tx arrived
         await mineAndSync();
         expect(walletHD.balance).toBe((1 + 0.05) * 10 ** 8);
 
@@ -103,13 +99,16 @@ describe('Wallet sync tests', () => {
             let newAddress = walletHD.getAddressFromPath(
                 path.slice(0, -1) + String(nAddress)
             );
+            // Create a Tx to the new account address
             await crateAndSendTransaction(
                 walletLegacy,
                 newAddress,
                 0.01 * 10 ** 8
             );
-            await mineAndSync();
+            // Validate the balance of the HD wallet pre-tx-confirm
             expect(walletHD.balance).toBe((1 + 0.01 * i) * 10 ** 8);
+            // Mine a block with the Tx
+            await mineAndSync();
         }
     });
     it('recognizes immature balance', async () => {


### PR DESCRIPTION
## Abstract

This PR allows the majority of MPW data, aside from heavily indexed (Pubkey/XPub) data, to be acquired from Node RPCs.

This was initially as a fix for MPW being completely unloadable when Explorers are down, due to being unable to fetch chain data, MPW can't even pass the "Loading" screen - however after getting in to the rabbit hole, this PR is able to replace the reliance on Explorers almost entirely and allow full access to MPW despite total explorer outage, relying instead on the internal TXDB, internal mempool, and public RPC data.

This PR adds the ability to use all MPW functions aside from Transparent Sync - Shield can be fully utilised as normal.

## RPC Layer Suggestions
This PR proposes the following RPCs be enabled on all RPC Servers supported by MPW:
`getblockcount, getblockhash, getblock, getbestblockhash, getrawtransaction, sendrawtransaction`

It would however be more efficient to develop a custom RPC layer API like `getblockbyheight`, it would just be `getblockhash` passed through `getblock`, halving the requests MPW needs to make for blockchain sync-via-RPC.

## TODOs

- [x] Add general endpoint fallbacks (getBlockCount, getBestBlockHash, getBlock, getRawTx, etc).
- [x] Allow Shield synchronisation via Nodes.
- [x] Allow a "complete" usable wallet state without Explorers based on TXDB + internal mempool. (Activity, Sending).
- [x] Figure out how to gracefully handle the state in which `Shield` is synced and ready, but `Transparent` is not.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test that MPW loads and opens as expected, without explorers.
- Test that Shield continues to sync, transact and confirm, without explorers.
- Test that Shield is capable of syncing from scratch, without explorers.
- Test transactions, without explorers.
- Test that, after initially failing to sync transparent, the delayed sync is successful and stable.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---