### PR TITLE
Render the 'unhandled exception' title in bold

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -580,7 +580,7 @@ export function switchSettings(page) {
 }
 
 function errorHandler(e) {
-    const message = `${translation.unhandledException} <br> ${sanitizeHTML(
+    const message = `<b>${translation.unhandledException}</b><br>${sanitizeHTML(
         e.message || e.reason
     )}`;
     try {


### PR DESCRIPTION
## Abstract

A tiny PR fixing the consistency of a notification - all notifications should highlight the title in bold for design consistency.

![image](https://github.com/user-attachments/assets/ea731b4e-7c02-4f64-969e-4aa44df4db91)

---

## Testing
None, really.

---