### PR TITLE
doc: remove an unused portion of the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,23 +14,3 @@ To test this PR, it's suggested to attempt these user flows, or variations of th
 If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!
 
 ---
-
-<!---
-Below is for LMP (Labs Micro Proposals), how your PR is rewarded PIVX: this'll help your PR be rewarded faster by the DAO!
---->
-
-## What does this PR address?
-<!---
-Here, describe the problem (or lack of a feature) which this PR aims to address, in as simple terms/concepts as possible to the reader.
---->
-
-## What features or improvements were added?
-<!---
-Here, describe the new improvement; what it does, and how it does it, in as simple terms/concepts as possible to the reader.
---->
-
-## How does this benefit users?
-<!---
-Here, describe how the user will benefit from the change, if at all; it may not be noticable to the user (i.e: code cleanup), in that case you may simply state so.
---->
-


### PR DESCRIPTION
## Abstract

This PR simplifies the Pull Request template, since Labs now does reporting on a per-dev basis (rather than a writer whom compiled reports, in the past), this template portion is unnecessary and just gets deleted in every modern PR.