### PR TITLE
Remove global NetworkManager::callRPC

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -777,19 +777,19 @@ export async function updateGovernanceTab() {
 
     // Update governance counter when testnet/mainnet has been switched
     if (!governanceFlipdown && blockCount > 0) {
-        Masternode.getNextSuperblock().then((nSuperblock) => {
-            // The estimated time to the superblock (using the block target and remaining blocks)
-            const nTimestamp =
-                Date.now() / 1000 + (nSuperblock - blockCount) * 60;
-            governanceFlipdown = new FlipDown(nTimestamp).start();
-        });
+        getNetwork()
+            .getNextSuperblock()
+            .then((nSuperblock) => {
+                // The estimated time to the superblock (using the block target and remaining blocks)
+                const nTimestamp =
+                    Date.now() / 1000 + (nSuperblock - blockCount) * 60;
+                governanceFlipdown = new FlipDown(nTimestamp).start();
+            });
         isTestnetLastState = cChainParams.current.isTestnet;
     }
 
     // Fetch all proposals from the network
-    const arrProposals = await Masternode.getProposals({
-        fAllowFinished: false,
-    });
+    const arrProposals = await getNetwork().getProposals();
 
     /* Sort proposals into two categories
         - Standard (Proposal is either new with <100 votes, or has a healthy vote count)
@@ -979,7 +979,7 @@ async function renderProposals(arrProposals, fContested) {
     );
 
     // Fetch the Masternode count for proposal status calculations
-    const cMasternodes = await Masternode.getMasternodeCount();
+    const cMasternodes = await getNetwork().getMasternodeCount();
 
     let totalAllocatedAmount = 0;
 
@@ -1654,7 +1654,7 @@ export async function createProposal() {
     const strAddress =
         document.getElementById('proposalAddress').value.trim() ||
         wallet.getNewAddress(1)[0];
-    const nextSuperblock = await Masternode.getNextSuperblock();
+    const nextSuperblock = await getNetwork().getNextSuperblock();
     const proposal = {
         name: strTitle,
         url: strUrl,

--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -41,23 +41,23 @@ export class Network {
         }
     }
 
-    async getBlock(blockHeight) {
+    async getBlock(_blockHeight) {
         throw new Error('getBlockCount must be implemented');
     }
 
-    async getTxPage(nStartHeight, addr, n) {
+    async getTxPage(_nStartHeight, _addr, _n) {
         throw new Error('getTxPage must be implemented');
     }
 
-    async getNumPages(nStartHeight, addr) {
+    async getNumPages(_nStartHeight, _addr) {
         throw new Error('getNumPages must be implemented');
     }
 
-    async getUTXOs(strAddress) {
+    async getUTXOs(_strAddress) {
         throw new Error('getUTXOs must be implemented');
     }
 
-    async getXPubInfo(strXPUB) {
+    async getXPubInfo(_strXPUB) {
         throw new Error('getXPubInfo must be implemented');
     }
 
@@ -73,7 +73,7 @@ export class Network {
         throw new Error('getBestBlockHash must be implemented');
     }
 
-    async sendTransaction(hex) {
+    async sendTransaction(_hex) {
         throw new Error('sendTransaction must be implemented');
     }
 
@@ -93,7 +93,7 @@ export class Network {
         throw new Error('getNextSuperblock must be implemented');
     }
 
-    async startMasternode(broadcastMsg) {
+    async startMasternode(_broadcastMsg) {
         throw new Error('startMasternode must be implemented');
     }
 

--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -81,10 +81,51 @@ export class Network {
         throw new Error('getTxInfo must be implemented');
     }
 
-    // TODO: this should be just a private function of RPCNodeNetwork
-    // However we use this in masternode.js, let's solve this in a future refactor
-    async callRPC(api, isText = false) {
-        throw new Error('callRPC must be implemented');
+    async getMasternodeInfo(_collateralTxId) {
+        throw new Error('getMasternodeInfo must be implemented');
+    }
+
+    async getMasternodeCount() {
+        throw new Error('getMasternodeCount must be implemented');
+    }
+
+    async getNextSuperblock() {
+        throw new Error('getNextSuperblock must be implemented');
+    }
+
+    async startMasternode(broadcastMsg) {
+        throw new Error('startMasternode must be implemented');
+    }
+
+    async getProposals() {
+        throw new Error('getProposals must be implemented');
+    }
+
+    async getProposalVote(_proposalName, _collateralTxId, _outidx) {
+        throw new Error('getProposalVote must be implemented');
+    }
+
+    async voteProposal(
+        _collateralTxId,
+        _outidx,
+        _hash,
+        _voteCode,
+        _sigTime,
+        _signature
+    ) {
+        throw new Error('voteProposal must be implemented');
+    }
+
+    async submitProposal({
+        name,
+        url,
+        nPayments,
+        start,
+        address,
+        monthlyPayment,
+        txid,
+    }) {
+        throw new Error('submitProposal must be implemented');
     }
 }
 
@@ -110,7 +151,7 @@ export class RPCNodeNetwork extends Network {
         return fetch(this.strUrl + api, options);
     }
 
-    async callRPC(api, isText = false) {
+    async #callRPC(api, isText = false) {
         const cRes = await this.#fetchNode(api);
         return isText ? await cRes.text() : await cRes.json();
     }
@@ -123,7 +164,7 @@ export class RPCNodeNetwork extends Network {
     async getBlock(blockHeight) {
         // First we fetch the blockhash (and strip RPC's quotes)
         const strHash = (
-            await this.callRPC(`/getblockhash?params=${blockHeight}`, true)
+            await this.#callRPC(`/getblockhash?params=${blockHeight}`, true)
         ).replace(/"/g, '');
         // Craft a filter to retrieve only raw Tx hex and txid, also change "tx" to "txs"
         const strFilter =
@@ -132,7 +173,7 @@ export class RPCNodeNetwork extends Network {
                 `. | .txs = [.tx[] | { hex: .hex, txid: .txid}] | del(.tx)`
             );
         // Fetch the full block (verbose)
-        return await this.callRPC(`/getblock?params=${strHash},2${strFilter}`);
+        return await this.#callRPC(`/getblock?params=${strHash},2${strFilter}`);
     }
 
     /**
@@ -140,16 +181,16 @@ export class RPCNodeNetwork extends Network {
      * @returns {Promise<number>} - Block height
      */
     async getBlockCount() {
-        return parseInt(await this.callRPC('/getblockcount', true));
+        return parseInt(await this.#callRPC('/getblockcount', true));
     }
 
     async getBestBlockHash() {
-        return await this.callRPC('/getbestblockhash', true);
+        return await this.#callRPC('/getbestblockhash', true);
     }
 
     async sendTransaction(hex) {
         // Use Nodes as a fallback
-        let strTXID = await this.callRPC(
+        let strTXID = await this.#callRPC(
             '/sendrawtransaction?params=' + hex,
             true
         );
@@ -161,7 +202,111 @@ export class RPCNodeNetwork extends Network {
      * @return {Promise<Number[]>} The list of blocks which have at least one shield transaction
      */
     async getShieldBlockList() {
-        return await this.callRPC('/getshieldblocks');
+        return await this.#callRPC('/getshieldblocks');
+    }
+
+    /**
+     * @param{string} collateralTxId - masternode collateral transaction id
+     * @param{number} outidx - masternode collateral output index
+     */
+    async getMasternodeInfo(collateralTxId, outidx) {
+        return (
+            await this.#callRPC(`/listmasternodes?params=${collateralTxId}`)
+        ).filter((m) => m.outidx === outidx);
+    }
+
+    async getMasternodeCount() {
+        return await this.#callRPC('/getmasternodecount');
+    }
+
+    /**
+     * @returns {Promise<number>} the block height of the next superblock
+     */
+    async getNextSuperblock() {
+        return parseInt(await this.#callRPC(`/getnextsuperblock`, true));
+    }
+
+    /**
+     * @param {string} broadcastMsg
+     */
+    async startMasternode(broadcastMsg) {
+        return await this.#callRPC(
+            `/relaymasternodebroadcast?params=${broadcastMsg}`,
+            true
+        );
+    }
+
+    async getProposals() {
+        return (await this.#callRPC(`/getbudgetinfo`)).filter(
+            (a) => a.RemainingPaymentCount > 0
+        );
+    }
+
+    /**
+     * Returns the proposal vote of a given masternode
+     * @param {string} proposalName - name of the proposal
+     * @param{string} collateralTxId - masternode collateral transaction id
+     * @param{number} outidx - masternode collateral output index
+     */
+    async getProposalVote(proposalName, collateralTxId, outidx) {
+        const filterString = `.[] | select(.mnId=="`;
+        const filter =
+            `${encodeURI(filterString)}` + `${collateralTxId}-${outidx}")`;
+        return await this.#callRPC(
+            `/getbudgetvotes?params=${proposalName}&filter=${filter}`
+        );
+    }
+
+    /**
+     * @param {string} collateralTxId - masternode collateral transaction id
+     * @param {number} outidx - masternode collateral output index
+     * @param {string} hash - the hash of the proposal to vote
+     * @param {number} voteCode - the vote code. "Yes" is 1, "No" is 2
+     * @param {number} sigTime - vote signature time
+     * @param {string} signature - vote signature
+     */
+    async voteProposal(
+        collateralTxId,
+        outidx,
+        hash,
+        voteCode,
+        sigTime,
+        signature
+    ) {
+        const url = `/mnbudgetrawvote?params=${collateralTxId},${outidx},${hash},${
+            voteCode === 1 ? 'yes' : 'no'
+        },${sigTime},${signature}`;
+        return await this.#callRPC(url, true);
+    }
+
+    /**
+     * Submit a proposal
+     * @param {Object} options
+     * @param {String} options.name - Name of the proposal
+     * @param {String} options.url - Url of the proposal
+     * @param {Number} options.nPayments - Number of cycles this proposal is gonna last
+     * @param {Number} options.start - Superblock of when the proposal is going to start
+     * @param {String} options.address - Base58 encoded PIVX address
+     * @param {Number} options.monthlyPayment - Payment amount per cycle in satoshi
+     * @param {String} options.txid - Transaction id of the proposal fee
+     */
+    async submitProposal({
+        name,
+        url,
+        nPayments,
+        start,
+        address,
+        monthlyPayment,
+        txid,
+    }) {
+        return await this.#callRPC(
+            `/submitbudget?params=${encodeURI(name)},${encodeURI(
+                url
+            )},${nPayments},${start},${encodeURI(
+                address
+            )},${monthlyPayment},${txid}`,
+            true
+        );
     }
 }
 

--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -153,7 +153,14 @@ export class RPCNodeNetwork extends Network {
 
     async #callRPC(api, isText = false) {
         const cRes = await this.#fetchNode(api);
-        return isText ? await cRes.text() : await cRes.json();
+        const cResTxt = await cRes.text();
+        if (isText) return cResTxt;
+        // RPC calls with filters might return empty string instead of empty JSON,
+        // In that case return an empty object
+        if (cResTxt.length === 0) {
+            return {};
+        }
+        return await JSON.parse(cResTxt);
     }
 
     /**

--- a/scripts/network/network_manager.js
+++ b/scripts/network/network_manager.js
@@ -178,8 +178,8 @@ class NetworkManager {
         }
     }
 
-    async getTxInfo(_txHash) {
-        return await this.#retryWrapper('getTxInfo', false, _txHash);
+    async getTxInfo(txHash) {
+        return await this.#retryWrapper('getTxInfo', false, txHash);
     }
 
     /**

--- a/scripts/network/network_manager.js
+++ b/scripts/network/network_manager.js
@@ -87,7 +87,11 @@ class NetworkManager {
             } catch (error) {
                 debugLog(
                     DebugTopics.NET,
-                    attemptNet.strUrl + ' failed on ' + funcName
+                    attemptNet.strUrl +
+                        ' failed on ' +
+                        funcName +
+                        ' with error ' +
+                        error
                 );
                 // If allowed, switch instances
                 if (!fAutoSwitch || attempts === nMaxTries) {
@@ -178,8 +182,108 @@ class NetworkManager {
         return await this.#retryWrapper('getTxInfo', false, _txHash);
     }
 
-    async callRPC(api, isText = false) {
-        return await this.#retryWrapper('callRPC', true, api, isText);
+    /**
+     * @param{string} collateralTxId - masternode collateral transaction id
+     * @param{number} outidx - masternode collateral output index
+     */
+    async getMasternodeInfo(collateralTxId, outidx) {
+        return await this.#retryWrapper(
+            'getMasternodeInfo',
+            true,
+            collateralTxId,
+            outidx
+        );
+    }
+
+    async getMasternodeCount() {
+        return await this.#retryWrapper('getMasternodeCount', true);
+    }
+
+    async getNextSuperblock() {
+        return await this.#retryWrapper('getNextSuperblock', true);
+    }
+
+    async startMasternode(broadcastMsg) {
+        return await this.#retryWrapper('startMasternode', true, broadcastMsg);
+    }
+
+    async getProposals() {
+        return await this.#retryWrapper('getProposals', true);
+    }
+
+    /**
+     * Returns the proposal vote of a given masternode
+     * @param {string} proposalName - name of the proposal
+     * @param{string} collateralTxId - masternode collateral transaction id
+     * @param{number} outidx - masternode collateral output index
+     */
+    async getProposalVote(proposalName, collateralTxId, outidx) {
+        return await this.#retryWrapper(
+            'getProposalVote',
+            true,
+            proposalName,
+            collateralTxId,
+            outidx
+        );
+    }
+
+    /**
+     * @param {string} collateralTxId - masternode collateral transaction id
+     * @param {number} outidx - masternode collateral output index
+     * @param {string} hash - the hash of the proposal to vote
+     * @param {number} voteCode - the vote code. "Yes" is 1, "No" is 2
+     * @param {number} sigTime - vote signature time
+     * @param {string} signature - vote signature
+     */
+    async voteProposal(
+        collateralTxId,
+        outidx,
+        hash,
+        voteCode,
+        sigTime,
+        signature
+    ) {
+        return await this.#retryWrapper(
+            'voteProposal',
+            true,
+            collateralTxId,
+            outidx,
+            hash,
+            voteCode,
+            sigTime,
+            signature
+        );
+    }
+
+    /**
+     * Submit a proposal
+     * @param {Object} options
+     * @param {String} options.name - Name of the proposal
+     * @param {String} options.url - Url of the proposal
+     * @param {Number} options.nPayments - Number of cycles this proposal is gonna last
+     * @param {Number} options.start - Superblock of when the proposal is going to start
+     * @param {String} options.address - Base58 encoded PIVX address
+     * @param {Number} options.monthlyPayment - Payment amount per cycle in satoshi
+     * @param {String} options.txid - Transaction id of the proposal fee
+     */
+    async submitProposal({
+        name,
+        url,
+        nPayments,
+        start,
+        address,
+        monthlyPayment,
+        txid,
+    }) {
+        return await this.#retryWrapper('submitProposal', true, {
+            name,
+            url,
+            nPayments,
+            start,
+            address,
+            monthlyPayment,
+            txid,
+        });
     }
 
     static #instance = new NetworkManager();


### PR DESCRIPTION
## Abstract

First commit:

Make `callRPC` private method of `RPCNodeNetwork`. In this way other classes cannot make random RPC requests and are forced to use the `NetworkManager` interface.

Second commit:
fix the following bug: some filtered RPC requests like
```
 const filterString = `.[] | select(.mnId=="`;
        const filter =
            `${encodeURI(filterString)}` + `${collateralTxId}-${outidx}")`;
        return await this.#callRPC(
            `/getbudgetvotes?params=${proposalName}&filter=${filter}`
        );
```
returns an empty string instead of an empty JSON if there are no matches. The result was that
```
await cRes.json();
```
was throwing false errors when trying to transform to JSON.
---
