### PR TITLE
Fix all linting warnings

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -2,16 +2,9 @@ import { TransactionBuilder } from './transaction_builder.js';
 import { ALERTS, start as i18nStart, translation } from './i18n.js';
 import { wallet, hasEncryptedWallet, Wallet } from './wallet.js';
 import { getNetwork } from './network/network_manager.js';
-import {
-    start as settingsStart,
-    strCurrency,
-    fAdvancedMode,
-} from './settings.js';
-import { createAndSendTransaction } from './legacy.js';
+import { start as settingsStart, strCurrency } from './settings.js';
 import { createAlert } from './alerts/alert.js';
-import { confirmPopup, sanitizeHTML } from './misc.js';
-import { cChainParams, COIN } from './chain_params.js';
-import { sleep } from './utils.js';
+import { sanitizeHTML } from './misc.js';
 import { registerWorker } from './native.js';
 import { getEventEmitter } from './event_bus.js';
 import { checkForUpgrades } from './changelog.js';


### PR DESCRIPTION
## Abstract

Another tiny PR that simply fixes all 6 linting warnings due to unused `global.js` variables.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- No functional testing, just run `npm run lint` yourself on `master` and assert that they are all resolved by this PR.

---