### PR TITLE
Sync transparent sync after shield sync (if available)

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -804,12 +804,13 @@ export class Wallet {
         // This is just to be sure since blockbook (as we know)
         // usually does not return txs of the actual last block.
         this.#lastProcessedBlock = blockCount - 5;
-        await this.#transparentSync();
+
         if (this.hasShield()) {
             debugTimerStart(DebugTopics.WALLET, 'syncShield');
             await this.#syncShield();
             debugTimerEnd(DebugTopics.WALLET, 'syncShield');
         }
+        await this.#transparentSync();
         this.#isSynced = true;
         // At this point download the last missing blocks in the range (blockCount -5, blockCount]
         await this.#getLatestBlocks(blockCount);
@@ -1046,8 +1047,8 @@ export class Wallet {
             this.#mempool = new Mempool();
             await this.#resetShield();
             this.#isSynced = false;
-            await this.#transparentSync();
             await this.#syncShield();
+            await this.#transparentSync();
             return false;
         }
         return true;

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -766,9 +766,12 @@ export class Wallet {
                 shieldDebit += spentNote.value;
             }
         }
-        const myOutputNotes = await this.#shield.decryptTransactionOutputs(
-            tx.serialize()
-        );
+        let myOutputNotes = [];
+        try {
+            myOutputNotes = await this.#shield.decryptTransactionOutputs(
+                tx.serialize()
+            );
+        } catch (e) {}
         for (const note of myOutputNotes) {
             shieldCredit += note.value;
             arrShieldReceivers.push(note.recipient);


### PR DESCRIPTION
## Abstract

MPW sometimes failed to perform transparent sync when importing a wallet.
This is probably because it was trying to decrypt transactions for shield activity before actually having synced the shield
This PR just switches the order of shield and transparent sync 

## Testing
The bug seemed to happen when the stream failed for whatever reason. So try doing that 