### PR TITLE
Hash bundle filenames for long-term browser caching

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -25,7 +25,8 @@ export default {
     entry: './scripts/index.js',
     output: {
         path: path.resolve(__dirname, './dist'),
-        filename: './mpw.js',
+        filename: 'mpw.[contenthash].js',
+        chunkFilename: '[name].[contenthash].js',
         library: 'MPW',
         libraryTarget: 'var',
         clean: true,
@@ -110,7 +111,7 @@ export default {
             includeAliases: ['stream', 'process', 'Buffer'],
         }),
         // Prevents non styled flashing on load
-        new MiniCssExtractPlugin(),
+        new MiniCssExtractPlugin({ filename: '[name].[contenthash].css' }),
         // Make jquery available globally
         new webpack.ProvidePlugin({
             $: 'jquery',


### PR DESCRIPTION
## Summary
- Adds `[contenthash]` to webpack's main entry (`mpw.js`), async chunks, and extracted CSS (`main.css`).
- Enables safe long-term browser/CDN caching (`max-age=31536000, immutable`) on built bundles without risking mixed-version state during deploys.

## Why
Previously `mpw.js` and `main.css` were emitted with stable filenames. A user visiting during a deploy could receive fresh `index.html` but a stale cached bundle → mixed-version state. Since wallets care very much about consistent code loading, caching was deliberately kept off everywhere (origin + CDN) to avoid this risk. Content-hashed filenames eliminate the risk: the filename itself changes whenever the content does.

HtmlWebpackPlugin auto-rewrites the injected `<script>`/`<link>` references, so `index.template.html` needs no change. Assets copied via `CopyPlugin` (`manifest.json`, `native-worker.js`, `favicon.ico`, PNG/SVG icons) intentionally remain unhashed — their URLs must be stable (service worker registration) or rarely change.

## Test plan
- [ ] `npm run build` → `dist/` contains `mpw.[hash].js`, `main.[hash].css`, and async chunks as `[id].[name].[hash].js`
- [ ] `dist/index.html` references the hashed filenames (grep for `mpw.*.js` and `main.*.css`)
- [ ] Verified on `app.mypivxwallet.org` (manual deploy ahead of merge): hashed assets serve with `cache-control: public, max-age=31536000, immutable`; `native-worker.js` still revalidated; `index.html` remains `no-store`
- [ ] Service worker still registers and updates correctly on a real browser (Chromium + Firefox)