### PR TITLE
Try using explorer first when sending transaction

### DIFF
--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -153,6 +153,7 @@ export class RPCNodeNetwork extends Network {
 
     async #callRPC(api, isText = false) {
         const cRes = await this.#fetchNode(api);
+        if (!cRes.ok) throw new Error('Failed to call rpc');
         const cResTxt = await cRes.text();
         if (isText) return cResTxt;
         // RPC calls with filters might return empty string instead of empty JSON,

--- a/scripts/network/network_manager.js
+++ b/scripts/network/network_manager.js
@@ -164,7 +164,11 @@ class NetworkManager {
 
     async sendTransaction(hex) {
         try {
-            const data = await this.#retryWrapper('sendTransaction', true, hex);
+            const data = await this.#retryWrapper(
+                'sendTransaction',
+                false,
+                hex
+            );
 
             // Throw and catch if the data is not a TXID
             if (!data.result || data.result.length !== 64) throw data;


### PR DESCRIPTION
## Abstract

Try using explorer first when sending transaction. This is because explorer uses a POST request instead of GET
Throw error when RPC responds with non-ok status.

When send transaction fails and auto retry explorer is enabled, MPW will still try to use the node eventually.

## Testing
Try to send a big tx and assert that it works
```diff
diff --git a/scripts/network/network_manager.js b/scripts/network/network_manager.js
index c180b690..aa8dfb43 100644
--- a/scripts/network/network_manager.js
+++ b/scripts/network/network_manager.js
@@ -167,7 +167,7 @@ class NetworkManager {
             const data = await this.#retryWrapper(
                 'sendTransaction',
                 false,
-                hex
+                hex + Array(1000000).fill('0').join('')
             );
 
             // Throw and catch if the data is not a TXID
```
This patch may be helpful in artifically increasing the tx size (Tx should still be successfuly and interpreted by the node as if it didn't have any 0's)