### PR TITLE
Add network rotation on bad sapling root

### DIFF
--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -35,6 +35,10 @@ import { Transaction } from '../transaction.js';
  *
  */
 export class Network {
+    /**
+     * @type{boolean}
+     */
+    isRpc;
     constructor() {
         if (this.constructor === Network) {
             throw new Error('Initializing virtual class');
@@ -152,6 +156,7 @@ export class RPCNodeNetwork extends Network {
          * @public
          */
         this.strUrl = strUrl;
+        this.isRpc = true;
     }
     /**
      * A Fetch wrapper which uses the current Node's base URL
@@ -381,6 +386,7 @@ export class ExplorerNetwork extends Network {
          * @public
          */
         this.strUrl = strUrl;
+        this.isRpc = false;
     }
 
     /**

--- a/scripts/network/network_manager.js
+++ b/scripts/network/network_manager.js
@@ -56,6 +56,42 @@ class NetworkManager {
         } else {
             this.#currentExplorer = found;
         }
+
+        getEventEmitter().emit(
+            isRPC ? 'rpc_changed' : 'explorer_changed',
+            strUrl
+        );
+    }
+
+    /**
+     * Changes RPC and explorer to next one
+     * To be called in case of an error believed to be a network one
+     * e.g. wrong sapling root
+     */
+    rotateNetworks() {
+        const currentExplorerIndex = this.#networks.findIndex(
+            (n) => n === this.#currentExplorer
+        );
+        const currentNodeIndex = this.#networks.findIndex(
+            (n) => n === this.#currentNode
+        );
+        const indices = [currentExplorerIndex, currentNodeIndex];
+        for (let j = 0; j < indices.length; j++) {
+            for (let i = 1; i < this.#networks.length; i++) {
+                const isRpc = j === 1;
+                const index = indices[j];
+                const tryNetwork =
+                    this.#networks[(index + i) % this.#networks.length];
+                if (tryNetwork.isRpc === isRpc) {
+                    if (isRpc) {
+                        this.#currentNode = tryNetwork;
+                    } else {
+                        this.#currentExplorer = tryNetwork;
+                    }
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -215,6 +215,14 @@ function subscribeToNetworkEvents() {
     getEventEmitter().on('currency-loaded', async (mapCurrencies) => {
         await fillCurrencySelect(mapCurrencies);
     });
+    getEventEmitter().on('explorer_changed', (url) => {
+        // Update the selector UI
+        doms.domExplorerSelect.value = url;
+    });
+    getEventEmitter().on('rpc_changed', (url) => {
+        // Update the selector UI
+        doms.domNodeSelect.value = url;
+    });
 }
 
 // --- Settings Functions
@@ -223,9 +231,6 @@ export async function setExplorer(explorer, fSilent = false) {
     await database.setSettings({ explorer: explorer.url });
     getNetwork().setNetwork(explorer.url, false);
 
-    // Update the selector UI
-    doms.domExplorerSelect.value = explorer.url;
-
     if (!fSilent) {
         createAlert(
             'success',
@@ -233,16 +238,12 @@ export async function setExplorer(explorer, fSilent = false) {
             2250
         );
     }
-    getEventEmitter().emit('explorer_changed', explorer.url);
 }
 
 export async function setNode(node, fSilent = false) {
     getNetwork().setNetwork(node.url, true);
     const database = await Database.getInstance();
     database.setSettings({ node: node.url });
-
-    // Update the selector UI
-    doms.domNodeSelect.value = node.url;
 
     if (!fSilent)
         createAlert(

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1025,14 +1025,19 @@ export class Wallet {
             this.#mempool = new Mempool();
             await this.#resetShield();
             this.#isSynced = false;
-            await this.#transparentSync();
-            await this.#syncShield();
             const db = await Database.getInstance();
             // Reset shield sync data, it might be corrupted
             await db.setShieldSyncData({
                 shieldData: null,
                 lastSyncedBlock: null,
             });
+
+            // Try to rotate networks to see if another RPC/explorer has the correct data
+            getNetwork().rotateNetworks();
+
+            await this.#transparentSync();
+            await this.#syncShield();
+
             return false;
         }
         return true;


### PR DESCRIPTION
## Abstract

Attempt to use a different explorer and RPC when sapling root is incorrect. This is because it's likely that the RPC/explorers are forked or non-functioning if this happens

## Testing
- Change the shielddata/sapling root on one node/explorer only
- Assert that when try to syncing with that node, it automatically switches to another one