### PR TITLE
Decouple Wallet and Network

### DIFF
--- a/scripts/__mocks__/network.js
+++ b/scripts/__mocks__/network.js
@@ -35,42 +35,34 @@ class TestNetwork {
     get enabled() {
         return true;
     }
+    getNumPages = vi.fn(() => {
+        return 1;
+    });
 
-    getLatestTxs = vi.fn(
-        /**
-         * @param {import('../wallet.js').Wallet}wallet
-         * @returns {Promise<void>}
-         */
-        async (wallet) => {
-            if (wallet.isSynced) {
-                throw new Error('Wallet already synced!');
-            }
-            if (
-                wallet.getKeyToExport() === 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC'
-            ) {
-                // 1) Legacy mainnet wallet
-                // tx_1 provides a spendable balance of 0.1 * 10^8 satoshi
-                const tx_1 =
-                    '010000000138f9c8ac1b4c6ad54e487206daad1fd12bae510dd70fbd2dc928f617ef6b4a47010000006a47304402200d01891ac5dc6d25452cadbe7ba7edd98143631cc2922da45dde94919593b222022066ef14c01c165a1530e2acf74bcd8648d7151b555fa0bfd0222c33e983091678012102033a004cb71693e809c45e1e491bc797654fa0c012be9dd46401ce8368beb705ffffffff02d02c5d05000000001976a91463fa54dad2e215ec21c54ff45a195d49b570b97988ac80969800000000001976a914f49b25384b79685227be5418f779b98a6be4c73888ac00000000';
-                await wallet.addTransaction(Transaction.fromHex(tx_1));
-            } else if (
-                wallet.getKeyToExport() ===
-                'xpub6DVaPT3irDwUth7Y6Ff137FgA9jjvsmA2CHD7g2vjvvuMiNSUJRs9F8jSoPpXpc1s7ohR93dNAuzR5T2oPZFDTn7G2mHKYtpwtk7krNZmnV'
-            ) {
-                // 2) HD mainnet wallet
-                // tx_1 provides a spendable balance of 1 * 10^8 satoshi to the address with path m/44'/119'/0'/0/0
-                const tx_1 =
-                    '0100000001458de14f4f4fecfdeebfef09fb16e761bbd15029f37bec0a63b86808cbb8a512010000006b483045022100ef4f4364aea7604d749aaff7a2609e3a51a12f49500b7910b34ced0d0837e1db022012d153d96ebcb94e9b905a609c0ea97cdc99ae961be2848e0e8f2f695379c21201210371eca6799221b82cbba9e880a8a5a0f47d811f3ff5cad346931406ab0a0469eeffffffff0200e1f505000000001976a9148952bf31104625a7b3e6fcf4c79b35c6849ef74d88ac905cfb2f010000001976a9144e8d2fcf6d909c62597e4defd1c26d50842d73df88ac00000000';
-                await wallet.addTransaction(Transaction.fromHex(tx_1));
-            } else {
-                debugWarn(
-                    DebugTopics.NET,
-                    'getLatestTxs did not find any txs this wallet! ' +
-                        wallet.getKeyToExport()
-                );
-            }
+    getTxPage = vi.fn((nStartHeight, addr, n) => {
+        if (addr === 'DTSTGkncpC86sbEUZ2rCBLEe2aXSeZPLnC') {
+            // 1) Legacy mainnet wallet
+            // tx_1 provides a spendable balance of 0.1 * 10^8 satoshi
+            const tx_1 =
+                '010000000138f9c8ac1b4c6ad54e487206daad1fd12bae510dd70fbd2dc928f617ef6b4a47010000006a47304402200d01891ac5dc6d25452cadbe7ba7edd98143631cc2922da45dde94919593b222022066ef14c01c165a1530e2acf74bcd8648d7151b555fa0bfd0222c33e983091678012102033a004cb71693e809c45e1e491bc797654fa0c012be9dd46401ce8368beb705ffffffff02d02c5d05000000001976a91463fa54dad2e215ec21c54ff45a195d49b570b97988ac80969800000000001976a914f49b25384b79685227be5418f779b98a6be4c73888ac00000000';
+            return [Transaction.fromHex(tx_1)];
+        } else if (
+            addr ===
+            'xpub6DVaPT3irDwUth7Y6Ff137FgA9jjvsmA2CHD7g2vjvvuMiNSUJRs9F8jSoPpXpc1s7ohR93dNAuzR5T2oPZFDTn7G2mHKYtpwtk7krNZmnV'
+        ) {
+            // 2) HD mainnet wallet
+            // tx_1 provides a spendable balance of 1 * 10^8 satoshi to the address with path m/44'/119'/0'/0/0
+            const tx_1 =
+                '0100000001458de14f4f4fecfdeebfef09fb16e761bbd15029f37bec0a63b86808cbb8a512010000006b483045022100ef4f4364aea7604d749aaff7a2609e3a51a12f49500b7910b34ced0d0837e1db022012d153d96ebcb94e9b905a609c0ea97cdc99ae961be2848e0e8f2f695379c21201210371eca6799221b82cbba9e880a8a5a0f47d811f3ff5cad346931406ab0a0469eeffffffff0200e1f505000000001976a9148952bf31104625a7b3e6fcf4c79b35c6849ef74d88ac905cfb2f010000001976a9144e8d2fcf6d909c62597e4defd1c26d50842d73df88ac00000000';
+            return [Transaction.fromHex(tx_1)];
+        } else {
+            debugWarn(
+                DebugTopics.NET,
+                'getLatestTxs did not find any txs this wallet! ' + addr
+            );
         }
-    );
+        return [];
+    });
 
     sendTransaction = vi.fn(
         /**

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -275,7 +275,7 @@ function getTxCount() {
 
 getEventEmitter().on(
     'transparent-sync-status-update',
-    (_str, progress, done) => done && update()
+    (i, totalPages, done) => done && update()
 );
 getEventEmitter().on(
     'shield-sync-status-update',

--- a/scripts/dashboard/WalletBalance.vue
+++ b/scripts/dashboard/WalletBalance.vue
@@ -133,7 +133,12 @@ const emit = defineEmits([
 
 getEventEmitter().on(
     'transparent-sync-status-update',
-    (str, progress, finished) => {
+    (i, totalPages, finished) => {
+        const str = tr(translation.syncStatusHistoryProgress, [
+            { current: totalPages - i + 1 },
+            { total: totalPages },
+        ]);
+        const progress = ((totalPages - i) / totalPages) * 100;
         syncTStr.value = str;
         transparentProgressSyncing.value = progress;
         transparentSyncing.value = !finished;

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -9,7 +9,7 @@ import { COutpoint, Transaction } from './transaction.js';
 import { confirmPopup, createAlert, isShieldAddress } from './misc.js';
 import { cChainParams } from './chain_params.js';
 import { COIN } from './chain_params.js';
-import { ALERTS, tr, translation } from './i18n.js';
+import { ALERTS, translation } from './i18n.js';
 import { encrypt } from './aes-gcm.js';
 import { Database } from './database.js';
 import { RECEIVE_TYPES } from './contacts-book.js';
@@ -722,11 +722,8 @@ export class Wallet {
         for (let i = totalPages; i > 0; i--) {
             getEventEmitter().emit(
                 'transparent-sync-status-update',
-                tr(translation.syncStatusHistoryProgress, [
-                    { current: totalPages - i + 1 },
-                    { total: totalPages },
-                ]),
-                ((totalPages - i) / totalPages) * 100,
+                i,
+                totalPages,
                 false
             );
 


### PR DESCRIPTION
## Abstract

Remove the circular dependency between wallet and network.  This has two main advantages:

- More simple: the network just make API calls and the wallet has the logic to handle the results;
- With this PR we get closer to the goal of being able to delete a wallet / switch network before the sync is done (because now we can stop the transparent sync internally from the wallet). 

---

## Testing
Sync a xpub and verify that you get the same balance on master

---

