### PR TITLE
Export Wallet fixes

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -2685,6 +2685,7 @@ a {
     width: 85%;
     text-align: center;
     transition: all .2s ease-in-out;
+    word-break: break-all;
 }
 
 .dcWallet-privateKeyDiv .blurred {

--- a/scripts/dashboard/ExportPrivKey.vue
+++ b/scripts/dashboard/ExportPrivKey.vue
@@ -15,7 +15,7 @@ const blur = ref(true);
 const emit = defineEmits(['close']);
 
 function downloadWalletFile() {
-    downloadBlob(props.privateKey, 'wallet.json', 'text/csv;charset=utf-8;');
+    downloadBlob(props.privateKey, 'wallet.json', 'application/json;charset=utf-8;');
 }
 
 function close() {

--- a/scripts/dashboard/ExportPrivKey.vue
+++ b/scripts/dashboard/ExportPrivKey.vue
@@ -71,7 +71,7 @@ function close() {
                     >
                         <span
                             data-i18n="saveWalletFile"
-                            class="buttoni-text"
+                            class="buttoni-icon"
                             v-html="pIconExport"
                         >
                         </span>

--- a/scripts/dashboard/ExportPrivKey.vue
+++ b/scripts/dashboard/ExportPrivKey.vue
@@ -15,7 +15,11 @@ const blur = ref(true);
 const emit = defineEmits(['close']);
 
 function downloadWalletFile() {
-    downloadBlob(props.privateKey, 'wallet.json', 'application/json;charset=utf-8;');
+    downloadBlob(
+        props.privateKey,
+        'wallet.json',
+        'application/json;charset=utf-8;'
+    );
 }
 
 function close() {


### PR DESCRIPTION
## Abstract

This small PR has various fixes for our Export Wallet feature:
- The file type in the File Export button is now correct (`.json` instead of `.csv`).
- The file export icon now renders correctly; previously, it was invisible.
- The private key text now word-wraps symmetrically; nicer on the eyes, uses less height, and easier to copy/paste.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Check that the 'file export' button icon is displayed.
- Check that the plaintext export data word-wraps symmetrically and evenly.
- Check that the file export's file type is the correct type (`json`).

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---