### PR TITLE
Fix vault override

### DIFF
--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -445,16 +445,19 @@ export const useWallets = defineStore('wallets', () => {
         activeVault,
         addVault: async (v) => {
             const vault = addVault(v);
-            rawVaults.push(v);
+
             const i = vaults.value.findIndex(
                 (other) =>
                     other.defaultKeyToExport === v.getDefaultKeyToExport()
             );
             if (i !== -1) {
+                console.log('Replacing old vault');
                 // Replace old vault, so we can seed unseeded vaults
                 vaults.value[i] = vault;
+                rawVaults[i] = v;
             } else {
                 vaults.value.push(vault);
+                rawVaults.push(v);
             }
             for (let i = 0; i < v.getWallets().length; i++) {
                 const wallet = await vault.addWallet(i);


### PR DESCRIPTION
## Abstract

Fix vault override when you import and existing vault, for example when a seedless vault is overridden for a seeded one

## Testing
- Import a seedless vault (You can go to an old instance of MPW, import a seed phrase and export the private key)
- Import the seed corresponding to that vault
- Assert that it's overridden and you can generate wallets correctly