### PR TITLE
Reset db on wallet reset

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -291,6 +291,7 @@ export class Wallet {
         this.#mempool = new Mempool();
         this.#lastProcessedBlock = 0;
         this.#historicalTxs.clear();
+        const db = await Database.getInstance();
         await db.removeAllTxs();
     }
 

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -245,7 +245,7 @@ export class Wallet {
         this.#nAccount = nAccount;
         if (extsk) await this.setExtsk(extsk);
         if (isNewAcc) {
-            this.reset();
+            await this.reset();
             this.#iterChains((chain) => {
                 this.#loadAddresses(chain);
             });
@@ -276,7 +276,7 @@ export class Wallet {
     /**
      * Reset the wallet, indexes address map and so on
      */
-    reset() {
+    async reset() {
         this.#highestUsedIndices = new Map();
         this.#loadedIndexes = new Map();
         this.#ownAddresses = new Map();
@@ -291,6 +291,7 @@ export class Wallet {
         this.#mempool = new Mempool();
         this.#lastProcessedBlock = 0;
         this.#historicalTxs.clear();
+        await db.removeAllTxs();
     }
 
     /**


### PR DESCRIPTION
## Abstract

Reset db on Wallet::reset
This is supposed to be handled by loadFromDisk, but perhaps on some edge cases it will not trigger

## Testing
- Idk this is just a guess