### PR TITLE
Implement Stake Pre-Splitting

### DIFF
--- a/chain_params.prod.json
+++ b/chain_params.prod.json
@@ -32,7 +32,8 @@
         "proposalFeeConfirmRequirement": 6,
         "maxPaymentCycles": 6,
         "maxPayment": 43200000000000,
-        "defaultColdStakingAddress": "SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy"
+        "defaultColdStakingAddress": "SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy",
+        "stakeSplitTarget": 50000000000
     },
     "testnet": {
         "name": "testnet",
@@ -64,6 +65,7 @@
         "proposalFeeConfirmRequirement": 3,
         "maxPaymentCycles": 20,
         "maxPayment": 144000000000,
-        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44"
+        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44",
+        "stakeSplitTarget": 50000000000
     }
 }

--- a/chain_params.test.json
+++ b/chain_params.test.json
@@ -24,7 +24,8 @@
         "proposalFeeConfirmRequirement": 3,
         "maxPaymentCycles": 20,
         "maxPayment": 144000000000,
-        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44"
+        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44",
+        "stakeSplitTarget": 50000000000
     },
     "testnet": {
         "name": "testnet",
@@ -54,6 +55,7 @@
         "proposalFeeConfirmRequirement": 3,
         "maxPaymentCycles": 20,
         "maxPayment": 144000000000,
-        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44"
+        "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44",
+        "stakeSplitTarget": 50000000000
     }
 }

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1062,7 +1062,7 @@ export class Wallet {
             }
 
             const fee = transactionBuilder.getFee();
-            const changeValue = transactionBuilder.valueIn - value - fee;
+            const changeValue = transactionBuilder.valueIn - transactionBuilder.valueOut - fee;
             if (changeValue < 0) {
                 if (!subtractFeeFromAmt) {
                     throw new Error('Not enough balance');


### PR DESCRIPTION
## Abstract

This PR adds a simple but very useful improvement to staking efficiency for MPW, by pre-splitting large delegations, we allow each output to confirm and start staking individually without causing one stake to put the entire balance in to a long maturation period.

Take these two examples of how this change could improve the user experience:

## Example 1: unusually large 'immature balances' confusing users
If a user delegates 10,000 PIVX (their entire balance), and it hits a stake, their entire balance is going to be considered immature, and thus unusable, which is not ideal - this situation can be prevented by pre-splitting delegated UTXOs.

## Example 2: slower stake rewards, shortly after delegating
In the same example of staking 10,000 PIV: if you delegate a single UTXO of 10,000, which hits a stake - then that entire UTXO will not be staking until it re-matures, and the Cold Address splits this automatically with PIVX Core's `stakesplitthreshold`, this wasted time ends up reducing the rewards you could potentially earn in the short-term.

With pre-splitting in to, say, 20x 500 PIV UTXOs, hitting a stake means only 500 PIV is immature, and the other 9,500 PIV continues staking, which means you could earn more stakes in the same time period that it takes for your initial 10k to re-mature and become stakeable again.

---

# Note
The PR's suggested split target is **500 PIV** - the same setting that the PIVX Labs Cold Pool uses for it's `stakesplitthreshold`.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Stake 500 or less PIV: ensure it is a single UTXO (`vout`) on the explorer.
- Stake over >500 PIV: ensure the outputs 'split' in to even 500-per-out UTXOs, and the remainder is less than 500 PIV.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---