### PR TITLE
Add privacy warning for XPub sharing

### DIFF
--- a/scripts/contacts-book.js
+++ b/scripts/contacts-book.js
@@ -436,12 +436,12 @@ function renderAddress(strAddress) {
         // SanitizeHTML shouldn't be necessary, but let's keep it just in case
         sanitizeHTML(strAddress) +
         `<i onclick="MPW.toClipboard('${strAddress}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; ${
-            cWallet.isHD ? 'right: 55px;' : ''
+            cWallet.isHD && !fXPub ? 'right: 55px;' : 'right: 27px;'
         } margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;
     document.getElementById('clipboard').value = strAddress;
 
-    // HD wallets gain a 'Refresh' button for quick address rotation
-    if (cWallet.isHD) {
+    // HD wallets gain a 'Refresh' button for quick address rotation - XPubs themselves cannot be rotated
+    if (cWallet.isHD && !fXPub) {
         doms.domModalQrLabel.style['padding-right'] = '65px';
         doms.domModalQrLabel.innerHTML += `<i onclick="MPW.getNewAddress({ updateGUI: true, verify: true, shield: ${!cWallet.publicMode} })" class="pColor fa-solid fa-arrows-rotate fa-lg" style="position: absolute; right: 27px; margin-top: 10px; cursor: pointer; width: 20px;"></i>`;
     }

--- a/scripts/contacts-book.js
+++ b/scripts/contacts-book.js
@@ -413,13 +413,22 @@ async function renderContactModal() {
 }
 
 function renderAddress(strAddress) {
+    // For XPubs, we render a privacy warning
+    const fXPub = isXPub(strAddress);
+
+    // Prepare the QR DOM (taking the warning in to account)
+    doms.domModalQR.innerHTML =
+        (fXPub ? `<p>${translation.onlyShareContactPrivately}</p>` : '') +
+        `<div id="receiveModalEmbeddedQR"></div>`;
+    const domQR = document.getElementById('receiveModalEmbeddedQR');
     try {
-        createQR('pivx:' + strAddress, doms.domModalQR);
-        doms.domModalQR.firstChild.style.width = '100%';
-        doms.domModalQR.firstChild.style.height = 'auto';
-        doms.domModalQR.firstChild.classList.add('no-antialias');
+        // Update the QR section
+        createQR('pivx:' + strAddress, domQR, 10);
+        domQR.firstChild.style.width = '100%';
+        domQR.firstChild.style.height = 'auto';
+        domQR.firstChild.classList.add('no-antialias');
     } catch (e) {
-        doms.domModalQR.hidden = true;
+        domQR.hidden = true;
     }
 
     const cWallet = useWallet();
@@ -458,32 +467,9 @@ export async function guiRenderReceiveModal(
         case RECEIVE_TYPES.SHIELD:
             renderAddress(await wallet.getNewShieldAddress());
             break;
-        case RECEIVE_TYPES.XPUB: {
-            // Get our current wallet XPub
-            const strXPub = wallet.getXPub();
-
-            // Update the QR Label (we'll show the address here for now, user can set Contact "Name" optionally later)
-
-            doms.domModalQrLabel.innerHTML =
-                sanitizeHTML(strXPub) +
-                `<i onclick="MPW.toClipboard('${strXPub}', this)" id="guiAddressCopy" class="pColor" style="position: absolute; right: 27px; margin-top: -1px; cursor: pointer; width: 20px;">${pIconCopy}</i>`;
-
-            // We'll render a short informational text, alongside a QR below for Contact scanning
-            doms.domModalQR.innerHTML = `
-            <!--<p>${translation.onlyShareContactPrivately}</p>-->
-            <div id="receiveModalEmbeddedQR"></div>
-        `;
-
-            // Update the QR section
-            const domQR = document.getElementById('receiveModalEmbeddedQR');
-            createQR(strXPub, domQR, 10);
-            domQR.firstChild.style.width = '100%';
-            domQR.firstChild.style.height = 'auto';
-            domQR.firstChild.classList.add('no-antialias');
-            document.getElementById('clipboard').value = strXPub;
-
+        case RECEIVE_TYPES.XPUB:
+            renderAddress(wallet.getXPub());
             break;
-        }
     }
 }
 


### PR DESCRIPTION
## Abstract

This PR re-adds a privacy warning to XPub sharing, as requested by a community member - it also cleans up the QR rendering logic to remove duplicate code from `guiRenderReceiveModal` by delegating QR rendering solely to `renderAddress`, hence the reduction in code.

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Switch to XPubs in Public Mode, check that a privacy warning is displayed above the QR.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---