### PR TITLE
Show parsed secret errors again

### DIFF
--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -79,7 +79,7 @@ watch(showExportModal, async (showExportModal) => {
  * @param {Object} o - Options
  * @param {'legacy'|'hd'|'hardware'} o.type - type of import
  * @param {string} o.secret
- * @param {nubmer?} [o.blockCount] Creation block count. Defaults to 4_200_000
+ * @param {number?} [o.blockCount] Creation block count. Defaults to 4_200_000
  * @param {string} [o.password]
  */
 async function importWallet({

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -125,11 +125,15 @@ async function importWallet({
                 12500
             );
         } else {
-            parsedSecret = await ParsedSecret.parse(
-                secret,
-                password,
-                advancedMode.value
-            );
+            try {
+                parsedSecret = await ParsedSecret.parse(
+                    secret,
+                    password,
+                    advancedMode.value
+                );
+            } catch (e) {
+                createAlert('warning', e.message, 8000);
+            }
         }
         if (parsedSecret) {
             await wallet.setMasterKey({ mk: parsedSecret.masterKey });


### PR DESCRIPTION
## Abstract

Parsed secret errors were not showing correctly, bad imports were just discared with no warning.
This PR actually shows the error message in an alert
![image](https://github.com/user-attachments/assets/f18c7c60-d406-4aff-b04f-a65e79397314)


## Testing
- Import an invalid seed phrase in standard (not advanced) mode
- Assert that you see an alert