### PR TITLE
Silence tests

### DIFF
--- a/debug_config.json
+++ b/debug_config.json
@@ -8,5 +8,6 @@
     "governance": true,
     "i18n": true,
     "ledger": true,
-    "masternode": true
+    "masternode": true,
+    "vanity_gen": true
 }

--- a/scripts/dashboard/VanityGen.vue
+++ b/scripts/dashboard/VanityGen.vue
@@ -6,6 +6,7 @@ import { ref, computed, watch, nextTick } from 'vue';
 import { cChainParams } from '../chain_params.js';
 import { MAP_B58 } from '../misc.js';
 import { useAlerts } from '../composables/use_alerts.js';
+import { debugLog, DebugTopics } from '../debug.js';
 
 const { createAlert } = useAlerts();
 const addressPrefix = ref('');
@@ -72,7 +73,10 @@ function generate() {
         Math.floor(window.navigator.hardwareConcurrency * 0.75),
         1
     );
-    console.log('Spawning ' + nThreads + ' vanity search threads!');
+    debugLog(
+        DebugTopics.VANITY_GEN,
+        'Spawning ' + nThreads + ' vanity search threads!'
+    );
     for (let i = 0; i < nThreads; i++) {
         const worker = new Worker(
             new URL('../vanitygen_worker.js', import.meta.url)
@@ -83,7 +87,8 @@ function generate() {
             if (data.pub.substr(1, prefix.length).toLowerCase() === prefix) {
                 try {
                     emit('import-wallet', data.priv);
-                    console.log(
+                    debugLog(
+                        DebugTopics.VANITY_GEN,
                         `VANITY: Found an address after ${attempts.value} attempts!`
                     );
                 } finally {

--- a/scripts/debug.js
+++ b/scripts/debug.js
@@ -82,6 +82,7 @@ export const DebugTopics = {
     I18N: new DebugTopic('[I18N]', 1 << 7),
     LEDGER: new DebugTopic('[LEDGER]', 1 << 8),
     MASTERNODE: new DebugTopic('[MASTERNODE]', 1 << 9),
+    VANITY_GEN: new DebugTopic('[VANITY_GEN]', 1 << 10),
 };
 
 let enabledDebug = 0;

--- a/test_setup.js
+++ b/test_setup.js
@@ -1,5 +1,8 @@
 import { vi } from 'vitest';
 import 'fake-indexeddb/auto';
+vi.spyOn(console, 'warn').mockImplementation((message) => {
+    if (message?.includes && message?.includes('[vue]')) return;
+});
 
 // We need to attach the component to a HTML,
 // or .isVisible() function does not work


### PR DESCRIPTION
## Abstract

Silence test warnings and add debugLog instead of console.log in VanityGen.
Adding console.logs in tests for debugging during development still works as intended.
Fixes #414 

## Testing
- Green CI