### PR TITLE
Increase alert timeout and set it on createAlert too

### DIFF
--- a/scripts/alerts/alert.js
+++ b/scripts/alerts/alert.js
@@ -56,7 +56,7 @@ export class AlertController {
      * @param {string} message - The message to relay to the user
      * @param {number?} timeout - The time in `ms` until the alert expires (Defaults to never expiring)
      */
-    createAlert(level, message, timeout = 2000) {
+    createAlert(level, message, timeout = 10000) {
         this.addAlert(new Alert({ level, message, timeout }));
     }
 
@@ -95,7 +95,7 @@ export class AlertController {
  * @param {string} message - The message to relay to the user
  * @param {number?} [timeout] - The time in `ms` until the alert expires (Defaults to never expiring)
  */
-export function createAlert(type, message, timeout = 0) {
+export function createAlert(type, message, timeout) {
     const alertController = AlertController.getInstance();
     return alertController.createAlert(type, message, timeout);
 }


### PR DESCRIPTION
## Abstract

Some alerts, like the uncaught exception ones were not showing because the default timeout was 0.
This PR removes the default `0` timeout, and increases the `AlertController::createAlert` timeout to 10s.
This makes the unhandled exception alert show again 
![image](https://github.com/user-attachments/assets/67c38d5b-de2b-4f34-b4a8-bd9668e4c86d)

## Testing
- Trigger some alerts