### PR TITLE
Fix Governance Budget + Superblock display on iOS Safari

### DIFF
--- a/scripts/governance/Governance.vue
+++ b/scripts/governance/Governance.vue
@@ -206,7 +206,7 @@ async function vote(proposal, voteCode) {
         @create="createProposal"
     />
     <div>
-        <div class="col-md-12 title-section float-left rm-pd">
+        <div class="col-md-12 title-section rm-pd">
             <span
                 style="
                     font: 23px 'Montserrat Regular';


### PR DESCRIPTION
## Abstract

After dropping 6 IQ points from an hour of random testing, I found that removing the class `float-left` from the parent div of the upper Governance display fixes the iOS rendering without any noticeable difference on Desktop.

**Production (v2.1):**
![image](https://github.com/user-attachments/assets/9c7a179f-2504-4eaa-b218-eda053f5c141)

**Pull Request:**
![image](https://github.com/user-attachments/assets/5774287d-4240-4a82-add1-85396665e4af)


---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- (if iPhone owner): check that the Governance tab renders nicely on Safari.
- (if non-iPhone owner): check that the Governance tab looks fine on your own device(s), both Mobile and Desktop.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---