### PR TITLE
Improve shield sync loading bar and efficiency

### DIFF
--- a/chain_params.prod.json
+++ b/chain_params.prod.json
@@ -33,7 +33,8 @@
         "maxPaymentCycles": 6,
         "maxPayment": 43200000000000,
         "defaultColdStakingAddress": "SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy",
-        "stakeSplitTarget": 50000000000
+        "stakeSplitTarget": 50000000000,
+        "defaultStartingShieldBlock": 4190531
     },
     "testnet": {
         "name": "testnet",
@@ -66,6 +67,7 @@
         "maxPaymentCycles": 20,
         "maxPayment": 144000000000,
         "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44",
-        "stakeSplitTarget": 50000000000
+        "stakeSplitTarget": 50000000000,
+        "defaultStartingShieldBlock": 1503537
     }
 }

--- a/chain_params.test.json
+++ b/chain_params.test.json
@@ -29,7 +29,8 @@
         "maxPaymentCycles": 6,
         "maxPayment": 43200000000000,
         "defaultColdStakingAddress": "SdgQDpS8jDRJDX8yK8m9KnTMarsE84zdsy",
-        "stakeSplitTarget": 50000000000
+        "stakeSplitTarget": 50000000000,
+        "defaultStartingShieldBlock": 4190531
     },
     "testnet": {
         "name": "testnet",
@@ -62,6 +63,7 @@
         "maxPaymentCycles": 20,
         "maxPayment": 144000000000,
         "defaultColdStakingAddress": "WmNziUEPyhnUkiVdfsiNX93H6rSJnios44",
-        "stakeSplitTarget": 50000000000
+        "stakeSplitTarget": 50000000000,
+        "defaultStartingShieldBlock": 1503537
     }
 }

--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -105,6 +105,10 @@ export class Network {
         throw new Error('getShieldData must be implemented');
     }
 
+    async getShieldDataLength(initialBlock, endBlock) {
+        throw new Error('getShieldDataLength must be implemented');
+    }
+
     async getSaplingOutput() {
         throw new Error('getSaplingOutput must be implemented');
     }
@@ -338,6 +342,14 @@ export class RPCNodeNetwork extends Network {
         );
         if (!res.ok) throw new Error('Invalid response');
         return res;
+    }
+
+    async getShieldDataLength(startBlock, endBlock) {
+        const res = await this.#fetchNode(
+            `/getshielddatalength?startBlock=${startBlock}&endBlock=${endBlock}`
+        );
+        if (!res.ok) throw new Error('Invalid response');
+        return Number.parseInt(await res.text());
     }
 
     #getSaplingParamsUrl() {

--- a/scripts/network/network_manager.js
+++ b/scripts/network/network_manager.js
@@ -274,6 +274,16 @@ class NetworkManager {
         return await this.#retryWrapper('getShieldData', true, 0, initialBlock);
     }
 
+    async getShieldDataLength(startBlock, endBlock) {
+        return await this.#retryWrapper(
+            'getShieldDataLength',
+            true,
+            0,
+            startBlock,
+            endBlock
+        );
+    }
+
     async getSaplingOutput() {
         return await this.#retryWrapper('getSaplingOutput', true, 0);
     }

--- a/scripts/parsed_secret.js
+++ b/scripts/parsed_secret.js
@@ -67,7 +67,8 @@ export class ParsedSecret {
                         seed,
                         // hardcoded value considering the last checkpoint, this is good both for mainnet and testnet
                         // TODO: take the wallet creation height in input from users
-                        blockHeight: 4200000,
+                        blockHeight:
+                            cChainParams.current.defaultStartingShieldBlock,
                         coinType: cChainParams.current.BIP44_TYPE,
                         // TODO: Change account index once account system is made
                         accountIndex: 0,

--- a/scripts/reader.js
+++ b/scripts/reader.js
@@ -106,4 +106,35 @@ export class Reader {
             });
         }
     }
+
+    /**
+     * Discards bytes, but updates `readBytes` in real time instead of the end
+     * @param {number} byteLength
+     */
+    async discard(byteLength) {
+        if (this.#awaiter) throw new Error('Reading more than once');
+        while (true) {
+            const discaredBytes = Math.min(
+                this.#maxBytes - this.#i,
+                byteLength
+            );
+            this.#i += discaredBytes;
+            byteLength -= discaredBytes;
+            console.log(byteLength);
+            if (byteLength === 0) {
+                this.#awaiter = null;
+                return;
+            }
+            // No more byte to return
+            if (this.#done) return;
+            // If we didn't respond, wait for the next batch of bytes, then try again
+            await new Promise((res) => {
+                this.#awaiter = res;
+            });
+        }
+    }
+
+    isBusy() {
+        return !!this.#awaiter;
+    }
 }


### PR DESCRIPTION
## Abstract

After #545 the shield syncer needed to look though the cached binary to find the right point to start the syncing.
This was not ideal because it added a delay even if you only needed to sync a small amount of blocks. It was also not very clear what was happening looking at the loading bar.

Now, the shield syncer asks for the RPC node a byte offset based on the first block MPW tries to sync (Now in chain_params as defaultStartingShieldBlock) and the lastSyncedBlock, the node returns the length of that data, and the wallet can discard it without having to parse it.

As a result of this, the shield sync loading bar now updates based in 3 phases:
- Bytes that we have already in cache but not needed are not displayed (e.g. if we total shield data is 60MB but we already have 40MB in cache, the shield loading bar will display 40MB)
- Bytes that we don't have in cache but are not needed for sync progress based on the download speed only
- Bytes that we do have in cache and are needed for sync progress are based on the processing speed
- Bytes that we don't have in cache and are needed for sync also progress based on the processing speed, but may be bottle necked by download speed
This means that if you have a really fast network compared to processing speed and you are downloading bytes that you don't need for sync (e.g. the first every sync on MPW after creating a new wallet), the progress bar speed may slow down when it needs to process those bytes.

## Testing
- Test shield sync and assert that the progress bar looks smooth in all situations