### PR TITLE
Fix invalid password alerts

### DIFF
--- a/locale/cnr/translation.toml
+++ b/locale/cnr/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Interna greška, molimo pokušajte ponovo kasnije" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Neuspešan uvoz!</b> Neispravna lozinka" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Neispravna lozinka" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Neuspešan uvoz Hardverskog Novčanika</b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Režim testne mreže je UKLJUČEN!</b><br>Enkripcija novčanika je onemogućena" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "Ta lozinka je malo kratka!<br>Koristite najmanje <b>{MIN_PASS_LENGTH} karaktera.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/cnr/translation.toml
+++ b/locale/cnr/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Interna greška, molimo pokušajte ponovo kasnije" # Internal error, please try again later
-FAILED_TO_IMPORT = "Neispravna lozinka" # Invalid password
+INVALID_PASSWORD = "Neispravna lozinka" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Neuspešan uvoz Hardverskog Novčanika</b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Režim testne mreže je UKLJUČEN!</b><br>Enkripcija novčanika je onemogućena" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "Ta lozinka je malo kratka!<br>Koristite najmanje <b>{MIN_PASS_LENGTH} karaktera.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/de/translation.toml
+++ b/locale/de/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Interner Fehler, bitte versuche es später erneut" # Internal error, please try again later
-FAILED_TO_IMPORT = "Falsches Passwort" # Invalid password
+INVALID_PASSWORD = "Falsches Passwort" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Importieren der Hardware Geldbörse fehlgeschlagen</b>" # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "Das Zeichen {char} ist nicht erlaubt in der Adresse! (Nicht Base58 kompatibel)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Dieser Browser unterstützt keine Web Worker (Multi-Threaded JS), leider kannst du keine Vanity Adresse generieren!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/de/translation.toml
+++ b/locale/de/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Interner Fehler, bitte versuche es später erneut" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Import fehlgeschlagen!</b> Falsches Passwort" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Falsches Passwort" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Importieren der Hardware Geldbörse fehlgeschlagen</b>" # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "Das Zeichen {char} ist nicht erlaubt in der Adresse! (Nicht Base58 kompatibel)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Dieser Browser unterstützt keine Web Worker (Multi-Threaded JS), leider kannst du keine Vanity Adresse generieren!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/en/translation.toml
+++ b/locale/en/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "Creating SHIELD transaction..." # Creating SHIELD t
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, please try again later" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Failed to import!</b> Invalid password" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Invalid password" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b> Failed to import Hardware Wallet</b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet Mode is ON!</b><br>Wallet encryption disabled" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/en/translation.toml
+++ b/locale/en/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "Creating SHIELD transaction..." # Creating SHIELD t
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, please try again later" # Internal error, please try again later
-FAILED_TO_IMPORT = "Invalid password" # Invalid password
+INVALID_PASSWORD = "Invalid password" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b> Failed to import Hardware Wallet</b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet Mode is ON!</b><br>Wallet encryption disabled" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/es-mx/translation.toml
+++ b/locale/es-mx/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Error interno, vuelve a intentarlo más tarde" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>¡No se ha podido importar!</b> Contraseña inválida" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Contraseña inválida" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "" # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "¡El carácter {char} no está soportado en las direcciones! (No compatible con Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Este navegador no soporta Web Workers (multi-threaded JS), ¡lamentablemente no puedes generar wallets Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/es-mx/translation.toml
+++ b/locale/es-mx/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Error interno, vuelve a intentarlo más tarde" # Internal error, please try again later
-FAILED_TO_IMPORT = "Contraseña inválida" # Invalid password
+INVALID_PASSWORD = "Contraseña inválida" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "" # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "¡El carácter {char} no está soportado en las direcciones! (No compatible con Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Este navegador no soporta Web Workers (multi-threaded JS), ¡lamentablemente no puedes generar wallets Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/fr/translation.toml
+++ b/locale/fr/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Erreur interne, veuillez réessayer plus tard" # Internal error, please try again later
-FAILED_TO_IMPORT = "Mot de passe invalide" # Invalid password
+INVALID_PASSWORD = "Mot de passe invalide" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Erreur d'importation du Hardware Wallet</b>." # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "Le caractère {char} n'est pas pris en charge dans les adresses ! (Non compatible avec Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Ce navigateur ne prend pas en charge Web Workers (JS multi-threaded), Malheureusement, il n'est pas possible de générer des portefeuilles Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/fr/translation.toml
+++ b/locale/fr/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Erreur interne, veuillez réessayer plus tard" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Échec de l'importation !</b> Mot de passe invalide" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Mot de passe invalide" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Erreur d'importation du Hardware Wallet</b>." # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "Le caractère {char} n'est pas pris en charge dans les adresses ! (Non compatible avec Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Ce navigateur ne prend pas en charge Web Workers (JS multi-threaded), Malheureusement, il n'est pas possible de générer des portefeuilles Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/hi/translation.toml
+++ b/locale/hi/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "क्रिएटिंग शील्ड ट्�
 
 [ALERTS]
 INTERNAL_ERROR = "आंतरिक त्रुटि, कृपया कुछ समय बाद पुनः प्रयास करें" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>इम्पोर्ट में विफल!</b> अवैध पासवर्ड" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "अवैध पासवर्ड" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b> हार्डवेयर वॉलेट इम्पोर्ट में विफल</b>।" # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>टेस्टनेट मोड चालू है!</b><br>वॉलेट एन्क्रिप्शन निष्क्रिय" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "वह पासवर्ड थोड़ी छोटी है!<br>कम से कम <b>{MIN_PASS_LENGTH} अक्षर</b> का उपयोग करें।" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/hi/translation.toml
+++ b/locale/hi/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "क्रिएटिंग शील्ड ट्�
 
 [ALERTS]
 INTERNAL_ERROR = "आंतरिक त्रुटि, कृपया कुछ समय बाद पुनः प्रयास करें" # Internal error, please try again later
-FAILED_TO_IMPORT = "अवैध पासवर्ड" # Invalid password
+INVALID_PASSWORD = "अवैध पासवर्ड" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b> हार्डवेयर वॉलेट इम्पोर्ट में विफल</b>।" # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>टेस्टनेट मोड चालू है!</b><br>वॉलेट एन्क्रिप्शन निष्क्रिय" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "वह पासवर्ड थोड़ी छोटी है!<br>कम से कम <b>{MIN_PASS_LENGTH} अक्षर</b> का उपयोग करें।" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/it/translation.toml
+++ b/locale/it/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Errore interno, rirova più tardi" # Internal error, please try again later
-FAILED_TO_IMPORT = "Password non valida" # Invalid password
+INVALID_PASSWORD = "Password non valida" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Impossibile importare il wallet Hardware!</b>" # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "Il carattere '{char}' non è supportato negli indirizzi! (Non compatibile con Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Questo browser non supporta i Web Worker (JS multi-thread), sfortunatamente non puoi generare portafogli Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/it/translation.toml
+++ b/locale/it/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Errore interno, rirova più tardi" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Impossibile importare!</b> Password non valida" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Password non valida" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Impossibile importare il wallet Hardware!</b>" # <b> Failed to import Hardware Wallet</b>.
 UNSUPPORTED_CHARACTER = "Il carattere '{char}' non è supportato negli indirizzi! (Non compatibile con Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Questo browser non supporta i Web Worker (JS multi-thread), sfortunatamente non puoi generare portafogli Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!

--- a/locale/nl/translation.toml
+++ b/locale/nl/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Interne fout, probeer het later opnieuw" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Importeren mislukt!</b> Ongeldig wachtwoord" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Ongeldig wachtwoord" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b> Hardware Wallet importeren mislukt </b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet-modus is AAN!</b><br>Portemonneeversleuteling uitgeschakeld" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "Dat wachtwoord is een beetje kort!<br>Gebruik minstens <b>{MIN_PASS_LENGTH} tekens.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/nl/translation.toml
+++ b/locale/nl/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Interne fout, probeer het later opnieuw" # Internal error, please try again later
-FAILED_TO_IMPORT = "Ongeldig wachtwoord" # Invalid password
+INVALID_PASSWORD = "Ongeldig wachtwoord" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b> Hardware Wallet importeren mislukt </b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet-modus is AAN!</b><br>Portemonneeversleuteling uitgeschakeld" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "Dat wachtwoord is een beetje kort!<br>Gebruik minstens <b>{MIN_PASS_LENGTH} tekens.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/ph/translation.toml
+++ b/locale/ph/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, Pakiusap uliting muli" # Internal error, please try again later
-FAILED_TO_IMPORT = "Ang password na ito ay hindi wasto" # Invalid password
+INVALID_PASSWORD = "Ang password na ito ay hindi wasto" # Invalid password
 UNSUPPORTED_CHARACTER = "Ang karakter na ito ‘{char}’ay hindi supportado sa mga address! (Not Base58 compatible)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Hindi supportado ng browser na ito ang Web Workers (multi-threaded JS)sa kasamaang palad ay hindi ka makakagawa ng Vanity wallets!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!
 INVALID_ADDRESS = "<b>Ang PIVX address na ito ay hindi wasto!</b><br> {address}" # <b>Invalid PIVX address!</b><br> {address}

--- a/locale/ph/translation.toml
+++ b/locale/ph/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, Pakiusap uliting muli" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Nabigong mag import!</b> Ang password na ito ay hindi wasto" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Ang password na ito ay hindi wasto" # Invalid password
 UNSUPPORTED_CHARACTER = "Ang karakter na ito ‘{char}’ay hindi supportado sa mga address! (Not Base58 compatible)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Hindi supportado ng browser na ito ang Web Workers (multi-threaded JS)sa kasamaang palad ay hindi ka makakagawa ng Vanity wallets!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!
 INVALID_ADDRESS = "<b>Ang PIVX address na ito ay hindi wasto!</b><br> {address}" # <b>Invalid PIVX address!</b><br> {address}

--- a/locale/pl/translation.toml
+++ b/locale/pl/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Błąd wewnętrzny, spróbuj ponownie później" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Nieprawidłowe hasło</b> Nie udało się zaimportować!" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Nie udało się zaimportować!" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Import portfela sprzętowego (Hardware Wallet) nie powiódł się</b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Tryb testnet jest włączony!</b><br>Szyfrowanie portfela wyłączone" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "To hasło jest za krótkie!<br>Użyj co najmniej <b>{MIN_PASS_LENGTH} znaków.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/pl/translation.toml
+++ b/locale/pl/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Błąd wewnętrzny, spróbuj ponownie później" # Internal error, please try again later
-FAILED_TO_IMPORT = "Nie udało się zaimportować!" # Invalid password
+INVALID_PASSWORD = "Nie udało się zaimportować!" # Invalid password
 FAILED_TO_IMPORT_HARDWARE = "<b>Import portfela sprzętowego (Hardware Wallet) nie powiódł się</b>." # <b> Failed to import Hardware Wallet</b>.
 TESTNET_ENCRYPTION_DISABLED = "<b>Tryb testnet jest włączony!</b><br>Szyfrowanie portfela wyłączone" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "To hasło jest za krótkie!<br>Użyj co najmniej <b>{MIN_PASS_LENGTH} znaków.</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>

--- a/locale/pt/translation.toml
+++ b/locale/pt/translation.toml
@@ -125,7 +125,7 @@ activityReceivedWith = "Recebido com {s}" # Received with {s}
 
 [ALERTS]
 INTERNAL_ERROR = "Erro interno, por favor tente novamente mais tarde" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Falha ao importar!</b> Senha inválida" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Senha inválida" # Invalid password
 UNSUPPORTED_CHARACTER = "O caracter {char} não é suportado em endereços! (Não é compatível com Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Este navegador não suporta Web Workers (JS multi-threaded), infelizmente você não pode gerar carteiras Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!
 INVALID_ADDRESS = "<b>Endereço PIVX inválido!</b><br> {address}" # <b>Invalid PIVX address!</b><br> {address}

--- a/locale/pt/translation.toml
+++ b/locale/pt/translation.toml
@@ -125,7 +125,7 @@ activityReceivedWith = "Recebido com {s}" # Received with {s}
 
 [ALERTS]
 INTERNAL_ERROR = "Erro interno, por favor tente novamente mais tarde" # Internal error, please try again later
-FAILED_TO_IMPORT = "Senha inválida" # Invalid password
+INVALID_PASSWORD = "Senha inválida" # Invalid password
 UNSUPPORTED_CHARACTER = "O caracter {char} não é suportado em endereços! (Não é compatível com Base58)" # The character '{char}' is unsupported in addresses! (Not Base58 compatible)
 UNSUPPORTED_WEBWORKERS = "Este navegador não suporta Web Workers (JS multi-threaded), infelizmente você não pode gerar carteiras Vanity!" # This browser doesn't support Web Workers (multi-threaded JS), unfortunately you cannot generate Vanity wallets!
 INVALID_ADDRESS = "<b>Endereço PIVX inválido!</b><br> {address}" # <b>Invalid PIVX address!</b><br> {address}

--- a/locale/template/translation.toml
+++ b/locale/template/translation.toml
@@ -235,7 +235,7 @@ creatingShieldTransaction = "Creating SHIELD transaction..."
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, please try again later"
-FAILED_TO_IMPORT = "<b>Failed to import!</b> Invalid password"
+FAILED_TO_IMPORT = "Invalid password"
 FAILED_TO_IMPORT_HARDWARE = "<b> Failed to import Hardware Wallet</b>."
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet Mode is ON!</b><br>Wallet encryption disabled"
 PASSWORD_TOO_SMALL = "That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>"

--- a/locale/template/translation.toml
+++ b/locale/template/translation.toml
@@ -235,7 +235,7 @@ creatingShieldTransaction = "Creating SHIELD transaction..."
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, please try again later"
-FAILED_TO_IMPORT = "Invalid password"
+INVALID_PASSWORD = "Invalid password"
 FAILED_TO_IMPORT_HARDWARE = "<b> Failed to import Hardware Wallet</b>."
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet Mode is ON!</b><br>Wallet encryption disabled"
 PASSWORD_TOO_SMALL = "That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>"

--- a/locale/uwu/translation.toml
+++ b/locale/uwu/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, pwease try again later" # Internal error, please try again later
-FAILED_TO_IMPORT = "<b>Faiwed to impawt!</b> Invawed password! Baka!" # <b>Failed to import!</b> Invalid password
+FAILED_TO_IMPORT = "Invawed password! Baka!" # Invalid password
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet Mowode in ON!</b><br>Wawwet encwyption disabwed" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "Dat password is a wittle short!<br>Pwease use at least<b> {MIN_PASS_LENGTH} chawacters!</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>
 PASSWORD_DOESNT_MATCH = "Yowour passwords dun match!! baka!!" # Your passwords don't match!

--- a/locale/uwu/translation.toml
+++ b/locale/uwu/translation.toml
@@ -211,7 +211,7 @@ creatingShieldTransaction = "" # Creating SHIELD transaction...
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, pwease try again later" # Internal error, please try again later
-FAILED_TO_IMPORT = "Invawed password! Baka!" # Invalid password
+INVALID_PASSWORD = "Invawed password! Baka!" # Invalid password
 TESTNET_ENCRYPTION_DISABLED = "<b>Testnet Mowode in ON!</b><br>Wawwet encwyption disabwed" # <b>Testnet Mode is ON!</b><br>Wallet encryption disabled
 PASSWORD_TOO_SMALL = "Dat password is a wittle short!<br>Pwease use at least<b> {MIN_PASS_LENGTH} chawacters!</b>" # That password is a little short!<br>Use at least <b>{MIN_PASS_LENGTH} characters.</b>
 PASSWORD_DOESNT_MATCH = "Yowour passwords dun match!! baka!!" # Your passwords don't match!

--- a/scripts/alerts/alert.js
+++ b/scripts/alerts/alert.js
@@ -56,7 +56,7 @@ export class AlertController {
      * @param {string} message - The message to relay to the user
      * @param {number?} timeout - The time in `ms` until the alert expires (Defaults to never expiring)
      */
-    createAlert(level, message, timeout = 0) {
+    createAlert(level, message, timeout = 2000) {
         this.addAlert(new Alert({ level, message, timeout }));
     }
 

--- a/scripts/dashboard/RestoreWallet.vue
+++ b/scripts/dashboard/RestoreWallet.vue
@@ -32,7 +32,7 @@ async function submit() {
     if (wif) {
         emit('import', wif, extsk);
     } else {
-        createAlert('warning', ALERTS.FAILED_TO_IMPORT, 2000);
+        createAlert('warning', ALERTS.INVALID_PASSWORD, 2000);
     }
 }
 

--- a/scripts/dashboard/RestoreWallet.vue
+++ b/scripts/dashboard/RestoreWallet.vue
@@ -32,7 +32,7 @@ async function submit() {
     if (wif) {
         emit('import', wif, extsk);
     } else {
-        createAlert('warning', ALERTS.INVALID_PASSWORD, 2000);
+        createAlert('warning', ALERTS.INVALID_PASSWORD);
     }
 }
 

--- a/scripts/dashboard/RestoreWallet.vue
+++ b/scripts/dashboard/RestoreWallet.vue
@@ -32,7 +32,7 @@ async function submit() {
     if (wif) {
         emit('import', wif, extsk);
     } else {
-        createAlert('warning', ALERTS.FAILED_TO_IMPORT);
+        createAlert('warning', ALERTS.FAILED_TO_IMPORT, 2000);
     }
 }
 


### PR DESCRIPTION
## Abstract

Recently, MPW stopped notifying users when attempted unlocks failed due to a bad password. This was resolved, alongside simplifying the alert strings for the notification, since an already-imported wallet (to the user) makes no sense showing "failed to import - invalid password", we only need to show "Invalid password".

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Try unlocking a wallet with the wrong password, ensure the notification appears.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---