### PR TITLE
Improve shield sync time

### DIFF
--- a/scripts/reader.js
+++ b/scripts/reader.js
@@ -38,6 +38,9 @@ export class Reader {
                 }
                 if (done) {
                     this.#done = true;
+                    if (this.#awaiter) {
+                        this.#awaiter();
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
## Abstract

Fix a edge case of #471 that led to sync never finishing.

Also profiling showed that a batch size in the range ~[10,100] gives fastest results. So I set it to 10 in order to have a smoother progress bar.

I left the profiling timers because they are very useful to test shield lib optimization PRs.

---