### PR TITLE
Improve error when staking balance doesn't have enough PIVs to cover for the change

### DIFF
--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1272,7 +1272,7 @@ export class Wallet {
                             fee / COIN
                         } more ${
                             cChainParams.current.TICKER
-                        }s to pay for cover for the change `
+                        }s to cover for the change`
                     );
                 }
                 transactionBuilder.equallySubtractAmt(Math.abs(changeValue));

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -1266,6 +1266,15 @@ export class Wallet {
                 if (!subtractFeeFromAmt) {
                     throw new Error('Not enough balance');
                 }
+                if (isDelegation && transactionBuilder.valueOut - fee < COIN) {
+                    throw new Error(
+                        `You can't stake less than one PIV, you need ${
+                            fee / COIN
+                        } more ${
+                            cChainParams.current.TICKER
+                        }s to pay for cover for the change `
+                    );
+                }
                 transactionBuilder.equallySubtractAmt(Math.abs(changeValue));
             } else if (changeValue > 0) {
                 // TransactionBuilder will internally add the change only if it is not dust


### PR DESCRIPTION
## Abstract
Improve error when staking balance doesn't have enough PIVs to cover for the change

## Testing
- Send exactly 1 PIV to a fresh account
- Try to stake 1 PIV
- Assert that you get the error message You can't stake less than one PIV, you need 0.xx more PIVs to cover for the change`