### PR TITLE
Don't assume the error has a filename field

### DIFF
--- a/scripts/global.js
+++ b/scripts/global.js
@@ -593,7 +593,7 @@ function errorHandler(e) {
         e.message || e.reason
     )}`;
     // Don't display extension errors
-    if (e.filename.includes('extension')) return;
+    if (e?.filename?.includes('extension')) return;
     try {
         createAlert('warning', message);
     } catch (_) {


### PR DESCRIPTION
## Abstract

Not all errors had a filename field, causing the alert to not contain the correct error

## Testing
- Throw an error
- Assert that the message shows correctly