### PR TITLE
Make MPW switch explorers when tx fails to send

### DIFF
--- a/scripts/network/network.js
+++ b/scripts/network/network.js
@@ -517,6 +517,7 @@ export class ExplorerNetwork extends Network {
             method: 'post',
             body: hex,
         });
+        if (!req.ok) throw new Error(await req.json());
         return await req.json();
     }
 


### PR DESCRIPTION
## Abstract
MPW will now try to switch explorers if the tx fails to send. 
Fixes #591 
<img width="774" height="214" alt="image" src="https://github.com/user-attachments/assets/de3d9044-70e6-4989-87b4-2998ab001570" />

## Testing

- Modify MPW to create an invalid tx (for example change Wallet::sign(transaction) to `return transaction` without actually signing)
- Try to send a tx
- Assert that it tries sends to every explorer and node