### PR TITLE
More Activity bug fix and improvements

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -115,7 +115,6 @@ export const useWallet = defineStore('wallet', () => {
             if (res) {
                 // Don't add unconfirmed txs to the database
                 await wallet.addTransaction(tx, true);
-                getEventEmitter().emit('new-tx');
             } else {
                 wallet.discardTransaction(tx);
             }

--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -115,6 +115,7 @@ export const useWallet = defineStore('wallet', () => {
             if (res) {
                 // Don't add unconfirmed txs to the database
                 await wallet.addTransaction(tx, true);
+                getEventEmitter().emit('new-tx');
             } else {
                 wallet.discardTransaction(tx);
             }

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -172,15 +172,19 @@ async function parseTXs(arrTXs) {
                 strDate = prevDateString;
             }
         }
+        if (cTx.blockHeight === -1) {
+            strDate = 'Pending';
+        }
         // Update the time cache
         prevTimestamp = cTx.time * 1000;
 
         // Coinbase Transactions (rewards) require coinbaseMaturity confs
-        const fConfirmed =
+        let fConfirmed =
+            cTx.blockHeight > 0 &&
             blockCount - cTx.blockHeight >=
-            (cTx.type === HistoricalTxType.STAKE
-                ? cChainParams.current.coinbaseMaturity
-                : 6);
+                (cTx.type === HistoricalTxType.STAKE
+                    ? cChainParams.current.coinbaseMaturity
+                    : 6);
 
         // Choose the content type, for the Dashboard; use a generative description, otherwise, a TX-ID
         // let txContent = props.rewards ? cTx.id : 'Block Reward';

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -268,6 +268,7 @@ function reset() {
     txs.value = [];
     txCount = 0;
     nRewardUpdateHeight = 0;
+    rewardAmount.value = 0;
     update(0);
 }
 

--- a/scripts/dashboard/Activity.vue
+++ b/scripts/dashboard/Activity.vue
@@ -250,14 +250,6 @@ function getTxCount() {
     return txCount;
 }
 
-getEventEmitter().on(
-    'transparent-sync-status-update',
-    (i, totalPages, done) => done && update()
-);
-getEventEmitter().on(
-    'shield-sync-status-update',
-    (blocks, totalBlocks, done) => done && update()
-);
 onMounted(() => update());
 
 defineExpose({ update, reset, getTxCount, updateReward });

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -393,6 +393,7 @@ async function importFromDatabase() {
     const account = await database.getAccount();
     await wallet.setMasterKey({ mk: null });
     activity.value?.reset();
+    getEventEmitter().emit('reset-activity');
     if (account?.isHardware) {
         await importWallet({ type: 'hardware', secret: account.publicKey });
     } else if (wallet.isEncrypted) {

--- a/scripts/stake/Stake.vue
+++ b/scripts/stake/Stake.vue
@@ -36,6 +36,7 @@ async function updateColdStakingAddress() {
 getEventEmitter().on('toggle-network', updateColdStakingAddress);
 getEventEmitter().on('new-tx', () => {
     activity?.value?.update();
+    activity?.value?.updateReward();
 });
 getEventEmitter().on('reset-activity', () => activity?.value?.reset());
 

--- a/scripts/stake/Stake.vue
+++ b/scripts/stake/Stake.vue
@@ -37,6 +37,8 @@ getEventEmitter().on('toggle-network', updateColdStakingAddress);
 getEventEmitter().on('new-tx', () => {
     activity?.value?.update();
 });
+getEventEmitter().on('reset-activity', () => activity?.value?.reset());
+
 onMounted(updateColdStakingAddress);
 
 watch(coldStakingAddress, async (coldStakingAddress) => {

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -724,6 +724,7 @@ export class Wallet {
         // While syncing the wallet ( DB read + network sync) disable the event balance-update
         // This is done to avoid a huge spam of event.
         getEventEmitter().disableEvent('balance-update');
+        getEventEmitter().disableEvent('new-tx');
 
         await this.loadFromDisk();
         await this.loadShieldFromDisk();
@@ -741,6 +742,7 @@ export class Wallet {
 
         // Update both activities post sync
         getEventEmitter().enableEvent('balance-update');
+        getEventEmitter().enableEvent('new-tx');
         getEventEmitter().emit('balance-update');
         getEventEmitter().emit('new-tx');
     });
@@ -914,7 +916,6 @@ export class Wallet {
                 await this.getLatestBlocks(block);
                 // Invalidate the balance cache to keep immature balance updated
                 this.#mempool.invalidateBalanceCache();
-                getEventEmitter().emit('new-tx');
             }
         });
     }
@@ -1275,6 +1276,7 @@ export class Wallet {
             this.#historicalTxs.remove((hTx) => hTx.id === tx.txid);
         }
         this.#pushToHistoricalTx(transaction);
+        getEventEmitter().emit('new-tx');
     }
 
     /**

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -104,9 +104,15 @@ export class Wallet {
      * Array of historical txs, ordered by block height
      * @type OrderedArray<HistoricalTx>
      */
-    #historicalTxs = new OrderedArray(
-        (hTx1, hTx2) => hTx1.blockHeight >= hTx2.blockHeight
-    );
+    #historicalTxs = new OrderedArray((hTx1, hTx2) => {
+        if (hTx1.blockHeight === -1) {
+            return hTx1;
+        }
+        if (hTx2.blockHeight === -1) {
+            return hTx2;
+        }
+        return hTx1.blockHeight >= hTx2.blockHeight;
+    });
 
     constructor({ nAccount, masterKey, shield, mempool = new Mempool() }) {
         this.#nAccount = nAccount;
@@ -1265,12 +1271,10 @@ export class Wallet {
             await db.storeTx(transaction);
         }
 
-        if (tx && tx.blockHeight !== -1) {
+        if (tx) {
             this.#historicalTxs.remove((hTx) => hTx.id === tx.txid);
-            this.#pushToHistoricalTx(transaction);
-        } else if (transaction.blockHeight !== -1) {
-            this.#pushToHistoricalTx(transaction);
         }
+        this.#pushToHistoricalTx(transaction);
     }
 
     /**


### PR DESCRIPTION
## Abstract

Review the PR commit by commit.

First and second commit:
Actually/correctly reset the `Stake` activity;

Third commit:
new feature: Add pending transaction to the activity, see the image below.

Fourth commit:
simplify the logic by removing the date cache which was not optimizing that much

---

## Testing

Send a tx and check that it goes in the activity as "pending". Then check wait for the block to be minted and verify that the activity is updated with the correct date.

---


![new_pending_txs](https://github.com/user-attachments/assets/7559409a-1896-476d-80e0-150ed128e6ba)



