### PR TITLE
Allow login offline

### DIFF
--- a/locale/cnr/translation.toml
+++ b/locale/cnr/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Interna greška, molimo pokušajte ponovo kasnije" # Internal error, please try again later

--- a/locale/de/translation.toml
+++ b/locale/de/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Interner Fehler, bitte versuche es später erneut" # Internal error, please try again later

--- a/locale/en/translation.toml
+++ b/locale/en/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "ENABLED" # ENABLED
 masternodeStatusPreEnabled = "PRE_ENABLED" # PRE_ENABLED
 masternodeStatusMissing = "MISSING" # MISSING
 masternodeStatusExpired = "EXPIRED" # EXPIRED
+failedToConnect = "Failed to connect to the PIVX node. Check your internet connection." # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, please try again later" # Internal error, please try again later

--- a/locale/es-mx/translation.toml
+++ b/locale/es-mx/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Error interno, vuelve a intentarlo más tarde" # Internal error, please try again later

--- a/locale/fr/translation.toml
+++ b/locale/fr/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Erreur interne, veuillez réessayer plus tard" # Internal error, please try again later

--- a/locale/hi/translation.toml
+++ b/locale/hi/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "आंतरिक त्रुटि, कृपया कुछ समय बाद पुनः प्रयास करें" # Internal error, please try again later

--- a/locale/it/translation.toml
+++ b/locale/it/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusMissing = "MANCANTE" # MISSING
 masternodeStatusExpired = "SCADUTO" # EXPIRED
 exportToCsv = "Esporta le transazioni" # Export transactions
 exportToCsvBody = "Vuoi esportare le transazioni in formato CSV?" # Do you want to export your transactions as CSV?
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Errore interno, rirova più tardi" # Internal error, please try again later

--- a/locale/nl/translation.toml
+++ b/locale/nl/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Interne fout, probeer het later opnieuw" # Internal error, please try again later

--- a/locale/ph/translation.toml
+++ b/locale/ph/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, Pakiusap uliting muli" # Internal error, please try again later

--- a/locale/pl/translation.toml
+++ b/locale/pl/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Błąd wewnętrzny, spróbuj ponownie później" # Internal error, please try again later

--- a/locale/pt-br/translation.toml
+++ b/locale/pt-br/translation.toml
@@ -121,6 +121,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 STAKE_ADDR_SET = "<b>Endereço de Cold Staking definido!</b><br>Ao fazer Stake no futuro este endereço irá ser usado." # <b>Cold Address set!</b><br>Future stakes will use this address.

--- a/locale/pt-pt/translation.toml
+++ b/locale/pt-pt/translation.toml
@@ -121,6 +121,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 STAKE_ADDR_SET = "<b>Endereço de Cold Staking definido!</b><br>Ao fazer Stake no futuro irá ser usado este endereço." # <b>Cold Address set!</b><br>Future stakes will use this address.

--- a/locale/template/translation.toml
+++ b/locale/template/translation.toml
@@ -258,6 +258,7 @@ masternodeStatusEnabled = "ENABLED"
 masternodeStatusPreEnabled = "PRE_ENABLED"
 masternodeStatusMissing = "MISSING"
 masternodeStatusExpired = "EXPIRED"
+failedToConnect = "Failed to connect to the PIVX node. Check your internet connection."
 
 
 [ALERTS]

--- a/locale/uwu/translation.toml
+++ b/locale/uwu/translation.toml
@@ -234,6 +234,7 @@ masternodeStatusEnabled = "" # ENABLED
 masternodeStatusPreEnabled = "" # PRE_ENABLED
 masternodeStatusMissing = "" # MISSING
 masternodeStatusExpired = "" # EXPIRED
+failedToConnect = "" # Failed to connect to the PIVX node. Check your internet connection.
 
 [ALERTS]
 INTERNAL_ERROR = "Internal error, pwease try again later" # Internal error, please try again later

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -409,7 +409,7 @@ getEventEmitter().on('toggle-network', async () => {
     doms.domDashboard.click();
 });
 
-onMounted(async () => {
+ onMounted(async () => {
     await start();
     await importFromDatabase();
 

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -201,7 +201,11 @@ export async function start() {
     await settingsStart();
     subscribeToNetworkEvents();
     // Make sure we know the correct number of blocks
-    await refreshChainData();
+    try {
+	await refreshChainData();
+    } catch (e) {
+	createAlert('warning', translation.failedToConnect, 10_000)
+    }
     // Load the price manager
     cOracle.load();
     new AsyncInterval(async () => {


### PR DESCRIPTION
## Abstract

Allow login when offline (for self hosted) or nodes/explorers are unavailable. This allows users to tweak their settings should they need to.
Also displays a nicer error rather than infinite loading
![image](https://github.com/user-attachments/assets/7988fb5b-86cd-4bb4-9066-9c0294046109)


## Testing
- Go offline
- Check that you can still tweak the settings