### PR TITLE
Update bleeding edge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h2>
 
 <p align="center">
-  <a href="https://mypivxwallet.org/">Production</a> (Stable) | <a href="https://pivx-labs.github.io/MyPIVXWallet/">Bleeding-Edge</a> (Unstable)
+  <a href="https://mypivxwallet.org/">Production</a> (Stable) | <a href="https://cheery-moxie-4f1121.netlify.app/">Bleeding-Edge</a> (Unstable)
 </p>
 
 ---


### PR DESCRIPTION
## Abstract

The GH pages URL is not updated anymore, and it is much older than the stable instance.
This PR updates the URL to use the netlify `master` build

## Testing
- Click the link