### PR TITLE
Fix amount input rejecting decimal values

### DIFF
--- a/scripts/dashboard/TransferMenu.vue
+++ b/scripts/dashboard/TransferMenu.vue
@@ -165,6 +165,7 @@ async function selectContact() {
                                 class="btn-group-input balanceInput"
                                 style="padding-right: 0px; border-right: 0px"
                                 type="number"
+                                step="any"
                                 placeholder="0.00"
                                 autocomplete="nope"
                                 onkeypress="return (event.charCode >= 46 && event.charCode <= 57) || event.charCode === 13"


### PR DESCRIPTION
## What

The send **Amount** input (`TransferMenu.vue`) is `type="number"` with no `step`, so the browser defaults to `step=1` and treats only whole numbers as valid. Any fractional amount — which is almost every send, and every **MAX** send — is rejected with:

> Please select a valid value. The two nearest valid values are N and N+1.

## Why it surfaced now

The input has been `type="number"` without `step` for a long time, but nothing triggered the browser's native constraint validation. **#616** (enter/esc form shortcuts) makes Enter submit the form, which runs the native validation and surfaces the tooltip.

## Fix

Add `step="any"` to the amount input, disabling integer-step validation so any decimal (PIVX has 8 dp) is accepted. MAX values are satoshi-precise, so `any` avoids false rejections.

## Scope

Audited every amount input in the app:

- **Send fiat field** — `type="text"`, unaffected.
- **Staking / unstaking / cold-stake amount** — plain text input with `inputmode="decimal"`, unaffected.
- **Proposal amount-per-cycle** — `NumericInput`, integer-by-design (`Number.isInteger`); `step=1` is correct there. Left unchanged.

The send amount is the only affected field.
