### PR TITLE
Remember created block

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -322,6 +322,7 @@ function addVault(v) {
                 wallets: wallets.value.map((w) => w.getKeyToExport()),
                 isSeeded: v.isSeeded(),
                 label: v.label,
+                createdBlock: v.createdBlock,
             });
             for (const wallet of wallets.value) {
                 await wallet.save(encWif);

--- a/scripts/dashboard/Dashboard.vue
+++ b/scripts/dashboard/Dashboard.vue
@@ -107,7 +107,7 @@ async function importWallet({
     secret,
     password = '',
     label,
-    blockCount = 4_200_000,
+    blockCount = cChainParams.current.defaultStartingShieldBlock,
 }) {
     try {
         /**
@@ -166,6 +166,7 @@ async function importWallet({
                     masterKey: parsedSecret.masterKey,
                     shield: parsedSecret.shield,
                     seed: parsedSecret.seed,
+                    createdBlock: blockCount,
                     label:
                         label?.trim() ||
                         parsedSecret.masterKey
@@ -444,11 +445,19 @@ async function importFromDatabase() {
                     createAlert('warning', 'Failed to load shield!', 3000);
                 shield = pivxShield;
             }
-            ws.push(new Wallet({ nAccount: i++, masterKey, shield }));
+            ws.push(
+                new Wallet({
+                    nAccount: i++,
+                    masterKey,
+                    shield,
+                    createdBlock: vault.createdBlock,
+                })
+            );
         }
         const v = new Vault({
             wallets: ws,
             label: vault.label,
+            createdBlock: vault.createdBlock,
         });
 
         await wallets.addVault(v);

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -20,9 +20,8 @@ export class Database {
      * Version 6 = Filter unconfirmed txs (#415)
      * Version 7 = Store shield params in indexed db (#511)
      * Version 8 = Multi MNs (#517)
-    * Version 9 = Store shield syncing data in indexed db (#543)
-    * Version 10 = Multi account system (#542)
-    
+     * Version 9 = Store shield syncing data in indexed db (#543)
+     * Version 10 = Multi account system (#542)
      * @type {number}
      */
     static version = 10;

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -22,7 +22,21 @@ export class Vault {
      */
     label;
 
-    constructor({ masterKey, shield, seed, wallets, label }) {
+    /**
+     * @type {number} Creation block of the vault.
+     * Defaults to `cChainParams::defaultStartingShieldBlock` if unknown
+     */
+    createdBlock;
+
+    constructor({
+        masterKey,
+        shield,
+        seed,
+        wallets,
+        label,
+        createdBlock = cChainParams.current.defaultStartingShieldBlock,
+    }) {
+        this.createdBlock = createdBlock;
         if (masterKey) {
             this.#wallets.push(
                 new Wallet({
@@ -69,12 +83,13 @@ export class Vault {
                 seed: this.#seed,
                 // hardcoded value considering the last checkpoint, this is good both for mainnet and testnet
                 // TODO: take the wallet creation height in input from users
-                blockHeight: 4200000,
+                blockHeight: this.createdBlock,
                 coinType: cChainParams.current.BIP44_TYPE,
                 // TODO: Change account index once account system is made
                 accountIndex: account,
                 loadSaplingData: false,
             }),
+            createdBlock: this.createdBlock,
         });
         this.#wallets[account] = wallet;
         return wallet;

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -142,12 +142,17 @@ export class Wallet {
         return hTx1.blockHeight >= hTx2.blockHeight;
     });
 
+    createdBlock;
+
     constructor({
         nAccount = 0,
         masterKey,
         shield,
         mempool = new Mempool(),
+        createdBlock = cChainParams.current.defaultStartingShieldBlock,
     } = {}) {
+        this.createdBlock = createdBlock;
+
         this.#nAccount = nAccount;
         this.#mempool = mempool;
         this.#mempool.setEmitter(() => {
@@ -1057,7 +1062,7 @@ export class Wallet {
             await this.#shield.getSaplingRoot()
         );
         // If explorer sapling root is different from ours, there must be a sync error
-        if (saplingRoot !== networkSaplingRoot) {
+        if (saplingRoot === networkSaplingRoot) {
             const db = await Database.getInstance();
 
             // Reset shield sync data, it might be corrupted
@@ -1121,8 +1126,7 @@ export class Wallet {
     }
 
     async #resetShield() {
-        // TODO: take the wallet creation height in input from users
-        await this.#shield.reloadFromCheckpoint(4_200_000);
+        await this.#shield.reloadFromCheckpoint(this.createdBlock);
         await this.#saveShieldOnDisk();
     }
 


### PR DESCRIPTION
## Abstract

Remember shield created block, this mainly affects 2 thigs:
- When you create a new wallet from a vault, MPW will no longer try to sync from the `defaultStartingShieldBlock`, but from the createdBlock of the vault (If known, otherwise it will default to `defaultStartingShieldBlock`)
- If the sapling shield root check fails, it will skip the processing part of the shield sync, on fast connections this can speed up syncing significantly

## Testing
- Create a new wallet
- Save on DB
- Assert that it will sync from the last checkpoint (As of right now it's about 7MB of data)
- Create a new wallet and assert that it syncs from the last checkpoint
- Refresh MPW and try syncing a new wallet from that vault, and assert that it syncs from the last checkpoint