### PR TITLE
Bump to v3.0.0 and update changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,48 +1,28 @@
-# Patch 2
-This patch primarily resolves many of the inconveniences with Shield, Governance and Ledger features, while also handling a dozen smaller bugs around the app.
+# v3.0 - Feature Update
+This is our biggest release yet; full Multi-Account support lets you run unlimited accounts and sub-accounts from a single app, and a new Shield Bridge delivers dramatically faster Shield Sync.
 
-# Improvements
-- Added a live progress bar to Shield Params download.
-- Outgoing Shield Txs now reflect in-balance immediately.
-- Added a tooltip to clarify Immature Stakes.
-- Added a 'queue' to Ledger comms for improved stability.
-
-# Bug Fixes
-- Fixed various Proposal Submission issues.
-- Fixed Ledger attempting to delegate 'unstake' change.
-- Added ability to delete prev. "stuck" proposals.
-- Fixed MN collaterals failing to lock.
-- Fixed currency rounding causing slightly-off Fiat values.
-- Disallowed Ledger Txs that are larger than Ledger permits.
-- Disallowed non-numeric inputs in Transfer menus.
-- Fixed NaN appearing in Payment URIs without Amounts.
-- Fixed old alerts re-appearing.
-- Fixed excess Ledger Import errors.
-- Fixed inaccurate Stake amount alerts.
-- Fixed incorrect icon metadata tag.
-
-# v2.1 - Feature Update
-This upgrade contains huge Shield Improvements; a 10-30x faster Shield Sync (device-dependent) and full Shield Activity support.
-
-It also brings real-time activity for internal transactions, more efficient staking with automatic UTXO splitting, and a redesigned notification system.
+It also brings Multi-Masternode management, send-and-receive Shield Memos, a revamped Proposal creation flow, Koinly-style CSV exports, and significant stability work across the app.
 
 # New Features
-- Shield Activity: Shield TXs are now supported in your Activity.
-- Real-time Activity: internal TXs now instantly show in your Activity.
-- Stake Pre-Splitting: automatic UTXO splitting for max staking efficiency.
-- New Notifications: beautified, with in-notif actions and prompts.
+- Multi-Account: create unlimited Accounts and Sub-Accounts within a single app — a "Personal" and a "Business" account, for example, each with its own unique seed, and each with Sub-Accounts to further separate your funds and accounting.
+- Ultrafast Shield Sync: a new Shield Bridge means you can expect up to 80% faster Shield Sync — barely a blink.
+- Multi-Masternode: the single-node limit is gone; set up and operate unlimited masternodes from a unified dashboard, complete with a reward list.
+- Shield Memos: you can now both send and receive Shield Memos.
+- Proposal Creation Revamp: a vastly improved submission flow that guides you through every field and verifies each one, with no more truncation.
+- Koinly-Style Tx Exports: export your transaction history as Koinly-style CSV for easy use with accounting and tax software.
+- Significant Stability Work: a more resilient app, with more reliable Explorer and RPC failover, and an easy Resync option for deeper issues.
 
 # Improvements
-- Proposal Fees are now recognised in your Activity.
-- Nicer Activity date format.
-- Randomise initial Explorer + Node selections.
-- Improved space-optimised PIVX Promos interface.
+- Renamed "PIVX Promos" to "PIVX Giftcodes" throughout the app.
+- Clearer error when a staking balance can't cover the change amount.
+- Added Enter and Esc shortcuts across forms.
+- Content-hashed asset filenames for long-term browser caching.
 
 # Bug Fixes
-- Fixed Unstaking for Ledger devices.
-- Fixed Currency failing to render in certain conditions.
-- Fixed getting stuck in Private mode when swapping to a public-only wallet.
-- Fixed automatic HD address rotation.
-- Fixed 'Total Rewards' counter computing wrong amounts.
-- Fixed large-byte-size Txs failing due to using RPC GET requests.
-- Fixed certain notifications failing to show.
+- Fixed the send Amount field rejecting decimal values.
+- Fixed export modals.
+- Fixed Ledger hardware wallet issues.
+- Fixed auto-unlock wallet failing.
+- Fixed create-wallet button and vault override edge cases.
+- Old transactions are now cleared when deleting a wallet.
+- Assorted UI fixes and refinements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mypivxwallet",
-    "version": "2.1.2",
+    "version": "3.0.0",
     "description": "Wallet for PIVX",
     "main": "scripts/index.js",
     "type": "module",


### PR DESCRIPTION
## Summary

Bumps the app version to **v3.0.0** (MPW v3) and updates the changelog for the v3 release. Version + changelog only — no feature code in this PR.

## Changes

- `package.json`: version `2.1.2` → `3.0.0`.
- `changelog.md`: rewritten as the v3.0 release notes — Multi-Account, Ultrafast Shield Sync, Multi-Masternode, Shield Memos, the Proposal Creation Revamp, Koinly-style Tx Exports, and Significant Stability Work, plus the smaller improvements and fixes.

The pre-v3 entries (Patch 2, v2.1) are intentionally removed so the in-app "what's new" popup — which renders the whole `changelog.md` — shows only the current release.
