### PR TITLE
BIP-21 QR Scanner Fixes

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -471,10 +471,10 @@ async function openSendQRScanner() {
             showTransferMenu.value = true;
             return;
         }
-        const cBIP32Req = parseBIP21Request(data);
-        if (cBIP32Req) {
-            transferAddress.value = cBIP32Req.address;
-            transferAmount.value = cBIP32Req.amount ?? 0;
+        const cBIP21Req = parseBIP21Request(data);
+        if (cBIP21Req) {
+            transferAddress.value = cBIP21Req.address;
+            transferAmount.value = cBIP21Req.options?.amount ?? 0;
             showTransferMenu.value = true;
             return;
         }

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -474,6 +474,7 @@ async function openSendQRScanner() {
         const cBIP21Req = parseBIP21Request(data);
         if (cBIP21Req) {
             transferAddress.value = cBIP21Req.address;
+            transferDescription.value = cBIP21Req.options?.label ?? '';
             transferAmount.value = cBIP21Req.options?.amount ?? 0;
             showTransferMenu.value = true;
             return;

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -258,7 +258,6 @@ export function isXPub(strXPub) {
 /**
  * Attempt to safely parse a BIP21 Payment Request
  * @param {string} strReq - BIP21 Payment Request string
- * @returns {object | false}
  */
 export function parseBIP21Request(strReq) {
     // Format should match: pivx:addr[?amount=x&label=x]


### PR DESCRIPTION
## Abstract

There were some trivial issues, along with some obvious missed fields, in our BIP-21 QR code scanner, namely:
- The optional `amount` field was not being read by the QC scanner correctly.
- The optional `label` field was missing, and has now been added (mapped as an MPW Payment Request description).
- The variable referenced BIP-32 rather than BIP-21, possibly a replace-all style trivial mistake.
- The JSDoc for `parseBIP21Request()` was regressive compared to the implicit JSDoc, which is more accurate without it.

These were discovered by accident while testing the PIVCards BIP-21 "One-Click" payment system, having realised MPW was ignoring the `amount` field, and didn't support the `label` field (similar to the `desc` field in MPW Payment Request URIs).

---

## Testing
To test this PR, it's suggested to attempt these user flows, or variations of these:
- Test that the QR Code scanner recognises BIP-21 `amount` and `label` fields correctly.

If any errors are found, the PR works unexpectedly, or you have viable suggestions to improve the UX or functionality of the PR, let me know!

---