### PR TITLE
Fix e2e test for forks

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
   e2e:
     name: Run e2e tests
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'safe-to-e2e-test')
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-e2e-test') || github.ref == 'refs/heads/master'
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,8 @@ on:
     - "*.md"
     - LICENSE
     - "*.yaml"
-  pull_request:
+  pull_request_target:
+    types: [labeled]
     branches:
       - master
     paths-ignore:
@@ -22,6 +23,7 @@ jobs:
   e2e:
     name: Run e2e tests
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-e2e-test')
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
## Abstract

Forks need access to secrets to run e2e tests, since git lfs requires authentication.
To prevent misuse, a PR needs to be approved first, by adding a safe-to-e2e-test tag. This is probably not strictly needed, as secrets are not shared as env variables in the dependencies install stage, but this protects us from people potentially spamming our lfs server with requests.

The PR needs to be merged to before the new workflow can run, I will push it to my fork as proof that it works:

https://github.com/Duddino/MyPIVXWallet/actions/runs/13568301553/job/37926505880 (e2e test works for master branch)
https://github.com/Duddino/MyPIVXWallet/actions/runs/13568258366/job/37926358958 (e2e test works for PR opened by another fork)