### PR TITLE
Integration test for getHistoricalTxs()

### DIFF
--- a/tests/integration/wallet/sync.spec.js
+++ b/tests/integration/wallet/sync.spec.js
@@ -237,9 +237,11 @@ describe('Wallet sync tests', () => {
         let addr = walletHD.getCurrentAddress();
         let blockHeight = getNetwork().getBlockCount() + 1;
         await createAndSendTransaction(walletLegacy, addr, 0.01 * 10 ** 8);
+
         // Sanity check: Before mining the block the history is unchanged (receiving from external wallet)
         getHistDiff(walletHD.getHistoricalTxs(), prevIds, 0);
         checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+
         // Mine and assert that a new tx has been added
         await mineBlocks(1);
         let diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
@@ -252,10 +254,12 @@ describe('Wallet sync tests', () => {
             type: HistoricalTxType.RECEIVED,
             receivers: [addr, walletLegacy.getCurrentAddress()],
         });
+
         // 2) This time send a transaction (To external wallet)
         blockHeight = getNetwork().getBlockCount() + 1;
         addr = walletLegacy.getCurrentAddress();
         await createAndSendTransaction(walletHD, addr, 0.5 * 10 ** 8);
+
         // Since walletHD created the tx, it must already be in its history... even without mining a block
         diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
         checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
@@ -265,6 +269,7 @@ describe('Wallet sync tests', () => {
             type: HistoricalTxType.SENT,
             receivers: [addr],
         });
+
         await mineBlocks(1);
         diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
         checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
@@ -276,10 +281,12 @@ describe('Wallet sync tests', () => {
         });
         diffCache.push(diff[0]);
         prevIds.push(diff[0].id);
+
         // 3) Create a self transaction
         blockHeight = getNetwork().getBlockCount() + 1;
         addr = walletHD.getCurrentAddress();
         await createAndSendTransaction(walletHD, addr, 0.2 * 10 ** 8);
+
         diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
         checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
         checkHistDiff(diff[0], {
@@ -288,6 +295,7 @@ describe('Wallet sync tests', () => {
             type: HistoricalTxType.SENT,
             receivers: [addr],
         });
+
         await mineBlocks(1);
         diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
         checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);

--- a/tests/integration/wallet/sync.spec.js
+++ b/tests/integration/wallet/sync.spec.js
@@ -13,6 +13,7 @@ import {
 import { refreshChainData } from '../../../scripts/global.js';
 import { COIN } from '../../../scripts/chain_params.js';
 import { flushPromises } from '@vue/test-utils';
+import { HistoricalTxType } from '../../../scripts/historical_tx.js';
 
 vi.mock('../../../scripts/network/network_manager.js');
 
@@ -222,7 +223,126 @@ describe('Wallet sync tests', () => {
         await mineBlocks(1);
         expect(walletHD.getCurrentAddress()).toBe(newAddress);
     });
+    it('correctly updates historical txs', async () => {
+        // Keep track of previous historical txs
+        let prevIds = walletHD.getHistoricalTxs().map((hTx) => {
+            return hTx.id;
+        });
+        /**
+         * @type {HistoricalTx[]}
+         */
+        let diffCache = [].concat(walletHD.getHistoricalTxs());
+
+        // 1) Receive a transaction to the current address
+        let addr = walletHD.getCurrentAddress();
+        let blockHeight = getNetwork().getBlockCount() + 1;
+        await createAndSendTransaction(walletLegacy, addr, 0.01 * 10 ** 8);
+        // Sanity check: Before mining the block the history is unchanged (receiving from external wallet)
+        getHistDiff(walletHD.getHistoricalTxs(), prevIds, 0);
+        checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+        // Mine and assert that a new tx has been added
+        await mineBlocks(1);
+        let diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
+        checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+        prevIds.push(diff[0].id);
+        diffCache.push(diff[0]);
+        checkHistDiff(diff[0], {
+            blockHeight,
+            isToSelf: false,
+            type: HistoricalTxType.RECEIVED,
+            receivers: [addr, walletLegacy.getCurrentAddress()],
+        });
+        // 2) This time send a transaction (To external wallet)
+        blockHeight = getNetwork().getBlockCount() + 1;
+        addr = walletLegacy.getCurrentAddress();
+        await createAndSendTransaction(walletHD, addr, 0.5 * 10 ** 8);
+        // Since walletHD created the tx, it must already be in its history... even without mining a block
+        diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
+        checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+        checkHistDiff(diff[0], {
+            blockHeight: -1, // pending block height
+            isToSelf: false,
+            type: HistoricalTxType.SENT,
+            receivers: [addr],
+        });
+        await mineBlocks(1);
+        diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
+        checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+        checkHistDiff(diff[0], {
+            blockHeight,
+            isToSelf: false,
+            type: HistoricalTxType.SENT,
+            receivers: [walletLegacy.getCurrentAddress()],
+        });
+        diffCache.push(diff[0]);
+        prevIds.push(diff[0].id);
+        // 3) Create a self transaction
+        blockHeight = getNetwork().getBlockCount() + 1;
+        addr = walletHD.getCurrentAddress();
+        await createAndSendTransaction(walletHD, addr, 0.2 * 10 ** 8);
+        diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
+        checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+        checkHistDiff(diff[0], {
+            blockHeight: -1, // pending block height
+            isToSelf: true,
+            type: HistoricalTxType.SENT,
+            receivers: [addr],
+        });
+        await mineBlocks(1);
+        diff = getHistDiff(walletHD.getHistoricalTxs(), prevIds, 1);
+        checkHistPersistence(walletHD.getHistoricalTxs(), diffCache);
+        checkHistDiff(diff[0], {
+            blockHeight,
+            isToSelf: true,
+            type: HistoricalTxType.SENT,
+            receivers: [addr],
+        });
+    });
     afterAll(() => {
         vi.clearAllMocks();
     });
+
+    /**
+     * @param {HistoricalTx[]} historicalTxs
+     * @param {string[]} txIds
+     * @param {number} expectedLength - expected size of the diff
+     * @returns {HistoricalTx[]} the history difference
+     */
+    function getHistDiff(historicalTxs, txIds, expectedLength) {
+        const diff = historicalTxs.filter((hTx) => {
+            return !txIds.includes(hTx.id);
+        });
+        expect(diff.length).toBe(expectedLength);
+        return diff;
+    }
+
+    /**
+     * @typedef {Object} SimplifiedHistoricalTx
+     * @property {number} blockHeight
+     * @property {HistoricalTxType} type
+     * @property {boolean} isToSelf
+     * @property {string[]} receivers - a SUBSET of the receivers of a historical tx
+     */
+
+    /**
+     * @param {HistoricalTx} historicalTx
+     * @param {SimplifiedHistoricalTx} exp
+     */
+    function checkHistDiff(historicalTx, exp) {
+        expect(historicalTx.blockHeight).toStrictEqual(exp.blockHeight);
+        expect(historicalTx.type).toStrictEqual(exp.type);
+        expect(historicalTx.isToSelf).toStrictEqual(exp.isToSelf);
+        for (let r of exp.receivers) {
+            expect(historicalTx.receivers.includes(r)).toBeTruthy();
+        }
+    }
+    /**
+     * @param {HistoricalTx[]} historicalTxs
+     * @param {HistoricalTx[]} diffCache
+     */
+    function checkHistPersistence(historicalTxs, diffCache) {
+        for (let hTx of diffCache) {
+            expect(historicalTxs.includes(hTx)).toBeTruthy();
+        }
+    }
 });


### PR DESCRIPTION
## Abstract

Add integration tests for the wallet method `getHistoricalTxs()`. The following things are tested:

- `HistoricalTxs` are correctly updated when a new block is received
- When a transaction is created, it is added as pending `HistoricalTx`
- When the corresponding block is mined, pending transaction are marked as non-pending
- Old non-pending `HistoricalTxs` don't change when a new block is received



Note: this tests are NOT testing that the final Activity displayed is correct.

---