### PR TITLE
Fix wallet sync bug

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -721,11 +721,8 @@ export class Wallet {
         let nStartHeight = Math.max(
             ...this.getTransactions().map((tx) => tx.blockHeight)
         );
-        const txNumber =
-            (await cNet.getNumPages(nStartHeight, addr)) -
-            this.getTransactions().length;
         // Compute the total pages and iterate through them until we've synced everything
-        const totalPages = Math.ceil(txNumber / 1000);
+        const totalPages = await cNet.getNumPages(nStartHeight, addr);
         for (let i = totalPages; i > 0; i--) {
             getEventEmitter().emit(
                 'transparent-sync-status-update',


### PR DESCRIPTION
## Abstract

With the latest shield-lib updates the number of transactions in the wallet doesn't correspond to the number of transactions returned by blockbook (because blockbook doesn't return shield txs that are not linkable to the user xpub).

In other words
```
const txNumber =
            (await cNet.getNumPages(nStartHeight, addr)) -
            this.getTransactions().length;
```
is potentially smaller than the actual number of missing transactions, therefore some transactions might be never fetched.

The bug is solved by asking for pages of transactions until we find a duplicate. 

The problem of this approach is that we don't know anymore how long it will take ( to show in a progress bar)


EDIT:
 
Found a way to solve the bug without changing the `transparentSync` logic



