### PR TITLE
Only use duddino2 in netlify builds

### DIFF
--- a/chain_params.netlify.json
+++ b/chain_params.netlify.json
@@ -16,11 +16,16 @@
         "MASTERNODE_PORT": 51472,
         "SHIELD_PREFIX": "ps",
         "Explorers": [
+            { "name": "Duddino (2)", "url": "https://explorer2.duddino.com" },
             { "name": "PIVX Labs", "url": "https://explorer.pivxla.bz" },
             { "name": "Duddino", "url": "https://explorer.duddino.com" },
             { "name": "zkBitcoin", "url": "https://zkbitcoin.com" }
         ],
         "Nodes": [
+            {
+                "name": "Duddino (2)",
+                "url": "https://rpc2.duddino.com/mainnet"
+            },
             { "name": "PIVX Labs", "url": "https://rpc.pivxla.bz/mainnet" },
             { "name": "Duddino", "url": "https://rpc.duddino.com/mainnet" }
         ],


### PR DESCRIPTION
## Abstract
Duddino2 is a test server I use to test RPC and explorer changes for MPW. This PR makes it so the default `prod` version of MPW doesn't have the duddino2 explorers or rpcs, while the netlify version has them and places it as the first pick.
The netlify build was changed to use the new version of chain_params

## Testing
- Test that duddino2 is present in netlify builds