### PR TITLE
Change bytes to num function

### DIFF
--- a/scripts/encoding.js
+++ b/scripts/encoding.js
@@ -272,7 +272,7 @@ export function numToByteArray(num) {
 export function bytesToNum(bytes) {
     let result = 0n;
     for (let i = 0n; i < BigInt(bytes.length); i++) {
-        result += BigInt(bytes[i]) * (256n ** i);
+        result += BigInt(bytes[i]) * 256n ** i;
     }
     return result;
 }

--- a/scripts/encoding.js
+++ b/scripts/encoding.js
@@ -270,8 +270,11 @@ export function numToByteArray(num) {
  * @returns {BigInt} converted number from bytes
  */
 export function bytesToNum(bytes) {
-    if (bytes.length === 0) return 0n;
-    else return BigInt(bytes[0]) + 256n * bytesToNum(bytes.slice(1));
+    let result = 0n;
+    for (let i = 0n; i < BigInt(bytes.length); i++) {
+        result += BigInt(bytes[i]) * (256n ** i);
+    }
+    return result;
 }
 
 /**


### PR DESCRIPTION
## Abstract

Shield sync sometimes failed. This is because valueBalance was out of bounds.
Debugging with advanced tools such as console logs revealed that MPW always picked up the correct array, but sometimes `bytesToNum` gave a wrong answer. Why and why does it only do it sometimes? I have no clue.
Hopefully this fixes the issue 

## Testing
Sync shield a bunch of times?