### PR TITLE
Convert to HistoricalTxs only once

### DIFF
--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -12,6 +12,7 @@ import { beautifyNumber } from '../misc';
 
 import iCheck from '../../assets/icons/icon-check.svg';
 import iHourglass from '../../assets/icons/icon-hourglass.svg';
+import { blockCount } from '../global.js';
 
 const props = defineProps({
     title: String,
@@ -174,6 +175,13 @@ async function parseTXs(arrTXs) {
         // Update the time cache
         prevTimestamp = cTx.time * 1000;
 
+        // Coinbase Transactions (rewards) require coinbaseMaturity confs
+        const fConfirmed =
+            blockCount - cTx.blockHeight >=
+            (cTx.type === HistoricalTxType.STAKE
+                ? cChainParams.current.coinbaseMaturity
+                : 6);
+
         // Choose the content type, for the Dashboard; use a generative description, otherwise, a TX-ID
         // let txContent = props.rewards ? cTx.id : 'Block Reward';
 
@@ -242,7 +250,7 @@ async function parseTXs(arrTXs) {
             content: props.rewards ? cTx.id : content,
             formattedAmt,
             amount: cTx.amount,
-            confirmed: cTx.isConfirmed,
+            confirmed: fConfirmed,
             icon,
             colour,
         });

--- a/scripts/historical_tx.js
+++ b/scripts/historical_tx.js
@@ -10,7 +10,6 @@ export class HistoricalTx {
      * @param {number} time - The block time of the transaction.
      * @param {number} blockHeight - The block height of the transaction.
      * @param {number} amount - The amount transacted, in coins.
-     * @param {boolean} isConfirmed - Whether the transaction has been confirmed.
      */
     constructor(
         type,
@@ -19,8 +18,7 @@ export class HistoricalTx {
         shieldedOutputs,
         time,
         blockHeight,
-        amount,
-        isConfirmed
+        amount
     ) {
         this.type = type;
         this.id = id;
@@ -29,7 +27,6 @@ export class HistoricalTx {
         this.time = time;
         this.blockHeight = blockHeight;
         this.amount = amount;
-        this.isConfirmed = isConfirmed;
     }
 }
 

--- a/scripts/mempool.js
+++ b/scripts/mempool.js
@@ -242,6 +242,14 @@ export class Mempool {
     }
 
     /**
+     * @param {string} txid - transaction id
+     * @returns {import('./transaction.js').Transaction | undefined}
+     */
+    getTransaction(txid) {
+        return this.#txmap.get(txid);
+    }
+
+    /**
      * @param blockCount - chain height
      */
     getBalance(blockCount) {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -754,7 +754,7 @@ export class Wallet {
         const cNet = getNetwork();
         const addr = this.getKeyToExport();
         let nStartHeight = Math.max(
-            ...this.getTransactions().map((tx) => tx.blockHeight)
+            ...this.#mempool.getTransactions().map((tx) => tx.blockHeight)
         );
         // Compute the total pages and iterate through them until we've synced everything
         const totalPages = await cNet.getNumPages(nStartHeight, addr);
@@ -1261,13 +1261,6 @@ export class Wallet {
                 blockCount,
             })
             .filter((u) => u.value === collateralValue);
-    }
-
-    /**
-     * @returns {import('./transaction.js').Transaction[]} a list of all transactions
-     */
-    getTransactions() {
-        return this.#mempool.getTransactions();
     }
 
     get balance() {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -678,10 +678,6 @@ export class Wallet {
             } else if (nAmount < 0) {
                 type = HistoricalTxType.SENT;
             }
-            const isCoinSpecial = tx.isCoinStake() || tx.isCoinBase();
-            const isConfirmed =
-                blockCount - tx.blockHeight >=
-                (isCoinSpecial ? cChainParams.current.coinbaseMaturity : 6);
 
             histTXs.push(
                 new HistoricalTx(
@@ -691,8 +687,7 @@ export class Wallet {
                     false,
                     tx.blockTime,
                     tx.blockHeight,
-                    Math.abs(nAmount),
-                    isConfirmed
+                    Math.abs(nAmount)
                 )
             );
         }


### PR DESCRIPTION
## Abstract

Avoid converting a `Transaction` object to `HistoricalTx` more than once. This is a useful optimization since the conversion is computationally expensive (especially with the incoming feature of shield activity)


---

## Testing

Verify that activity is unchanged

---