### PR TITLE
Prevent double imports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cypress/fixtures/e2e"]
 	path = cypress/fixtures/e2e
-	url = https://mpw-git.duddino.com/Duddino/MPW-playbacks.git
+	url = https://github.com/PIVX-Labs/MPW-playbacks.git

--- a/scripts/dashboard/CreateWallet.vue
+++ b/scripts/dashboard/CreateWallet.vue
@@ -16,9 +16,9 @@ const passphrase = ref('');
 
 const props = defineProps({
     advancedMode: Boolean,
+    importLock: Boolean,
 });
-const { advancedMode } = toRefs(props);
-const wallet = useWallet();
+const { advancedMode, importLock } = toRefs(props);
 
 async function informUserOfMnemonic() {
     return await new Promise((res, _) => {
@@ -33,6 +33,7 @@ async function informUserOfMnemonic() {
 }
 
 async function generateWallet() {
+    if (importLock.value) return;
     mnemonic.value = generateMnemonic();
     const network = getNetwork();
 

--- a/scripts/dashboard/Login.vue
+++ b/scripts/dashboard/Login.vue
@@ -1,12 +1,11 @@
 <script setup>
-import pLogo from '../../assets/p_logo.svg';
 import ledgerWallet from '../../assets/icons/icon-ledger-wallet.svg';
 import VanityGen from './VanityGen.vue';
 import CreateWallet from './CreateWallet.vue';
 import AccessWallet from './AccessWallet.vue';
-import { watch, toRefs } from 'vue';
+import { toRefs, ref } from 'vue';
 
-defineEmits(['import-wallet']);
+const emit = defineEmits(['import-wallet']);
 
 const isUSBSupported = !!navigator.usb;
 
@@ -14,6 +13,14 @@ const props = defineProps({
     advancedMode: Boolean,
 });
 const { advancedMode } = toRefs(props);
+const importLock = defineModel('importLock');
+
+function importWallet(importObj) {
+    if (!importLock.value) {
+        importLock.value = true;
+        emit('import-wallet', importObj);
+    }
+}
 </script>
 
 <template>
@@ -22,20 +29,21 @@ const { advancedMode } = toRefs(props);
             :advanced-mode="advancedMode"
             @import-wallet="
                 (mnemonic, password, blockCount) =>
-                    $emit('import-wallet', {
+                    importWallet({
                         type: 'hd',
                         secret: mnemonic,
                         password,
                         blockCount,
                     })
             "
+            :import-lock="importLock"
         />
 
         <br />
 
         <VanityGen
             @import-wallet="
-                (wif) => $emit('import-wallet', { type: 'legacy', secret: wif })
+                (wif) => importWallet({ type: 'legacy', secret: wif })
             "
         />
 
@@ -45,7 +53,7 @@ const { advancedMode } = toRefs(props);
                 id="generateHardwareWallet"
                 class="dashboard-item dashboard-display"
                 :style="{ opacity: isUSBSupported ? 1 : 0.5 }"
-                @click="$emit('import-wallet', { type: 'hardware' })"
+                @click="importWallet({ type: 'hardware' })"
                 data-testid="hardwareWalletBtn"
             >
                 <div class="coinstat-icon" v-html="ledgerWallet"></div>
@@ -68,7 +76,7 @@ const { advancedMode } = toRefs(props);
             :advancedMode="advancedMode"
             @import-wallet="
                 (secret, password) =>
-                    $emit('import-wallet', { type: 'hd', secret, password })
+                    importWallet({ type: 'hd', secret, password })
             "
         />
     </div>

--- a/scripts/governance/Governance.vue
+++ b/scripts/governance/Governance.vue
@@ -20,7 +20,7 @@ import { useMasternode } from '../composables/use_masternode';
 import { useAlerts } from '../composables/use_alerts.js';
 const { createAlert } = useAlerts();
 
-const showCreateProposalModal = ref(false);
+const showCreateProposalModal = ref(true);
 
 const wallet = useWallet();
 const settings = useSettings();

--- a/tests/components/Login.test.js
+++ b/tests/components/Login.test.js
@@ -22,6 +22,7 @@ describe('Login tests', () => {
         expect(createWalletComponent.isVisible()).toBeTruthy();
         expect(createWalletComponent.props()).toStrictEqual({
             advancedMode: false,
+            importLock: undefined,
         });
         // We can just emit the event: CreateWallet has already been unit tested!
         createWalletComponent.vm.$emit('import-wallet', 'mySecret', '');
@@ -51,6 +52,7 @@ describe('Login tests', () => {
         expect(createWalletComponent.isVisible()).toBeTruthy();
         expect(createWalletComponent.props()).toStrictEqual({
             advancedMode: true,
+            importLock: undefined,
         });
         // We can just emit the event: CreateWallet has already been unit tested!
         createWalletComponent.vm.$emit('import-wallet', 'mySecret', 'myPass');


### PR DESCRIPTION
## Abstract
If you have a laggy connection, you could create an account twice.
This doesn't normally pose a problem, unless you somehow lock the wallet before you get the second prompt.
Specifically, the user would have to do this:
- Click `Create a new wallet` and completely ignore the first seed phrase prompt
- Click `Create a new wallet` again, but do not dismiss the second seed phrase prompt yet
- Encrypt the wallet with a password
- Dismiss the second seed phrase prompt

By doing this, the `receive` tab gets an address that's associated with the first account, but not the imported account (the second seed phrase). Of course, a user could recover the funds by reimporting the first seed phrase again, but they are unlikely to have it, since this flow requires them to have closed the first one fairly quickily

## Testing
- Test that you can never double import seed phrases or other keys