### PR TITLE
Sync fixes

### DIFF
--- a/scripts/__mocks__/network.js
+++ b/scripts/__mocks__/network.js
@@ -12,6 +12,7 @@ class TestNetwork {
     getBlockCount = vi.fn(() => {
         return this.#blockHeight;
     });
+    getBlockHeight = vi.fn(() => this.#blockHeight);
     /**
      * map blockHeight -> block
      * @type {Map<number, TestBlock>}

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -118,6 +118,17 @@ export class ExplorerNetwork extends Network {
     }
 
     /**
+     * FIXME this is going to be merged in getBlockCount once explorer and RPC are separated
+     * @returns {number} last indexed block of blockbook
+     */
+    async getBlockHeight() {
+        const { blockbook } = await (
+            await retryWrapper(fetchBlockbook, true, `/api/v2/api`)
+        ).json();
+        return blockbook.bestHeight;
+    }
+
+    /**
      * Fetch the latest block hash of the current explorer or fallback node
      * @returns {Promise<string>} - Block hash
      */

--- a/scripts/network.js
+++ b/scripts/network.js
@@ -119,7 +119,7 @@ export class ExplorerNetwork extends Network {
 
     /**
      * FIXME this is going to be merged in getBlockCount once explorer and RPC are separated
-     * @returns {number} last indexed block of blockbook
+     * @returns {Promise<number>} last indexed block of blockbook
      */
     async getBlockHeight() {
         const { blockbook } = await (

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -169,7 +169,7 @@ export class Wallet {
     }
 
     get isSyncing() {
-        return this.sync.isLocked();
+        return this.#syncInternal.isLocked();
     }
 
     wipePrivateData() {
@@ -704,12 +704,16 @@ export class Wallet {
         // This is done to avoid a huge spam of event.
         getEventEmitter().disableEvent('balance-update');
         await this.#syncInternal();
-        const networkSaplingRoot = (
-            await getNetwork().getBlock(this.#shield.getLastSyncedBlock())
-        ).finalsaplingroot;
-        if (networkSaplingRoot) {
-            while (!(await this.#checkShieldSaplingRoot(networkSaplingRoot))) {
-                /* checkShieldSaplingRoot automatically tries to resync */
+        if (this.hasShield()) {
+            const networkSaplingRoot = (
+                await getNetwork().getBlock(this.#shield.getLastSyncedBlock())
+            ).finalsaplingroot;
+            if (networkSaplingRoot) {
+                while (
+                    !(await this.#checkShieldSaplingRoot(networkSaplingRoot))
+                ) {
+                    /* checkShieldSaplingRoot automatically tries to resync */
+                }
             }
         }
         this.#isSynced = true;

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -708,7 +708,9 @@ export class Wallet {
             await getNetwork().getBlock(this.#shield.getLastSyncedBlock())
         ).finalsaplingroot;
         if (networkSaplingRoot) {
-            while (!(await this.#checkShieldSaplingRoot(networkSaplingRoot))) {}
+            while (!(await this.#checkShieldSaplingRoot(networkSaplingRoot))) {
+                /* checkShieldSaplingRoot automatically tries to resync */
+            }
         }
         this.#isSynced = true;
         // Update both activities post sync
@@ -927,8 +929,9 @@ export class Wallet {
                         !(await this.#checkShieldSaplingRoot(
                             block.finalsaplingroot
                         ))
-                    )
-                        return;
+                    ) {
+                        /* checkShieldSaplingRoot automatically tries to resync */
+                    }
                 }
                 await this.saveShieldOnDisk();
             }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -746,8 +746,8 @@ export class Wallet {
         }
         if (this.hasShield()) {
             await this.#syncShield(this.#lastProcessedBlock);
-            await this.getLatestBlocks(await getNetwork().getBlockCount());
         }
+        await this.getLatestBlocks(await getNetwork().getBlockCount());
     });
 
     /**


### PR DESCRIPTION
## Abstract

1) Split sync in syncInternal so we can resync from scratch when sapling root is different
2) On initial sync:
- Sync up to blockbook indexed height
- Then, call `getLatestBlocks` to finish the sync and go past the blockbook indexed height. Most of the times this is 1-2 blocks

## Testing
- Test that sapling root check works as expected both on initial sync and after.
- Test that `sync()` syncs both transparent and shield up to the last available block