### PR TITLE
Fix NaN when omitting amount url param

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -408,7 +408,7 @@ onMounted(async () => {
         } else if (urlParams.has('pay')) {
             transferAddress.value = urlParams.get('pay') ?? '';
             transferDescription.value = urlParams.get('desc') ?? '';
-            transferAmount.value = parseFloat(urlParams.get('amount')) ?? 0;
+            transferAmount.value = parseFloat(urlParams.get('amount')) || '';
             showTransferMenu.value = true;
         }
 


### PR DESCRIPTION
## Abstract

Fix currency input being NaN when omitting the amount in the params.
E.g.  https://app.mypivxwallet.org/?pay=myaddress&desc=Tip%20PalmTree 

## Testing
- Create a new wallet and encrypt it
- Open MPW with `?pay=myaddress&desc=Tip%20PalmTree`
- Assert that the currency input is empty