### PR TITLE
Remove blur from seed phrase

### DIFF
--- a/scripts/dashboard/import_modals/CreateWalletModal.vue
+++ b/scripts/dashboard/import_modals/CreateWalletModal.vue
@@ -51,7 +51,7 @@ function submit() {
                     >
                         {{ i }} <br />
                         <div class="privateKeysBadge">
-                            <span class="filterBlur">{{ word }}</span>
+                            <span>{{ word }}</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Abstract

Remove blur from seed phrase when creating wallet.
This encourages people to hopefully actually backup the seed phrase and not just skip to the next dialog

## Testing
- Create wallet
- test that there is no blur