### PR TITLE
Don't use Request::bytes

### DIFF
--- a/scripts/sapling_params.js
+++ b/scripts/sapling_params.js
@@ -76,7 +76,7 @@ export class SaplingParams {
                 if (done) break;
             }
 
-            stream.bytes = await request.bytes();
+            stream.bytes = new Uint8Array(await request.arrayBuffer());
         }
         await shield.loadSaplingProverWithBytes(
             streams[0].bytes,

--- a/tests/unit/sapling_params.spec.js
+++ b/tests/unit/sapling_params.spec.js
@@ -49,7 +49,7 @@ describe('SaplingParams', () => {
                 headers: {
                     get: vi.fn(() => '4'),
                 },
-                bytes: vi.fn(() =>
+                arrayBuffer: vi.fn(() =>
                     Promise.resolve(new Uint8Array([1, 2, 3, 4]))
                 ),
             };


### PR DESCRIPTION
## Abstract

Don't use `Response::bytes`, as it's a recent addition to the standard and many browsers don't support it
Instead, use `Response::arrayBuffer` https://caniuse.com/mdn-api_response_arraybuffer

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- With an older browser, try to make a shield tx