### PR TITLE
Accept X-Content-Length as fallback too

### DIFF
--- a/scripts/reader.js
+++ b/scripts/reader.js
@@ -26,7 +26,6 @@ export class Reader {
      * @param
      */
     constructor(req) {
-        debugger;
         this.#availableBytes = new Uint8Array(
             req.headers?.get('Content-Length') ||
                 req.headers?.get('X-Content-Length') ||

--- a/scripts/reader.js
+++ b/scripts/reader.js
@@ -26,8 +26,11 @@ export class Reader {
      * @param
      */
     constructor(req) {
+        debugger;
         this.#availableBytes = new Uint8Array(
-            req.headers?.get('Content-Length') || 1024
+            req.headers?.get('Content-Length') ||
+                req.headers?.get('X-Content-Length') ||
+                1024
         );
         const stream = req.body.getReader();
         (async () => {


### PR DESCRIPTION
## Abstract

Accept custom X-Content-Length header if Content-Header is missing.
This is required when response is compressed

## Testing
Check that rpc.duddino.com shield data response size is displayed correctly