### PR TITLE
Allow naming sub-accounts

### DIFF
--- a/scripts/accounts.js
+++ b/scripts/accounts.js
@@ -11,6 +11,7 @@ export class Account {
      * @param {Array<Object>} [accountData.localProposals] - The local proposals.
      * @param {Array<import('./contact-book.js').Contact>} [accountData.contacts] - The Contacts saved in this account.
      * @param {String} [accountData.name] - The Contact Name of the account.
+     * @param {String} [accountData.label] - The user-chosen display label for this sub-account.
      * @param {String} [accountData.shieldData] - Shield data necessary to load shielding
      * @param {String} [accountData.encExtsk] - Encrypted extended spending key
      * @param {boolean} [accountData.isHardware] - Whether this is a hardware wallet
@@ -23,6 +24,7 @@ export class Account {
         this.localProposals = accountData?.localProposals || [];
         this.contacts = accountData?.contacts || [];
         this.name = accountData?.name || '';
+        this.label = accountData?.label || '';
         this.shieldData = accountData?.shieldData || '';
         this.encExtsk = accountData?.encExtsk || '';
         this.isHardware = accountData?.isHardware || false;
@@ -43,6 +45,9 @@ export class Account {
 
     /** @type {String} The Contact Name of the account. */
     name = '';
+
+    /** @type {String} The user-chosen display label for this sub-account. */
+    label = '';
 
     /** @type {String} Shield data necessary to load shielding */
     shieldData = '';

--- a/scripts/composables/use_wallet.js
+++ b/scripts/composables/use_wallet.js
@@ -34,6 +34,25 @@ function addWallet(wallet) {
     const getNewAddress = (nReceiving) => wallet.getNewAddress(nReceiving);
     const blockCount = ref(0);
 
+    // The user-chosen display label for this sub-account (empty = default numbered name).
+    // Stored on the Account DB record, keyed by this wallet's export key.
+    const label = ref('');
+    (async () => {
+        const database = await Database.getInstance();
+        const account = await database.getAccount(wallet.getKeyToExport());
+        if (account?.label) label.value = account.label;
+    })();
+    const setLabel = async (newLabel) => {
+        const trimmed = (newLabel ?? '').trim();
+        const database = await Database.getInstance();
+        const account = await database.getAccount(wallet.getKeyToExport());
+        if (!account) return;
+        account.label = trimmed;
+        // allowDeletion lets the user clear the label back to the default numbered name
+        await database.updateAccount(account, true);
+        label.value = trimmed;
+    };
+
     const updateWallet = async () => {
         isImported.value = wallet.isLoaded();
         isHardwareWallet.value = wallet.isHardwareWallet();
@@ -234,6 +253,8 @@ function addWallet(wallet) {
             await updateWallet();
         },
         historicalTxs,
+        label,
+        setLabel,
         onNewTx,
         onTransparentSyncStatusUpdate,
         onShieldSyncStatusUpdate,

--- a/scripts/dashboard/MultiWallet.vue
+++ b/scripts/dashboard/MultiWallet.vue
@@ -77,6 +77,26 @@ function select(wallet) {
     wallets.selectWallet(wallet);
 }
 
+// Inline sub-account label editing — tracks which account (by export key) is open
+const editingKey = ref(null);
+const editingLabel = ref('');
+
+function startEditLabel(wallet) {
+    editingKey.value = wallet.getKeyToExport();
+    editingLabel.value = wallet.label || '';
+}
+
+async function saveLabel(wallet) {
+    // The editor closes before persisting, so the trailing blur is a no-op
+    if (editingKey.value !== wallet.getKeyToExport()) return;
+    editingKey.value = null;
+    await wallet.setLabel(editingLabel.value);
+}
+
+function cancelEditLabel() {
+    editingKey.value = null;
+}
+
 function formatBalance(balance) {
     return balance.toFixed(settings.displayDecimals);
 }
@@ -202,9 +222,32 @@ async function restoreWallet() {
                                 wallets.activeWallet.getKeyToExport(),
                         }"
                     >
-                        <span>
-                            <strong>{{ vault.label }} {{ i }} </strong></span
-                        >
+                        <span class="accountLabel">
+                            <template
+                                v-if="editingKey === wallet.getKeyToExport()"
+                            >
+                                <input
+                                    :ref="(el) => el && el.focus()"
+                                    v-model="editingLabel"
+                                    class="accountLabelInput"
+                                    :placeholder="`${vault.label} ${i}`"
+                                    maxlength="24"
+                                    @click.stop
+                                    @keydown.enter.prevent="saveLabel(wallet)"
+                                    @keydown.esc.prevent="cancelEditLabel()"
+                                    @blur="saveLabel(wallet)"
+                                />
+                            </template>
+                            <template v-else>
+                                <i
+                                    class="fa-solid fa-pencil accountEditIcon"
+                                    @click.stop="startEditLabel(wallet)"
+                                ></i>
+                                <strong>{{
+                                    wallet.label || `${vault.label} ${i}`
+                                }}</strong>
+                            </template>
+                        </span>
                         <div class="walletsAmount">
                             <span style="margin-right: 5px">{{
                                 formatBalance(
@@ -279,6 +322,53 @@ async function restoreWallet() {
 .walletContainer {
     display: flex;
     align-items: center;
+}
+.accountLabel {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+.accountEditIcon {
+    cursor: pointer;
+    margin-right: 8px;
+    font-size: 0.8em;
+    opacity: 0.5;
+    transition: opacity 0.15s ease-in-out;
+}
+.accountEditIcon:hover {
+    opacity: 1;
+    color: #9221ff;
+}
+/* Seamless inline editor — overrides the global `input` rule (which forces a
+   light background, monospace font, fixed 43px height and margins). Scoped under
+   .multiWalletList + !important so it matches the static account name exactly. */
+.multiWalletList .accountLabelInput {
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    outline: none !important;
+    box-shadow: none !important;
+    color: inherit !important;
+    font-family: Montserrat, sans-serif !important;
+    font-size: inherit !important;
+    font-weight: 700 !important;
+    line-height: inherit;
+    height: auto !important;
+    width: auto;
+    min-width: 0;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+.multiWalletList .accountLabelInput:focus-visible {
+    outline: none !important;
+    border: none !important;
+}
+/* Dim, same-size ghost of the account name (overrides the bright global placeholder) */
+.multiWalletList .accountLabelInput::placeholder {
+    color: inherit !important;
+    opacity: 0.3 !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
 }
 .walletSelected {
     color: #9221ff;


### PR DESCRIPTION
## What

Sub-accounts in the wallet switcher were only ever shown as numbered entries (`Personal 0`, `Personal 1`, …). This adds an optional, user-editable name per sub-account, edited inline via a pencil next to each one.

## How it works

- **Storage:** the name is a new `label` field on the `Account` record, keyed by the wallet's export key (xpub). Every sub-account already persists an `Account`, so there's no new store and no extra key plumbing. `Account.name` is left untouched — that's the contacts-book display name.
- **No migration:** the DB layer overlays records onto a fresh `Account` with type-safe defaults, so existing accounts read back `label: ''` and fall back to the numbered name.
- **Composable:** `addWallet()` exposes a reactive `label` (loaded from the DB on creation) and `setLabel()`, which persists via `updateAccount(..., allowDeletion=true)` so clearing the field reverts to the default name.
- **UI:** the switcher row shows a pencil + name; clicking the pencil swaps in an inline input (`Enter`/blur saves, `Esc` cancels). Editing uses `@click.stop` so it never fires row-select — clicking the name still selects the account as before.

## Notes

- The input matches the static name exactly (transparent, Montserrat, `color: inherit` so it's purple on the selected account), overriding MPW's global `input` styling.
- Persists across reloads (IndexedDB); empty label → default `<Vault> <n>`.

## Screenshots

<img width="562" height="376" alt="38ec6242952b412ffb6cb3229e1851f18015cc836644707f14395bd5227fa793" src="https://github.com/user-attachments/assets/95078fb5-75a0-457e-af82-3154f5843951" />

## Testing

- `vitest`: 254 passing (incl. the `use_wallet` suite)
- Builds clean; manually verified create / rename / clear / reload across multiple vaults.
