### PR TITLE
Various PIVX Promos fixes

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -16,7 +16,7 @@ import {
 } from '../misc.js';
 import { ALERTS, translation, tr } from '../i18n.js';
 import { HardwareWalletMasterKey, HdMasterKey } from '../masterkey';
-import { COIN } from '../chain_params';
+import { COIN, cChainParams } from '../chain_params';
 import { onMounted, ref, watch, computed } from 'vue';
 import { getEventEmitter } from '../event_bus';
 import { Database } from '../database';
@@ -791,7 +791,13 @@ defineExpose({
                                                         "
                                                         class="text-center"
                                                     >
-                                                        <b> Amount </b>
+                                                        <b>
+                                                            {{
+                                                                cChainParams
+                                                                    .current
+                                                                    .TICKER
+                                                            }}
+                                                        </b>
                                                     </td>
                                                     <td
                                                         style="
@@ -800,7 +806,12 @@ defineExpose({
                                                                 solid #534270;
                                                         "
                                                         class="text-center"
-                                                    ></td>
+                                                    >
+                                                        <i
+                                                            onclick="MPW.promosToCSV()"
+                                                            class="fa-solid fa-lg fa-file-csv ptr"
+                                                        ></i>
+                                                    </td>
                                                 </tr>
                                             </thead>
                                             <tbody


### PR DESCRIPTION
## Abstract

This PR fixes various PIVX Promos UX issues.
- Re-adds the CSV Export button, resolves #491
- Move the `PIV` ticker outside of in-line in replacement of the `Amount` title, for extra table space.
- Change the "default-max code length" to a const and use it everywhere.
- Remove additional entropy on codes over `MAX_LENGTH`, which is currently 10.
- Use the unicode ellipsis instead of a manual `...` one, which is smaller, as it's a single character length.

*Example of a >10 length code and an exactly 10 length code, rendering nicely without any wrapping.*
![image](https://github.com/user-attachments/assets/93c93996-143c-4ba0-a57d-a3b9deb27467)

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test CSV exports for PIVX Promos.
- Test that <10 length codes are created with entropy, 10 length codes have no entropy or cutoff, and >10 have no entropy but cut-off to prevent overflow scrolling.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---